### PR TITLE
fix(smart-contracts): eliminate contract count flicker

### DIFF
--- a/src/contexts/smartContractPage/index.tsx
+++ b/src/contexts/smartContractPage/index.tsx
@@ -1,7 +1,6 @@
 import {
   smartContractsListCall,
   smartContractsStatisticCall,
-  smartContractsTotalContractsCall,
   smartContractTotalTransactionsListCall,
   smartContractsBeforeYesterdayTransactionsCall,
 } from '@/services/requests/smartContracts';
@@ -29,7 +28,6 @@ export const SmartContractDataProvider: React.FC<PropsWithChildren> = ({
   const [
     smartContractsStatisticResult,
     smartContractsListResult,
-    smartContractTotalContractsResult,
     smartContractTotalTransactionsResult,
     smartContractsBeforeYesterdayTransactionsResult,
   ] = useQueries({
@@ -42,11 +40,6 @@ export const SmartContractDataProvider: React.FC<PropsWithChildren> = ({
       {
         queryKey: ['smartContractsList'],
         queryFn: smartContractsListCall,
-        refetchInterval: watcherTimeout,
-      },
-      {
-        queryKey: ['smartContractsTotalContracts'],
-        queryFn: smartContractsTotalContractsCall,
         refetchInterval: watcherTimeout,
       },
       {
@@ -66,7 +59,7 @@ export const SmartContractDataProvider: React.FC<PropsWithChildren> = ({
     smartContractsStatistic:
       smartContractsStatisticResult.data?.statistics || [],
     smartContractsList: smartContractsListResult.data?.smartContracts || [],
-    smartContractTotalContracts: smartContractTotalContractsResult.data || 0,
+    smartContractTotalContracts: smartContractsListResult.data?.totalContracts || 0,
     beforeYesterdayTransactions:
       smartContractsBeforeYesterdayTransactionsResult.data
         ?.beforeYesterdayTxs || 0,

--- a/src/services/requests/smartContracts/index.ts
+++ b/src/services/requests/smartContracts/index.ts
@@ -7,7 +7,7 @@ import {
 import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 
 const smartContractsListCall = async (): Promise<
-  { smartContracts: SmartContractsList[] } | undefined
+  { smartContracts: SmartContractsList[]; totalContracts: number } | undefined
 > => {
   try {
     const smartContractsRes = await api.get({
@@ -15,7 +15,10 @@ const smartContractsListCall = async (): Promise<
     });
 
     if (!smartContractsRes.error || smartContractsRes.error === '') {
-      return { smartContracts: smartContractsRes.data.sc };
+      return {
+        smartContracts: smartContractsRes.data.sc,
+        totalContracts: smartContractsRes.pagination?.totalRecords || 0,
+      };
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary

The "Contracts" counter on the Smart Contracts page flickered between values (e.g. 178 ↔ 181) because two independent `sc/list` calls polled on 4-second intervals. Since responses arrived at slightly different times, `pagination.totalRecords` could differ between the two calls.

## Fix

`smartContractsListCall` now also returns `totalContracts` from the same response's `pagination.totalRecords`. The separate `smartContractsTotalContractsCall` query is removed from the context.

One call → list and count always come from the same response → no race condition → no flicker.

## Files changed

- `src/services/requests/smartContracts/index.ts` — `smartContractsListCall` extended with `totalContracts`
- `src/contexts/smartContractPage/index.tsx` — redundant query removed, count read from list result
