### PR TITLE
fix: getServiceSideProps to verify network

### DIFF
--- a/src/pages/smart-contract/[address].tsx
+++ b/src/pages/smart-contract/[address].tsx
@@ -36,6 +36,7 @@ import nextI18nextConfig from '../../../next-i18next.config';
 import { WhiteTick, RedFailed } from '@/assets/icons';
 import { useMobile } from '@/contexts/mobile';
 import { timestampToDate } from '@/utils/timeFunctions';
+import { getNetwork } from '@/utils/networkFunctions';
 
 const SmartContractInvoke: React.FC = () => {
   const router = useRouter();
@@ -105,14 +106,6 @@ const SmartContractInvoke: React.FC = () => {
     },
   ];
 
-  useEffect(() => {
-    if (!contractAddress) return;
-    requestBeforeYesterdayTransactions();
-    requestSmartContractData();
-    requestInvokesTotalRecords();
-    setSelectedTab(tabHeaders[0].label);
-  }, [contractAddress]);
-
   const SelectedComponent = () => {
     switch (selectedTab) {
       case 'Transactions':
@@ -125,6 +118,15 @@ const SmartContractInvoke: React.FC = () => {
   const formatKey = (str: string) => {
     return str.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase());
   };
+
+  useEffect(() => {
+    if (contractAddress) {
+      requestBeforeYesterdayTransactions();
+      requestSmartContractData();
+      requestInvokesTotalRecords();
+      setSelectedTab(tabHeaders[0].label);
+    }
+  }, [contractAddress]);
 
   return (
     <Container>
@@ -226,19 +228,17 @@ const SmartContractInvoke: React.FC = () => {
   );
 };
 
-// export const getServerSideProps: GetServerSideProps = async ({
-//   locale = 'en',
-// }) => {
-//   if (process.env.NODE_ENV !== 'development') {
-//     return {
-//       notFound: true,
-//     };
-//   }
-//   const props = await serverSideTranslations(
-//     locale,
-//     ['en'],
-//   );
-//   return { props };
-// };
+export const getServerSideProps: GetServerSideProps = async ({
+  locale = 'en',
+}) => {
+  const network = getNetwork();
+  if (network !== 'Devnet') {
+    return {
+      notFound: true,
+    };
+  }
+  const props = await serverSideTranslations(locale, ['en']);
+  return { props };
+};
 
 export default SmartContractInvoke;

--- a/src/pages/smart-contracts/index.tsx
+++ b/src/pages/smart-contracts/index.tsx
@@ -18,6 +18,7 @@ import { DataCardsContainer } from '@/views/home';
 import MostUsedApplications from '@/components/SmartContracts/MostUsedApplications';
 import BrowseAllDeployedContracts from '@/components/SmartContracts/BrowseAllDeployedContracts';
 import SmartContractTopCard from '@/components/SmartContracts/SmartContractTopCard';
+import { getNetwork } from '@/utils/networkFunctions';
 
 const SmartContracts: React.FC<PropsWithChildren> = () => {
   const { t } = useTranslation(['common', 'smartContracts']);
@@ -52,7 +53,8 @@ const SmartContracts: React.FC<PropsWithChildren> = () => {
 export const getServerSideProps: GetServerSideProps = async ({
   locale = 'en',
 }) => {
-  if (process.env.NODE_ENV !== 'development') {
+  const network = getNetwork();
+  if (network !== 'Devnet') {
     return {
       notFound: true,
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * As páginas de contratos inteligentes agora exibem erro 404 quando acessadas fora da rede "Devnet", em vez de depender do ambiente de desenvolvimento.
  
* **Melhoria**
  * A lógica de exibição das páginas foi atualizada para considerar a rede ativa, proporcionando uma experiência mais consistente ao usuário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->