### PR TITLE
feat(accounts): show staking reward expiry countdown in overview

### DIFF
--- a/public/locales/en/accounts.json
+++ b/public/locales/en/accounts.json
@@ -24,7 +24,10 @@
         "Rewards": "Rewards",
         "Available": "Available",
         "Allowance": "Allowance",
-        "Staking": " {{asset}} Staking"
+        "Staking": " {{asset}} Staking",
+        "Expired": "Expired",
+        "ExpiresIn_one": "Expires in ~{{count}} day",
+        "ExpiresIn_other": "Expires in ~{{count}} days"
       },
       "Nonce": "Nonce"
     },

--- a/public/locales/pt-BR/accounts.json
+++ b/public/locales/pt-BR/accounts.json
@@ -24,7 +24,10 @@
         "Rewards": "Recompensas",
         "Available": "Disponíveis",
         "Allowance": "Permissão",
-        "Staking": "Participação de {{asset}}"
+        "Staking": "Participação de {{asset}}",
+        "Expired": "Expirado",
+        "ExpiresIn_one": "Expira em ~{{count}} dia",
+        "ExpiresIn_other": "Expira em ~{{count}} dias"
       },
       "Nonce": "Nonce"
     },

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -17,6 +17,8 @@ import {
 import { useContractModal } from '@/contexts/contractModal';
 import { useExtension } from '@/contexts/extension';
 import { useMobile } from '@/contexts/mobile';
+import { useNetworkParams } from '@/contexts/contract/networkParams';
+import api from '@/services/api';
 import {
   KFIAllowancePromise,
   KLVAllowancePromise,
@@ -54,6 +56,7 @@ import {
   IconContainer,
   ItemContainerPermissions,
   ItemContentPermissions,
+  RewardExpiry,
   RewardsAvailableContainer,
   StakingRewards,
 } from '@/views/accounts/detail';
@@ -104,6 +107,7 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
   const { walletAddress, extensionInstalled, connectExtension } =
     useExtension();
   const { isTablet } = useMobile();
+  const { paramsList } = useNetworkParams();
   const router = useRouter();
 
   const { data: priceCall, isLoading: isLoadingPriceCall } = useQuery<
@@ -141,6 +145,31 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
     queryFn: () => accountAssetsOwnerCall(router.query.account as string),
     enabled: !!router?.isReady,
   });
