### PR TITLE
fix: asset name when mobile version view

### DIFF
--- a/src/components/Asset/AssetSummary/index.tsx
+++ b/src/components/Asset/AssetSummary/index.tsx
@@ -154,7 +154,11 @@ export const AssetSummary: React.FC<PropsWithChildren<AssetSummaryProps>> = ({
                   <Title
                     key={asset?.name}
                     Component={() =>
-                      isMobile ? <h3>{asset?.name}</h3> : <h1>{asset?.name}</h1>
+                      isMobile ? (
+                        <span>{asset?.name}</span>
+                      ) : (
+                        <h1>{asset?.name}</h1>
+                      )
                     }
                   />
                 ) : (

--- a/src/components/Asset/AssetSummary/styles.ts
+++ b/src/components/Asset/AssetSummary/styles.ts
@@ -33,9 +33,17 @@ export const AssetHeaderContainer = styled.div`
   &:hover {
     cursor: default;
   }
-  h1,
-  h2 {
+  h1 {
     width: 100%;
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+
+  span {
+    max-width: 280px;
+    font-size: 20px;
+    font-weight: 700;
     white-space: normal;
     word-wrap: break-word;
     overflow-wrap: break-word;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Aprimoramentos**
  * O nível do cabeçalho do nome do ativo agora se adapta ao tipo de dispositivo, exibindo `<span>` em dispositivos móveis e `<h1>` em outros casos.
* **Ajustes de Estilo**
  * Removido o limite máximo de largura do componente lateral esquerdo na visualização do resumo do ativo.
  * Adicionadas novas regras de estilo para o elemento `<span>` no cabeçalho do ativo, otimizando a exibição em dispositivos móveis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->