### PR TITLE
fix: show fpr amount only if asset has fpr amount

### DIFF
--- a/src/components/Asset/StakingRoyaltiesTab.tsx
+++ b/src/components/Asset/StakingRoyaltiesTab.tsx
@@ -72,7 +72,7 @@ export const StakingRoyaltiesTab: React.FC<
         </span>
       </Row>
 
-      {asset?.staking?.fpr.length > 0 && (
+      {asset?.staking.interestType === 'FPRI' && (
         <Row>
           <strong>{t('assets:Staking.Current FPR Amount')}</strong>
 

--- a/src/components/Asset/StakingRoyaltiesTab.tsx
+++ b/src/components/Asset/StakingRoyaltiesTab.tsx
@@ -71,16 +71,20 @@ export const StakingRoyaltiesTab: React.FC<
           )}
         </span>
       </Row>
-      <Row>
-        <strong>{t('assets:Staking.Current FPR Amount')}</strong>
 
-        <span>
-          {toLocaleFixed(
-            (asset?.staking?.currentFPRAmount || 0) / 10 ** asset?.precision,
-            asset?.precision,
-          )}
-        </span>
-      </Row>
+      {asset?.staking?.fpr.length > 0 && (
+        <Row>
+          <strong>{t('assets:Staking.Current FPR Amount')}</strong>
+
+          <span>
+            {toLocaleFixed(
+              (asset?.staking?.currentFPRAmount || 0) / 10 ** asset?.precision,
+              asset?.precision,
+            )}
+          </span>
+        </Row>
+      )}
+
       <Row>
         <strong> {t('assets:Staking.Min Epochs To Claim')}</strong>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Correções de Bugs**
  - Ajustada a renderização da seção "Current FPR Amount" para exibir os dados apenas quando o tipo de interesse for 'FPRI', evitando a apresentação de informações não aplicáveis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->