### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,14 +17,14 @@ jobs:
         run: sudo timedatectl set-timezone America/Sao_Paulo
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -33,7 +33,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           build: yarn build
           start: yarn start
+          install: false

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,14 +17,14 @@ jobs:
         run: sudo timedatectl set-timezone America/Sao_Paulo
 
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -31,7 +31,7 @@ jobs:
         run: yarn test --ci --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions used in CI to current major versions so workflows stop relying on outdated `checkout`/`setup-node` majors (including v3 in unit tests) and pick up security and runtime fixes from newer action releases.

## Changes

- `actions/checkout`: v3/v4 → **v7**
- `actions/setup-node`: v3/v4 → **v7**
- `cypress-io/github-action`: v6 → **v7**
- `codecov/codecov-action`: v5 → **v7**
- E2E: set `install: false` on the Cypress step after the existing `yarn install --frozen-lockfile` to avoid a redundant install

## Test plan

- [ ] CI **Build** workflow passes on this PR
- [ ] CI **Tests** workflow passes and Codecov upload still succeeds (or fails soft as before)
- [ ] CI **E2E Tests** workflow passes with Cypress action v7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and continuous integration workflows to use newer action versions.
  * Improved end-to-end test execution by preventing redundant dependency installation.
  * Updated code coverage reporting workflow integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->