### PR TITLE
fix: claim contract fields

### DIFF
--- a/src/components/Home/CardDataFetcher/HomeDataCards/index.tsx
+++ b/src/components/Home/CardDataFetcher/HomeDataCards/index.tsx
@@ -76,17 +76,14 @@ const Progress: React.FC<{ percent: number }> = ({ percent }) => {
 };
 
 const EpochCard: React.FC = () => {
-  const { blocks, metrics } = useHomeData();
+  const { epoch, metrics } = useHomeData();
   const { t } = useTranslation('common', { keyPrefix: 'Cards' });
-  const block = blocks && blocks[0];
 
   return (
     <DataCard className="epoch">
       <Progress percent={metrics.epochLoadPercent} />
       <EpochCardContent>
-        <span>
-          {`${t('Epoch')}` + (block?.epoch ? ` #${block.epoch} ` : ' ')}
-        </span>
+        <span>{`${t('Epoch')}` + (epoch ? ` #${epoch} ` : ' ')}</span>
         <small>Time remaining</small>
         <DataCardValue isEpoch={true}>
           <p className="epochSeconds">

--- a/src/components/TransactionContractComponents/index.tsx
+++ b/src/components/TransactionContractComponents/index.tsx
@@ -56,6 +56,7 @@ import {
   findReceipt,
   findReceiptWithAssetId,
   findReceiptWithSender,
+  findReceipts,
 } from '@/utils/findKey';
 import { formatDate, toLocaleFixed } from '@/utils/formatFunctions';
 import { KLV_PRECISION } from '@/utils/globalVariables';
@@ -1343,10 +1344,9 @@ export const Claim: React.FC<IIndexedContract> = ({
   renderMetadata,
 }) => {
   const parameter = par as IClaimContract;
-  const claimReceipt = findReceipt(filteredReceipts, 17) as
-    | IClaimReceipt
+  const claimReceipts = findReceipts(filteredReceipts, 17) as
+    | IClaimReceipt[]
     | undefined;
-  const precision = usePrecision(claimReceipt?.assetIdReceived || 'KLV');
 
   return (
     <>
@@ -1362,49 +1362,56 @@ export const Claim: React.FC<IIndexedContract> = ({
         </span>
         <span>{parameter?.claimType}</span>
       </Row>
-      {claimReceipt && (
+      <Row>
+        <span>
+          <strong>Asset Id</strong>
+        </span>
+        <span>{parameter?.id || 'KLV'}</span>
+      </Row>
+      {claimReceipts &&
+        claimReceipts.length > 0 &&
+        claimReceipts?.[0]?.assetId && (
+          <>
+            <Row>
+              <span>
+                <strong>Received</strong>
+              </span>
+              <FrozenContainer>
+                {claimReceipts.map((claimReceipt, index) => {
+                  const precision = usePrecision(
+                    claimReceipt?.assetIdReceived || 'KLV',
+                  );
+
+                  return (
+                    <div>
+                      {toLocaleFixed(
+                        claimReceipt?.amount / 10 ** precision,
+                        precision,
+                      )}{' '}
+                      {claimReceipt.assetIdReceived}
+                    </div>
+                  );
+                })}
+              </FrozenContainer>
+            </Row>
+          </>
+        )}
+      {claimReceipts?.[0]?.marketplaceId && (
         <Row>
           <span>
-            <strong>Asset Id</strong>
+            <strong>MarketPlace ID</strong>
           </span>
-          <span>{claimReceipt?.assetId}</span>
+          <span>{claimReceipts?.[0].marketplaceId || '--'}</span>
         </Row>
       )}
-      {claimReceipt && typeof claimReceipt?.amount === 'number' && (
+      {claimReceipts?.[0]?.orderId && (
         <Row>
           <span>
-            <strong>Amount</strong>
+            <strong>OrderId</strong>
           </span>
-          <span>
-            {toLocaleFixed(claimReceipt?.amount / 10 ** precision, precision)}{' '}
-            {claimReceipt.assetIdReceived}
-          </span>
+          <span>{claimReceipts?.[0].orderId || '--'}</span>
         </Row>
       )}
-      <>
-        <Row>
-          <span>
-            <strong>Asset Id Received</strong>
-          </span>
-          <span>{claimReceipt?.assetIdReceived || '--'}</span>
-        </Row>
-        {claimReceipt?.marketplaceId && (
-          <Row>
-            <span>
-              <strong>MarketPlace ID</strong>
-            </span>
-            <span>{claimReceipt.marketplaceId || '--'}</span>
-          </Row>
-        )}
-        {claimReceipt?.orderId && (
-          <Row>
-            <span>
-              <strong>OrderId</strong>
-            </span>
-            <span>{claimReceipt.orderId || '--'}</span>
-          </Row>
-        )}
-      </>
     </>
   );
 };

--- a/src/contexts/mainPage/index.tsx
+++ b/src/contexts/mainPage/index.tsx
@@ -41,6 +41,7 @@ export interface IHomeData {
   nodes?: Node[];
   mostTransactedTokens: MostTransferedToken[];
   mostTransactedNFTs: MostTransferedToken[];
+  epoch?: number;
 }
 
 export const HomeData = createContext({} as IHomeData);
@@ -156,6 +157,7 @@ export const HomeDataProvider: React.FC = ({ children }) => {
     nodes: nodes.data?.nodes,
     mostTransactedTokens: mostTransactedTokens.data || [],
     mostTransactedNFTs: mostTransactedNFTs.data || [],
+    epoch: aggregateResult.data?.overview?.epochNumber,
   };
 
   prevValuesRef.current = {

--- a/src/utils/findKey/index.ts
+++ b/src/utils/findKey/index.ts
@@ -63,6 +63,22 @@ export const findReceipt = (
  *
  * @param receipts Array of receipts
  * @param type type of the contract
+ * @returns the first receipt that matched the contract type
+ */
+export const findReceipts = (
+  receipts: IReceipt[] | undefined,
+  type: number,
+): IReceipt[] | undefined => {
+  if (!receipts) {
+    return undefined;
+  }
+  return receipts.filter(receipt => receipt.type === type);
+};
+
+/**
+ *
+ * @param receipts Array of receipts
+ * @param type type of the contract
  * @param sender sender of the tx
  * @returns the first receipt that matches the contract type and sender
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionada função `findReceipts` para filtrar recibos por tipo e retornar os correspondentes.

- **Correções de Bugs**
  - Atualizada a lógica de exibição do número de época no componente `EpochCard`.
  - Corrigida a exibição de `Asset Id`, `MarketPlace ID` e `OrderId` no componente `TransactionContractComponents`.

- **Refatoração**
  - Renomeado variável `claimReceipt` para `claimReceipts` e ajustada a lógica de renderização para refletir essa mudança.
  - Substituído `blocks` por `epoch` no hook `useHomeData` no componente `EpochCard`.

- **Chores**
  - Adicionada propriedade `epoch` de tipo `number` à interface `IHomeData` e inicializada no `HomeDataProvider`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->