### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/src/components/Tabs/Buckets/mock.ts
+++ b/src/components/Tabs/Buckets/mock.ts
@@ -54,7 +54,7 @@ export const mockAssetKLVResponse = {
       name: 'KLEVER',
       ticker: 'KLV',
       ownerAddress: '',
-      logo: 'https://bc.klever.finance/logo_klv',
+      logo: 'https://bc.klever.org/logo_klv',
       uris: [
         {
           key: 'Github',
@@ -70,15 +70,15 @@ export const mockAssetKLVResponse = {
         },
         {
           key: 'Wallet',
-          value: 'https://klever.finance/wallet',
+          value: 'https://klever.org/wallet',
         },
         {
           key: 'Website',
-          value: 'https://klever.finance',
+          value: 'https://klever.org',
         },
         {
           key: 'Whitepaper',
-          value: 'https://bc.klever.finance/wp',
+          value: 'https://bc.klever.org/wp',
         },
         {
           key: 'Exchange',

--- a/src/configs/footer.ts
+++ b/src/configs/footer.ts
@@ -71,7 +71,7 @@ const contents: IContent[] = [
       },
 
       { name: 'Klever.Org', href: 'https://klever.org/' },
-      { name: 'Klever Docs', href: 'https://docs.klever.finance/' },
+      { name: 'Klever Docs', href: 'https://docs.klever.org/' },
       { name: 'Klever News', href: 'https://klevernews.com/' },
       { name: 'Careers', href: 'https://klever.compleo.com.br/' },
       { name: 'Help Center', href: 'https://support.klever.org/' },

--- a/src/contexts/extension/index.tsx
+++ b/src/contexts/extension/index.tsx
@@ -63,10 +63,10 @@ export const ExtensionProvider: React.FC<PropsWithChildren> = ({
       window.kleverWeb.provider = {
         api:
           process.env.DEFAULT_API_HOST ||
-          'https://api.testnet.klever.finance/v1.0',
+          'https://api.testnet.klever.org/v1.0',
         node:
           process.env.DEFAULT_NODE_HOST ||
-          'https://node.testnet.klever.finance',
+          'https://node.testnet.klever.org',
       };
     }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -57,13 +57,13 @@ export const getHost = (
 ): string => {
   const hostService = {
     [Service.PROXY]:
-      process.env.DEFAULT_API_HOST || 'https://api.testnet.klever.finance',
+      process.env.DEFAULT_API_HOST || 'https://api.testnet.klever.org',
     [Service.NODE]:
-      process.env.DEFAULT_NODE_HOST || 'https://node.testnet.klever.finance',
+      process.env.DEFAULT_NODE_HOST || 'https://node.testnet.klever.org',
     [Service.GECKO]: 'https://api.coingecko.com/api/v3',
     [Service.MULTISIGN]:
       process.env.DEFAULT_API_MULTISIGN ||
-      'https://multisign.testnet.klever.finance',
+      'https://multisign.testnet.klever.org',
     [Service.EXPLORER]:
       process.env.DEFAULT_EXPLORER_HOST || 'https://testnet.kleverscan.org',
     [Service.CDN]: process.env.DEFAULT_CDN_HOST || 'https://cdn.klever.io',

--- a/src/utils/mocks/index.ts
+++ b/src/utils/mocks/index.ts
@@ -17,7 +17,7 @@ const KFI: IAsset = {
     Wallet: 'https://klever.io/',
     Website: 'https://klever.org/',
     Whitepaper:
-      'https://klever.finance/wp-content/uploads/2021/10/Klever_Finance_Whitepaper_v1.1.pdf',
+      'https://storage.googleapis.com/kleverchain-public/Klever-Blockchain-Whitepaper-v.2.0-lr.pdf',
   },
   precision: 6,
   initialSupply: 21000000000000,

--- a/src/utils/transaction/index.ts
+++ b/src/utils/transaction/index.ts
@@ -24,7 +24,7 @@ export const broadcastTXSuccessful = async (hash: string): Promise<any> => {
     try {
       const fetchPromise = fetch(
         `${
-          process.env.DEFAULT_API_HOST || 'https://api.testnet.klever.finance'
+          process.env.DEFAULT_API_HOST || 'https://api.testnet.klever.org'
         }/transaction/${hash}`,
         {
           method: 'GET',


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Atualizados os links e endereços de recursos (logo, whitepaper, etc.) para refletir a mudança para o domínio klever.org.
	- Ajustado o link de “Klever Docs” no rodapé.
	- Revisados os endpoints dos serviços e API no ambiente de teste para utilizar o novo domínio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->