### PR TITLE
feat: :sparkles: create check for sft in mainnet

### DIFF
--- a/src/components/Home/QuickAccess/index.tsx
+++ b/src/components/Home/QuickAccess/index.tsx
@@ -1,4 +1,5 @@
 import { Currency, PaperPlus, Token, Transfer } from '@/assets/transaction';
+import { getNetwork } from '@/utils/networkFunctions';
 import { useTranslation } from 'next-i18next';
 import React, { useState } from 'react';
 import { FaRegSnowflake, FaRocket, FaVoteYea } from 'react-icons/fa';
@@ -27,6 +28,7 @@ const QuickAccess: React.FC<{
   const [contractType, setContractType] = useState('');
   const [openModalTransactions, setOpenModalTransactions] = useState(false);
   const [titleModal, setTitleModal] = useState('');
+  const network = getNetwork();
 
   const quickAccessContract: IShortCutContract[] = [
     {
@@ -46,12 +48,16 @@ const QuickAccess: React.FC<{
       openWiz: () => setWizard('NFT'),
       icon: <Token />,
     },
-    {
-      title: 'Create SFT',
-      type: 'CreateAssetContract',
-      openWiz: () => setWizard('SFT'),
-      icon: <Token />,
-    },
+    ...(network !== 'mainnet'
+      ? [
+          {
+            title: 'Create SFT',
+            type: 'CreateAssetContract',
+            openWiz: () => setWizard('SFT'),
+            icon: <Token />,
+          },
+        ]
+      : []),
     {
       title: 'Create ITO',
       type: 'ConfigITOContract',
@@ -96,10 +102,11 @@ const QuickAccess: React.FC<{
         <Title>What do you want to do?</Title>
       </TitleContainer>
       <Content>
-        {quickAccessContract.map((contract) => (
+        {quickAccessContract.map(contract => (
           <CardItem
             key={JSON.stringify(contract.title)}
-            onClick={(e) => handleClick(contract, e)}
+            onClick={e => handleClick(contract, e)}
+            isMainNet={network !== 'mainnet'}
           >
             <PlusIcon>{contract.icon}</PlusIcon>
             <p>{contract.title}</p>

--- a/src/components/Home/QuickAccess/styles.ts
+++ b/src/components/Home/QuickAccess/styles.ts
@@ -39,7 +39,9 @@ export const TitleContainer = styled.div`
   }
 `;
 
-export const CardItem = styled.div`
+export const CardItem = styled.div<{
+  isMainNet: boolean;
+}>`
   ${DefaultCardStyles}
   display: flex;
   flex-direction: column;
@@ -93,10 +95,10 @@ export const CardItem = styled.div`
     grid-column: span 2;
 
     &:nth-last-child(2) {
-      grid-column: 0;
+      grid-column: ${props => (props.isMainNet ? 0 : '1/4')};
     }
     &:nth-last-child(1) {
-      grid-column: 5/7;
+      grid-column: ${props => (props.isMainNet ? '5/7' : '4/7')};
     }
   }
 `;

--- a/src/components/TransactionForms/CustomForms/CreateAsset/index.tsx
+++ b/src/components/TransactionForms/CustomForms/CreateAsset/index.tsx
@@ -1,4 +1,5 @@
 import { parseRoles } from '@/components/Wizard/utils';
+import { getNetwork } from '@/utils/networkFunctions';
 import { ICreateAsset } from '@klever/sdk-web';
 import React, { PropsWithChildren } from 'react';
 import { useFormContext } from 'react-hook-form';
@@ -26,21 +27,6 @@ export interface ISectionProps {
   precision?: number;
 }
 
-export const assetTypes = [
-  {
-    label: 'Fungible',
-    value: 0,
-  },
-  {
-    label: 'Non Fungible',
-    value: 1,
-  },
-  {
-    label: 'Semi Fungible',
-    value: 2,
-  },
-];
-
 export const parseCreateAsset = (data: ICreateAsset) => {
   const dataCopy = JSON.parse(JSON.stringify(data));
   parseTickerName(dataCopy);
@@ -60,6 +46,27 @@ export const CreateAsset: React.FC<PropsWithChildren<IContractProps>> = ({
   const { handleSubmit, watch } = useFormContext<ICreateAsset>();
 
   const type = watch('type');
+
+  const network = getNetwork();
+
+  const assetTypes = [
+    {
+      label: 'Fungible',
+      value: 0,
+    },
+    {
+      label: 'Non Fungible',
+      value: 1,
+    },
+    ...(network !== 'Mainnet'
+      ? [
+          {
+            label: 'Semi Fungible',
+            value: 2,
+          },
+        ]
+      : []),
+  ];
 
   const isFungible = type === 0;
   const isNFT = type === 1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Adicionada a opção "Criar SFT" no componente QuickAccess, dependendo da rede.
  - O tipo de ativo "Semi Fungível" agora é incluído na criação de ativos, também dependendo da rede.

- **Ajustes de Estilo**
  - O layout do componente CardItem foi aprimorado para ser responsivo com base na rede.

- **Correções de Bugs**
  - Melhoria na lógica de seleção de tipos de ativos, garantindo que o comportamento dependa da rede atual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->