### PR TITLE
fix(validators): enable partial name search in validator filter

### DIFF
--- a/src/pages/validators/index.tsx
+++ b/src/pages/validators/index.tsx
@@ -19,7 +19,7 @@ import { parseValidators } from '@/utils/parseValues';
 import { AddressContainer } from '@/views/validators/detail';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { PropsWithChildren, useMemo } from 'react';
+import React, { PropsWithChildren, useMemo, useRef } from 'react';
 
 export const validatorsHeaders = [
   'Rank',
@@ -140,6 +140,7 @@ const Validators: React.FC<PropsWithChildren> = () => {
   const router = useRouter();
   const [filterValidators, fetchPartialValidator, loading, setLoading] =
     useFetchPartial<IValidator>('validators', 'validator/list', 'name');
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const filters: IFilter[] = useMemo(() => {
     return [
@@ -157,6 +158,10 @@ const Validators: React.FC<PropsWithChildren> = () => {
         },
         onChange: async value => {
           setLoading(true);
+          if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
+          searchTimeoutRef.current = setTimeout(() => {
+            setQueryAndRouter(value ? { name: value } : {}, router);
+          }, 500);
           await fetchPartialValidator(value);
         },
         current: (router.query.name as string) || undefined,


### PR DESCRIPTION
## Summary

Fixes #652. The validator name filter only worked with exact full names selected from a dropdown. The API already supports partial name search (e.g. `?name=Kl`), but the UI never applied typed input to the URL query — only dropdown click did.

## Fix

`onChange` now also updates the URL with the typed partial term (debounced 500ms). This triggers `requestValidators` with the partial name and the table updates accordingly.

## Files changed

- `src/pages/validators/index.tsx` — debounced `setQueryAndRouter` call added to `onChange`, `useRef` for timeout management


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the Name filter in the Validators section with improved update mechanics. The filter now provides better responsiveness when searching, reducing unnecessary processing during filter operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->