### PR TITLE
fix: ito without packData

### DIFF
--- a/src/components/Asset/AssetSummary/index.tsx
+++ b/src/components/Asset/AssetSummary/index.tsx
@@ -265,7 +265,8 @@ export const AssetSummary: React.FC<PropsWithChildren<AssetSummaryProps>> = ({
           window.document.body,
         )}
 
-      {ITO &&
+      {ITO?.packData &&
+        ITO.packData.length > 0 &&
         ReactDOM.createPortal(
           <ParticipateModal
             isOpenParticipateModal={openParticipateModal}

--- a/src/components/Home/HomeITOSection/index.tsx
+++ b/src/components/Home/HomeITOSection/index.tsx
@@ -75,7 +75,8 @@ export const HomeITOSection: React.FC<PropsWithChildren> = () => {
 
         <Table {...tableProps} />
       </TableContainer>
-      {ITO &&
+      {ITO?.packData &&
+        ITO.packData.length > 0 &&
         ReactDOM.createPortal(
           <ParticipateModal
             key={ITO.assetId}

--- a/src/pages/ito/index.tsx
+++ b/src/pages/ito/index.tsx
@@ -441,7 +441,8 @@ const ITOsPage: React.FC<PropsWithChildren> = () => {
         <LaunchPadFAQ />
       </ITOContainer>
 
-      {ITO &&
+      {ITO?.packData &&
+        ITO.packData.length > 0 &&
         ReactDOM.createPortal(
           <ParticipateModal
             key={ITO.assetId}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correção de Bugs**
  * O modal de participação agora só é exibido quando houver dados de pacote disponíveis, evitando que seja mostrado quando essas informações estiverem ausentes ou vazias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->