+
+  const { data: currentEpoch } = useQuery({
+    queryKey: ['epoch'],
+    queryFn: async () => {
+      const res = await api.get({ route: 'block/list' });
+      return res.data?.blocks[0]?.epoch as number | undefined;
+    },
+  });
+
+  const maxEpochsUnclaimed =
+    paramsList?.find(p => p.parameterLabel === 'MaxEpochsUnclaimed')
+      ?.currentValue ?? 100;
+
+  const calcExpiry = (
+    lastClaimEpoch: number | undefined,
+  ): { days: number; warning: boolean } | null => {
+    if (currentEpoch == null || lastClaimEpoch == null) return null;
+    const remaining = maxEpochsUnclaimed - (currentEpoch - lastClaimEpoch);
+    if (remaining <= 0) return { days: 0, warning: true };
+    const days = Math.floor(remaining / 4);
+    return { days, warning: days < 3 };
+  };
+
+  const klvStakingExpiry = calcExpiry(account?.assets?.KLV?.lastClaim?.epoch);
+  const kfiStakingExpiry = calcExpiry(account?.assets?.KFI?.lastClaim?.epoch);
 
   const getHeaders = () => {
     if (hasProprietaryAssets) {
@@ -601,6 +630,15 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   {!isLoadingKLVAllowance ? (
                     <>
                       <span>{getKLVStaking()}</span>
+                      {klvStakingExpiry != null &&
+                        (KLVAllowance?.data?.result?.stakingRewards ?? 0) >
+                          0 && (
+                          <RewardExpiry warning={klvStakingExpiry.warning}>
+                            {klvStakingExpiry.days === 0
+                              ? 'Expired'
+                              : `Expires in ~${klvStakingExpiry.days} ${klvStakingExpiry.days === 1 ? 'day' : 'days'}`}
+                          </RewardExpiry>
+                        )}
                       <KLVStakingClaimButton />
                     </>
                   ) : (
@@ -617,6 +655,15 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                   {!isLoadingKFIAllowance ? (
                     <>
                       <span>{getKFIStaking()}</span>
+                      {kfiStakingExpiry != null &&
+                        (KFIAllowance?.data?.result?.stakingRewards ?? 0) >
+                          0 && (
+                          <RewardExpiry warning={kfiStakingExpiry.warning}>
+                            {kfiStakingExpiry.days === 0
+                              ? 'Expired'
+                              : `Expires in ~${kfiStakingExpiry.days} ${kfiStakingExpiry.days === 1 ? 'day' : 'days'}`}
+                          </RewardExpiry>
+                        )}
                       <KFIStakingClaimButton />
                     </>
                   ) : (

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -164,8 +164,8 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
     if (currentEpoch == null || lastClaimEpoch == null) return null;
     const remaining = maxEpochsUnclaimed - (currentEpoch - lastClaimEpoch);
     if (remaining <= 0) return { days: 0, warning: true };
-    const days = Math.floor(remaining / 4);
-    return { days, warning: days < 3 };
+    const days = Math.max(1, Math.floor(remaining / 4));
+    return { days, warning: remaining < 12 };
   };
 
   const klvStakingExpiry = calcExpiry(account?.assets?.KLV?.lastClaim?.epoch);
@@ -635,8 +635,13 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                           0 && (
                           <RewardExpiry warning={klvStakingExpiry.warning}>
                             {klvStakingExpiry.days === 0
-                              ? 'Expired'
-                              : `Expires in ~${klvStakingExpiry.days} ${klvStakingExpiry.days === 1 ? 'day' : 'days'}`}
+                              ? t(
+                                  'accounts:SingleAccount.Content.RewardsAvailable.Expired',
+                                )
+                              : t(
+                                  'accounts:SingleAccount.Content.RewardsAvailable.ExpiresIn',
+                                  { count: klvStakingExpiry.days },
+                                )}
                           </RewardExpiry>
                         )}
                       <KLVStakingClaimButton />
@@ -660,8 +665,13 @@ const Account: React.FC<PropsWithChildren<IAccountPage>> = () => {
                           0 && (
                           <RewardExpiry warning={kfiStakingExpiry.warning}>
                             {kfiStakingExpiry.days === 0
-                              ? 'Expired'
-                              : `Expires in ~${kfiStakingExpiry.days} ${kfiStakingExpiry.days === 1 ? 'day' : 'days'}`}
+                              ? t(
+                                  'accounts:SingleAccount.Content.RewardsAvailable.Expired',
+                                )
+                              : t(
+                                  'accounts:SingleAccount.Content.RewardsAvailable.ExpiresIn',
+                                  { count: kfiStakingExpiry.days },
+                                )}
                           </RewardExpiry>
                         )}
                       <KFIStakingClaimButton />

--- a/src/views/accounts/detail.ts
+++ b/src/views/accounts/detail.ts
@@ -279,6 +279,24 @@ export const RewardsAvailableContainer = styled.div`
   flex-direction: column;
 `;
 
+export const RewardExpiry = styled.span<{ warning: boolean }>`
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 2px 7px !important;
+  padding-right: 7px !important;
+  border-radius: 10px;
+  white-space: nowrap;
+  width: fit-content;
+  min-width: fit-content !important;
+  align-self: center;
+  color: ${props =>
+    props.warning ? props.theme.table.fail : props.theme.table.icon};
+  background-color: ${props =>
+    props.warning
+      ? `${props.theme.table.fail}22`
+      : `${props.theme.table.icon}22`};
+`;
+
 export const FrozenContainerLi = styled.li`
   div {
     padding: 0;


### PR DESCRIPTION
## Summary

KLV and KFI staking rewards expire after `MaxEpochsUnclaimed` epochs (~25 days at the default of 100) — after which they are burned. Users had no visibility into how much time remains before their pending staking rewards are lost.

This adds a color-coded expiry badge next to **KLV Staking** and **KFI Staking** in the account overview:
- Gray badge: `Expires in ~X days` (normal)
- Red badge: `Expires in ~1 day` / `Expired` (< 3 days remaining)
- Badge is hidden when staking rewards are 0 (nothing to lose)
- **Allowance** intentionally has no badge — allowance does not expire (confirmed via klever-go source: `LastClaim` is only updated by `StakingClaim`; `AllowanceClaim` bypasses it entirely)

Expiry limit is read from the live `MaxEpochsUnclaimed` network parameter (proposal param #3) via `useNetworkParams` — no hardcoded value. Falls back to `100` while loading. Current epoch is reused from the existing `['epoch']` query cache.

## Changes

- `src/views/accounts/detail.ts`: new `RewardExpiry` styled component
- `src/pages/account/[account].tsx`: epoch query + `maxEpochsUnclaimed` from network params + `calcExpiry` helper + badges in KLV Staking and KFI Staking rows

## Test plan

- [ ] Account with KLV staking rewards > 0 → gray badge with days remaining
- [ ] Account with < 3 days remaining → red badge
- [ ] Account with KFI staking rewards = 0 → no badge shown
- [ ] Allowance row → no badge (intentional)
- [ ] Account with no staking at all → no badges anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staking rewards expiry messaging for KLV and KFI, including a warning indicator when rewards are near expiration.
* **Bug Fixes**
  * Updated staking reward sections to conditionally display the expiry component only when expiry data and allowances are ready; otherwise, existing claim and loading states remain unchanged.
* **Documentation**
  * Extended English and Brazilian Portuguese reward-related translations with “Expired” and “Expires in” (pluralized) text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->