### PR TITLE
feat(accounts): show validator name and status badge in buckets tab

### DIFF
--- a/src/components/Tabs/Buckets/index.tsx
+++ b/src/components/Tabs/Buckets/index.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ContractContainer, Status } from './styles';
+import { ContractContainer, Status, ValidatorStatusBadge } from './styles';
 
 export interface IBuckets {
   bucketsTableProps: IInnerTableProps;
@@ -40,7 +40,7 @@ const Buckets: React.FC<PropsWithChildren<IBuckets>> = ({
   };
 
   const rowSections = (assetBucket: IAssetsBuckets): IRowSection[] => {
-    const { asset, bucket } = assetBucket;
+    const { asset, bucket, validatorStatus } = assetBucket;
 
     const minEpochsToUnstake = asset?.staking?.minEpochsToUnstake ?? 1;
     const minEpochsToWithdraw = asset?.staking?.minEpochsToWithdraw ?? 2;
@@ -226,9 +226,19 @@ const Buckets: React.FC<PropsWithChildren<IBuckets>> = ({
                 <ExplorerLink
                   type="validator"
                   value={bucket?.delegation}
-                  label={parseAddress(bucket?.delegation, 22)}
+                  label={
+                    bucket?.validatorName ||
+                    parseAddress(bucket?.delegation, 22)
+                  }
                   compact
                 />
+                {(validatorStatus === 'jailed' ||
+                  validatorStatus === 'inactive') && (
+                  <ValidatorStatusBadge status={validatorStatus}>
+                    {validatorStatus.charAt(0).toUpperCase() +
+                      validatorStatus.slice(1)}
+                  </ValidatorStatusBadge>
+                )}
               </>
             ) : (
               <>{getDelegation()}</>

--- a/src/components/Tabs/Buckets/styles.ts
+++ b/src/components/Tabs/Buckets/styles.ts
@@ -13,3 +13,25 @@ export const ContractContainer = styled.div`
   flex-direction: column;
   gap: 0.5rem;
 `;
+
+export const ValidatorStatusBadge = styled.span<{ status: string }>`
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 4px;
+  width: fit-content;
+
+  ${props =>
+    props.status === 'jailed' &&
+    `
+    color: ${props.theme.table.fail};
+    background-color: ${props.theme.table.fail}22;
+  `}
+
+  ${props =>
+    props.status === 'inactive' &&
+    `
+    color: ${props.theme.table.icon};
+    background-color: ${props.theme.table.icon}22;
+  `}
+`;

--- a/src/services/requests/account/index.ts
+++ b/src/services/requests/account/index.ts
@@ -206,6 +206,71 @@ export const bucketsRequest = (
         assetsBuckets.push({ asset, bucket });
     }
 
+    const uniqueDelegations = Array.from(
+      new Set(
+        assetsBuckets
+          .map(ab => ab.bucket?.delegation)
+          .filter((d): d is string => !!d && d.length > 0),
+      ),
+    );
+
+    const statusMap = new Map<string, string>();
+
+    if (uniqueDelegations.length > 0) {
+      if (uniqueDelegations.length <= 3) {
+        const results = await Promise.all(
+          uniqueDelegations.map(addr =>
+            api.get({ route: `validator/${addr}` }).catch(() => null),
+          ),
+        );
+        for (let i = 0; i < uniqueDelegations.length; i++) {
+          const res = results[i];
+          if (res && !res.error) {
+            statusMap.set(
+              uniqueDelegations[i],
+              res.data?.validator?.list || '',
+            );
+          }
+        }
+      } else {
+        const firstPage = await api
+          .get({ route: 'validator/list', query: { page: 1, limit: 100 } })
+          .catch(() => null);
+        if (firstPage && !firstPage.error) {
+          const totalPages = Math.ceil(
+            (firstPage.pagination?.totalRecords || 0) / 100,
+          );
+          const allPages = [firstPage];
+          if (totalPages > 1) {
+            const rest = await Promise.all(
+              Array.from({ length: totalPages - 1 }, (_, i) =>
+                api
+                  .get({
+                    route: 'validator/list',
+                    query: { page: i + 2, limit: 100 },
+                  })
+                  .catch(() => null),
+              ),
+            );
+            allPages.push(...rest.filter(Boolean));
+          }
+          for (const p of allPages) {
+            for (const v of p?.data?.validators ?? []) {
+              if (v.ownerAddress) {
+                statusMap.set(v.ownerAddress, v.list || '');
+              }
+            }
+          }
+        }
+      }
+    }
+
+    for (const ab of assetsBuckets) {
+      if (ab.bucket?.delegation) {
+        ab.validatorStatus = statusMap.get(ab.bucket.delegation) || '';
+      }
+    }
+
     return {
       data: { buckets: assetsBuckets },
       pagination: assetsDetailsResponse.pagination,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -296,6 +296,7 @@ export interface IAccount {
 export interface IAssetsBuckets {
   asset?: IAccountAsset;
   bucket?: IBucket;
+  validatorStatus?: string;
 }
 
 export interface IHolders {
@@ -558,6 +559,7 @@ export interface IBucket {
   balance: number;
   delegation: string;
   availableEpoch: number | string;
+  validatorName?: string;
 }
 
 // TODO: establish a pattern for filter types


### PR DESCRIPTION
## Summary

- **Validator names in Delegation column**: The `validatorName` field is
  already included in the `address/{address}` API response per bucket — no
  additional API calls are needed. The name is now displayed in the Delegation
  column instead of the truncated raw address.
- **Status badges**: A color-coded badge is shown next to the validator link
  for jailed (red) and inactive (gray) validators, allowing users to immediately
  see when they have delegated to a validator that is no longer active or has
  been jailed. Status is fetched adaptively: if the account delegates to ≤ 3
  unique validators, individual `validator/{addr}` calls are made in parallel;
  if > 3, the full paginated `validator/list` is fetched instead to avoid
  excessive per-address requests.

## Changes

- `src/types/index.ts`: added `validatorName?: string` to `IBucket`;
  added `validatorStatus?: string` to `IAssetsBuckets`
- `src/services/requests/account/index.ts`: adaptive status-fetching logic
  in `bucketsRequest` after bucket assembly
- `src/components/Tabs/Buckets/styles.ts`: new `ValidatorStatusBadge`
  styled component (jailed = red, inactive = gray)
- `src/components/Tabs/Buckets/index.tsx`: use `bucket.validatorName` as
  link label; render status badge for jailed/inactive validators

## Test plan

- [ ] Account with KLV bucket delegated to an elected validator → name shown, no badge
- [ ] Account delegating to an inactive validator → name + gray "Inactive" badge
- [ ] Account delegating to a jailed validator → name + red "Jailed" badge
- [ ] Account with no delegation → "--" / Delegate button unchanged
- [ ] Account delegating to > 3 different validators → all statuses resolved correctly via validator/list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validator status badges in the buckets table delegation column, displaying when validators are jailed or inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->