### PR TITLE
fix: display the correct balance without rounding

### DIFF
--- a/src/components/Tabs/Assets/index.tsx
+++ b/src/components/Tabs/Assets/index.tsx
@@ -84,7 +84,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${balance / 10 ** precision} ${ticker}`}
+            msg={`${(balance / 10 ** precision).toLocaleString()} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span>
@@ -99,7 +99,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${frozenBalance / 10 ** precision} ${ticker}`}
+            msg={`${(frozenBalance / 10 ** precision).toLocaleString()} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={frozenBalance}>
@@ -114,7 +114,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${unfrozenBalance / 10 ** precision} ${ticker}`}
+            msg={`${(unfrozenBalance / 10 ** precision).toLocaleString()} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={unfrozenBalance}>

--- a/src/components/Tabs/Assets/index.tsx
+++ b/src/components/Tabs/Assets/index.tsx
@@ -84,7 +84,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(balance / 10 ** precision).toLocaleString()} ${ticker}`}
+            msg={`${balance / 10 ** precision} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span>
@@ -99,10 +99,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(
-              frozenBalance /
-              10 ** precision
-            ).toLocaleString()} ${ticker}`}
+            msg={`${frozenBalance / 10 ** precision} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={frozenBalance}>
@@ -117,10 +114,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(
-              unfrozenBalance /
-              10 ** precision
-            ).toLocaleString()} ${ticker}`}
+            msg={`${unfrozenBalance / 10 ** precision} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={unfrozenBalance}>

--- a/src/components/Tabs/Assets/index.tsx
+++ b/src/components/Tabs/Assets/index.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@/components/Tooltip';
 import { useContractModal } from '@/contexts/contractModal';
 import { IAccountAsset, IInnerTableProps, IRowSection } from '@/types/index';
 import { parseApr } from '@/utils';
-import { formatAmount } from '@/utils/formatFunctions';
+import { formatAmount, toLocaleFixed } from '@/utils/formatFunctions';
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
 import React, { PropsWithChildren } from 'react';
