### PR TITLE
fix: update amount formatting in ITOTab and ITO row sections

### DIFF
--- a/src/components/Asset/ITOTab.tsx
+++ b/src/components/Asset/ITOTab.tsx
@@ -4,7 +4,7 @@ import Copy from '@/components/Copy';
 import { displayITOpacks } from '@/components/ITO';
 import { useExtension } from '@/contexts/extension';
 import { IParsedITO } from '@/types';
-import { formatDate } from '@/utils/formatFunctions';
+import { formatDate, toLocaleFixed } from '@/utils/formatFunctions';
 import {
   EllipsisSpan,
   ExpandableRow,
@@ -46,7 +46,7 @@ export const ITOTab: React.FC<PropsWithChildren<ITOTabProps>> = ({ ITO }) => {
               <span>
                 <strong>{t('assets:ITO.Max Amount')}</strong>
               </span>
-              <span>{ITO.maxAmount}</span>
+              <span>{toLocaleFixed(ITO.maxAmount, ITO.precision)}</span>
             </Row>
           ) : null}
           <Row span={2}>

--- a/src/pages/ito/index.tsx
+++ b/src/pages/ito/index.tsx
@@ -121,7 +121,7 @@ export const getITOrowSections =
       return (
         <strong>
           {!(maxAmount === 0 || Number.isNaN(maxAmount)) ? (
-            formatAmount(maxAmount / 10 ** precision)
+            formatAmount(maxAmount)
           ) : (
             <IoIosInfinite />
           )}
@@ -131,9 +131,7 @@ export const getITOrowSections =
     const renderSoldAmount = (): ReactNode => {
       return (
         <strong>
-          {mintedAmount && mintedAmount !== 0
-            ? formatAmount(mintedAmount / 10 ** precision)
-            : 0}
+          {mintedAmount && mintedAmount !== 0 ? formatAmount(mintedAmount) : 0}
         </strong>
       );
     };

--- a/src/pages/ito/index.tsx
+++ b/src/pages/ito/index.tsx
@@ -267,7 +267,7 @@ export const getITOTabletRowSections =
       return (
         <strong>
           {!(maxAmount === 0 || Number.isNaN(maxAmount)) ? (
-            formatAmount(maxAmount / 10 ** precision)
+            formatAmount(maxAmount)
           ) : (
             <IoIosInfinite />
           )}
@@ -277,9 +277,7 @@ export const getITOTabletRowSections =
     const renderSoldAmount = (): ReactNode => {
       return (
         <strong>
-          {mintedAmount && mintedAmount !== 0
-            ? formatAmount(mintedAmount / 10 ** precision)
-            : 0}
+          {mintedAmount && mintedAmount !== 0 ? formatAmount(mintedAmount) : 0}
         </strong>
       );
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Aprimoramentos**
  - Valores de "quantidade máxima" e "quantidade cunhada" agora são exibidos em formato localizado e mais legível na aba ITO e na página de ITO, facilitando a compreensão dos números apresentados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->