### PR TITLE
fix: :lady_beetle:  hiddem Max Amount for new ID

### DIFF
--- a/src/components/TransactionForms/CustomForms/AssetTrigger.tsx
+++ b/src/components/TransactionForms/CustomForms/AssetTrigger.tsx
@@ -103,6 +103,8 @@ const AssetTrigger: React.FC<PropsWithChildren<IContractProps>> = ({
 
 const getMintForm = (collection: ICollectionList, walletAddress: string) => {
   const hasInternalId = collection.value?.split('/').length > 1;
+  const { watch } = useFormContext();
+  const watchCollectionAssetId = watch('collectionAssetId');
 
   return (
     <FormSection>
@@ -114,7 +116,10 @@ const getMintForm = (collection: ICollectionList, walletAddress: string) => {
         tooltip={tooltip.receiver}
       />
       <FormInput name="amount" title="Amount" type="number" required />
-      {!collection.isNFT && !collection.isFungible && !hasInternalId ? (
+      {!collection.isNFT &&
+      !collection.isFungible &&
+      !hasInternalId &&
+      !watchCollectionAssetId ? (
         <FormInput name="value" title="Max Amount for new ID" type="number" />
       ) : null}
     </FormSection>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
	- Melhoria na lógica de renderização do componente `AssetTrigger`, controlando a visibilidade do campo de entrada "Max Amount for new ID" com base em um novo estado monitorado.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->