@@ -84,7 +84,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(balance / 10 ** precision).toLocaleString()} ${ticker}`}
+            msg={`${toLocaleFixed(balance / 10 ** precision, precision)} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span>
@@ -99,7 +99,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(frozenBalance / 10 ** precision).toLocaleString()} ${ticker}`}
+            msg={`${toLocaleFixed(frozenBalance / 10 ** precision, precision)} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={frozenBalance}>
@@ -114,7 +114,7 @@ const Assets: React.FC<PropsWithChildren<IAssets>> = ({
       {
         element: props => (
           <Tooltip
-            msg={`${(unfrozenBalance / 10 ** precision).toLocaleString()} ${ticker}`}
+            msg={`${toLocaleFixed(unfrozenBalance / 10 ** precision, precision)} ${ticker}`}
             Component={() => (
               <CustomFieldWrapper>
                 <span key={unfrozenBalance}>

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -712,9 +712,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   {!isLoadingKLVAllowance ? (
                     <>
-                      <span>
-                        {toLocaleFixed(getKLVStaking(), KLV_PRECISION)}
-                      </span>
+                      <span>{getKLVStaking()}</span>
                       <KLVStakingClaimButton />
                     </>
                   ) : (

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -607,7 +607,9 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   <div>
                     <BalanceKLVValue>
                       {!isLoadingAccount ? (
-                        <span data-testid="klv-balance">{totalKLV}</span>
+                        <span data-testid="klv-balance">
+                          {totalKLV.toString().replace('.', ',')}
+                        </span>
                       ) : (
                         <Skeleton height={19} />
                       )}
@@ -636,7 +638,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   <span>
                     {!isLoadingAccount ? (
-                      availableBalance
+                      availableBalance.toString().replace('.', ',')
                     ) : (
                       <Skeleton height={19} />
                     )}

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -607,9 +607,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   <div>
                     <BalanceKLVValue>
                       {!isLoadingAccount ? (
-                        <span data-testid="klv-balance">
-                          {totalKLV.toLocaleString()}
-                        </span>
+                        <span data-testid="klv-balance">{totalKLV}</span>
                       ) : (
                         <Skeleton height={19} />
                       )}
@@ -638,7 +636,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   <span>
                     {!isLoadingAccount ? (
-                      availableBalance.toLocaleString()
+                      availableBalance
                     ) : (
                       <Skeleton height={19} />
                     )}
@@ -650,7 +648,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   <span>
                     {!isLoadingAccount ? (
-                      getKLVfreezeBalance().toLocaleString()
+                      getKLVfreezeBalance()
                     ) : (
                       <Skeleton height={19} />
                     )}
@@ -662,7 +660,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   <span>
                     {!isLoadingAccount ? (
-                      getKLVunfreezeBalance().toLocaleString()
+                      getKLVunfreezeBalance()
                     ) : (
                       <Skeleton height={19} />
                     )}
@@ -694,7 +692,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   {!isLoadingKLVAllowance ? (
                     <>
-                      <span>{getKLVAllowance().toLocaleString()}</span>
+                      <span>{getKLVAllowance()}</span>
                       <AllowanceClaimButton />
                     </>
                   ) : (
@@ -710,7 +708,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   {!isLoadingKLVAllowance ? (
                     <>
-                      <span>{getKLVStaking().toLocaleString()}</span>
+                      <span>{getKLVStaking()}</span>
                       <KLVStakingClaimButton />
                     </>
                   ) : (

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -52,6 +52,7 @@ import {
   filterOperations,
   hexToBinary,
   invertBytes,
+  toLocaleFixed,
 } from '@/utils/formatFunctions';
 import { KLV_PRECISION } from '@/utils/globalVariables';
 import { parseAddress } from '@/utils/parseValues';
@@ -185,28 +186,29 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
     return (available + frozen + unfrozen) / 10 ** KLV_PRECISION;
   }, [account?.balance, account?.assets, KLV_PRECISION]);
 
-  const getKLVfreezeBalance = useCallback((): number => {
-    return (account?.assets?.KLV?.frozenBalance || 0) / 10 ** KLV_PRECISION;
+  const getKLVfreezeBalance = useCallback((): string => {
+    const fronzenBalance = account?.assets?.KLV?.frozenBalance || 0;
+    return toLocaleFixed(fronzenBalance / 10 ** KLV_PRECISION, KLV_PRECISION);
   }, [account?.assets, KLV_PRECISION]);
 
-  const getKLVunfreezeBalance = (): number => {
-    return (account?.assets?.KLV?.unfrozenBalance || 0) / 10 ** KLV_PRECISION;
+  const getKLVunfreezeBalance = (): string => {
+    const unfrozenBalance = account?.assets?.KLV?.unfrozenBalance || 0;
+    return toLocaleFixed(unfrozenBalance / 10 ** KLV_PRECISION, KLV_PRECISION);
   };
 
-  const getKLVAllowance = (): number => {
-    return (KLVAllowance?.data?.result?.allowance || 0) / 10 ** KLV_PRECISION;
+  const getKLVAllowance = (): string => {
+    const allowance = KLVAllowance?.data?.result?.allowance || 0;
+    return toLocaleFixed(allowance / 10 ** KLV_PRECISION, KLV_PRECISION);
   };
 
-  const getKLVStaking = (): number => {
-    return (
-      (KLVAllowance?.data?.result?.stakingRewards || 0) / 10 ** KLV_PRECISION
-    );
+  const getKLVStaking = (): string => {
+    const stakingRewards = KLVAllowance?.data?.result?.stakingRewards || 0;
+    return toLocaleFixed(stakingRewards / 10 ** KLV_PRECISION, KLV_PRECISION);
   };
 
-  const getKFIStaking = (): number => {
-    return (
-      (KFIAllowance?.data?.result?.stakingRewards || 0) / 10 ** KLV_PRECISION
-    );
+  const getKFIStaking = (): string => {
+    const stakingRewards = KFIAllowance?.data?.result?.stakingRewards || 0;
+    return toLocaleFixed(stakingRewards / 10 ** KLV_PRECISION, KLV_PRECISION);
   };
 
   const filterFromTo = (op: number) => {
@@ -608,7 +610,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                     <BalanceKLVValue>
                       {!isLoadingAccount ? (
                         <span data-testid="klv-balance">
-                          {totalKLV.toString().replace('.', ',')}
+                          {toLocaleFixed(totalKLV, KLV_PRECISION)}
                         </span>
                       ) : (
                         <Skeleton height={19} />
@@ -638,7 +640,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   <span>
                     {!isLoadingAccount ? (
-                      availableBalance.toString().replace('.', ',')
+                      toLocaleFixed(availableBalance, KLV_PRECISION)
                     ) : (
                       <Skeleton height={19} />
                     )}
@@ -710,7 +712,9 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   {!isLoadingKLVAllowance ? (
                     <>
-                      <span>{getKLVStaking()}</span>
+                      <span>
+                        {toLocaleFixed(getKLVStaking(), KLV_PRECISION)}
+                      </span>
                       <KLVStakingClaimButton />
                     </>
                   ) : (
@@ -726,7 +730,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   </strong>
                   {!isLoadingKFIAllowance ? (
                     <>
-                      <span>{getKFIStaking().toLocaleString()}</span>
+                      <span>{getKFIStaking()}</span>
                       <KFIStakingClaimButton />
                     </>
                   ) : (

--- a/src/utils/formatFunctions/index.ts
+++ b/src/utils/formatFunctions/index.ts
@@ -23,6 +23,11 @@ export const formatDate = (timestamp: number, reduced = false): string => {
     : format(new Date(timestamp || 0), 'MM/dd/yy HH:mm');
 };
 
+const toFixedDown = (number: number, decimals: number) => {
+  const factor = Math.pow(10, decimals);
+  return Math.floor(number * factor) / factor;
+};
+
 /**
  * Formats a number and returns it's string representation in short scale (Million, Billion...) with 2 decimals points when number is not integer.
  * Example: 8874165276.908615 --> "8.87 Bi"
@@ -51,9 +56,11 @@ export const formatAmount = (number: number): string => {
       .reverse()
       .find(i => number >= i.value) || lookup[0];
 
-  return `${(number / item.value).toFixed(2).replace(regex, '$1')} ${
-    item.symbol
-  }`;
+  const truncated = toFixedDown(number / item.value, 2)
+    .toString()
+    .replace(regex, '$1');
+
+  return `${truncated} ${item.symbol}`.trim();
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Ajustes de Formatação**
  - Os valores exibidos em saldos, recompensas e tooltips agora são apresentados sem formatação local (sem uso de separadores de milhar/ponto e vírgula automáticos).
  - A exibição dos valores numéricos foi ajustada para sempre truncar as casas decimais para baixo, em vez de arredondar, ao mostrar quantias de ativos.

- **Correções Visuais**
  - Pequenas melhorias na consistência da apresentação dos valores em diferentes seções da interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->