### PR TITLE
fix: extend global search field to filter asset by partial reference

### DIFF
--- a/src/components/InputGlobal/index.tsx
+++ b/src/components/InputGlobal/index.tsx
@@ -89,25 +89,20 @@ const Input: React.FC<InputGlobal> = ({
   };
 
   return (
-    <>
-      <Container {...containerProps}>
-        <input {...inputProps} />
-        <Search onClick={handleSearch} id={'SearchIcon'} />
-        {showTooltip && (
-          <>
-            <FocusBackground
-              onClick={handleTooltipFocus}
-              id="FocusBackground"
-            />
-            <PrePageTooltip
-              search={search}
-              setShowTooltip={setShowTooltip}
-              isInHomePage={containerProps.isInHomePage}
-            />
-          </>
-        )}
-      </Container>
-    </>
+    <Container {...containerProps}>
+      <input {...inputProps} />
+      <Search onClick={handleSearch} id={'SearchIcon'} />
+      {showTooltip && (
+        <>
+          <FocusBackground onClick={handleTooltipFocus} id="FocusBackground" />
+          <PrePageTooltip
+            search={search}
+            setShowTooltip={setShowTooltip}
+            isInHomePage={containerProps.isInHomePage}
+          />
+        </>
+      )}
+    </Container>
   );
 };
 

--- a/src/components/PrePageTooltip/index.tsx
+++ b/src/components/PrePageTooltip/index.tsx
@@ -1,6 +1,6 @@
 import { useInputSearch } from '@/contexts/inputSearch';
 import { useTheme } from '@/contexts/theme';
-import { getAsset } from '@/services/requests/asset';
+import { getAssetByPartialSymbol } from '@/services/requests/asset';
 import getAccount from '@/services/requests/searchBar/account';
 import getBlock from '@/services/requests/searchBar/block';
 import getTransaction from '@/services/requests/transaction';
@@ -85,7 +85,7 @@ const PrePageTooltip: React.FC<IPrePageTooltip> = ({
   };
   const canSearchResult = canSearch();
 
-  const { data, isLoading, isFetching } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: trimmedSearch,
     queryFn: () => getCorrectQueryFn(),
     enabled: canSearchResult,
@@ -123,7 +123,7 @@ const PrePageTooltip: React.FC<IPrePageTooltip> = ({
 
   const getCorrectQueryFn = (): Promise<SearchRequest> | undefined => {
     if (isAsset()) {
-      return getAsset(trimmedSearch);
+      return getAssetByPartialSymbol(trimmedSearch);
     }
 
     if (isAccount()) {

--- a/src/services/requests/asset/index.ts
+++ b/src/services/requests/asset/index.ts
@@ -36,6 +36,27 @@ export const getAsset = async (assetId: string): Promise<IAssetResponse> =>
     route: `assets/${assetId}`,
   });
 
+export const getAssetByPartialSymbol = async (
+  assetRef: string,
+): Promise<IAssetResponse> => {
+  const result = {
+    data: null,
+  } as IAssetResponse;
+
+  if (assetRef?.length) {
+    const res = await api.get({
+      route: `assets/list?asset=${assetRef}`,
+    });
+
+    if (res?.data?.assets?.length)
+      result.data = {
+        asset: res.data.assets[0],
+      };
+  }
+
+  return result;
+};
+
 export const assetInfoCall = async (router: NextRouter): Promise<any> => {
   try {
     const assetId = router.query?.asset as string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -883,9 +883,7 @@ export interface IAssetsResponse extends IPaginatedResponse {
 }
 
 export interface IAssetResponse extends IResponse {
-  data: {
-    asset: IAsset;
-  };
+  data: Record<'asset', IAsset> | null;
 }
 
 export interface IAssetPage {


### PR DESCRIPTION
- Fix: Extend the global search field to filter asset by partial reference - e.g. BTC (BTC-19QS);
- Fix: Lint issues.