### PR TITLE
fix(block): resolve asset precision and honour the filters on the block transactions list

### DIFF
--- a/src/components/DateFilter/__tests__/index.test.tsx
+++ b/src/components/DateFilter/__tests__/index.test.tsx
@@ -1,0 +1,118 @@
+import theme from '@/styles/theme';
+import { setQueryAndRouter } from '@/utils';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const routerQuery: Record<string, string> = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ isReady: true, query: routerQuery, push: jest.fn() }),
+}));
+
+jest.mock('@/utils', () => ({
+  setQueryAndRouter: jest.fn(),
+}));
+
+// SVG imports resolve to an object under Jest, which React cannot render.
+jest.mock('@/assets/calendar', () => ({
+  ArrowLeft: () => <svg data-testid="arrow-left" />,
+  ArrowRight: () => <svg data-testid="arrow-right" />,
+  WarningIcon: () => <svg data-testid="warning" />,
+}));
+
+jest.mock('@/assets/icons', () => ({
+  Calendar: () => <svg data-testid="calendar" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import DateFilter from '../index';
+
+const mockedSetQuery = setQueryAndRouter as jest.Mock;
+
+const renderFilter = (query: Record<string, string>) => {
+  Object.keys(routerQuery).forEach(key => delete routerQuery[key]);
+  Object.assign(routerQuery, query);
+
+  render(
+    <ThemeProvider theme={theme}>
+      <DateFilter />
+    </ThemeProvider>,
+  );
+};
+
+/** Opens the calendar, picks the first day of the month and confirms. */
+const pickADayAndConfirm = () => {
+  fireEvent.focus(screen.getByPlaceholderText('All'));
+  fireEvent.click(screen.getAllByText('1')[0]);
+  fireEvent.click(screen.getByText('Confirm'));
+};
+
+describe('DateFilter page reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns to the first page when a range is confirmed', () => {
+    renderFilter({ page: '5' });
+
+    pickADayAndConfirm();
+
+    const [query] = mockedSetQuery.mock.calls[0];
+    expect(query.page).toBe('1');
+    expect(query.startdate).toBeDefined();
+    expect(query.enddate).toBeDefined();
+  });
+
+  it('returns to the first page when the range is cleared', () => {
+    renderFilter({ page: '5' });
+
+    pickADayAndConfirm();
+    mockedSetQuery.mockClear();
+
+    // The clear control only exists once a range has been applied.
+    fireEvent.click(screen.getByTestId('date-filter-clear'));
+
+    const [query] = mockedSetQuery.mock.calls[0];
+    expect(query.page).toBe('1');
+    expect(query).not.toHaveProperty('startdate');
+    expect(query).not.toHaveProperty('enddate');
+  });
+});

--- a/src/components/DateFilter/index.tsx
+++ b/src/components/DateFilter/index.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from 'react';
 import { ArrowLeft, ArrowRight, WarningIcon } from '@/assets/calendar';
 import { Calendar as CalendarIcon } from '@/assets/icons';
 import { setQueryAndRouter } from '@/utils';
+import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 import { useRouter } from 'next/router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AiOutlineClose } from 'react-icons/ai';
@@ -80,7 +81,12 @@ const DateFilter: React.FC<PropsWithChildren> = () => {
     }`;
   };
   const resetDate = () => {
-    const updatedQuery = { ...router.query };
+    // Back to the first page, for the same reason the other filters do it: a
+    // different result set can have fewer pages than the one being viewed.
+    const updatedQuery: NextParsedUrlQuery = {
+      ...router.query,
+      page: String(1),
+    };
     delete updatedQuery.startdate;
     delete updatedQuery.enddate;
     setQueryAndRouter(updatedQuery, router);
@@ -264,6 +270,7 @@ const DateFilter: React.FC<PropsWithChildren> = () => {
     setQueryAndRouter(
       {
         ...router.query,
+        page: String(1),
         startdate: startDateWithTime.getTime().toString(),
         enddate: endDateWithTime.getTime().toString(),
       },

--- a/src/components/DateFilter/index.tsx
+++ b/src/components/DateFilter/index.tsx
@@ -324,7 +324,10 @@ const DateFilter: React.FC<PropsWithChildren> = () => {
             {!inputRef.current?.value && <CalendarIcon />}
             {inputRef.current?.value && (
               <CloseContainer>
-                <AiOutlineClose onClick={handleClear} />
+                <AiOutlineClose
+                  data-testid="date-filter-clear"
+                  onClick={handleClear}
+                />
               </CloseContainer>
             )}
           </OutsideContent>

--- a/src/components/TransactionsFilters/__tests__/index.test.tsx
+++ b/src/components/TransactionsFilters/__tests__/index.test.tsx
@@ -1,0 +1,150 @@
+import theme from '@/styles/theme';
+import { setQueryAndRouter } from '@/utils';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const routerQuery: Record<string, string> = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ isReady: true, query: routerQuery, push: jest.fn() }),
+}));
+
+jest.mock('@/utils', () => ({
+  setQueryAndRouter: jest.fn(),
+}));
+
+// useFetchPartial reaches @/utils/precisionFunctions and from there an ESM
+// package Jest cannot transform, so the hook module is replaced wholesale.
+// The tuple has to keep a stable identity: the component effects on `assets`,
+// so a fresh array per render re-runs them forever.
+jest.mock('@/utils/hooks', () => {
+  const stable = [[], () => undefined, false, () => undefined];
+  return { useFetchPartial: () => stable };
+});
+
+// The date filter has its own calendar; stub it out so this suite only
+// exercises handleSelected.
+jest.mock('@/components/DateFilter', () => ({
+  __esModule: true,
+  default: () => <div data-testid="date-filter" />,
+}));
+
+// SVG imports resolve to an object under Jest, which React cannot render.
+jest.mock('@/assets/icons', () => ({
+  FilterArrowDown: () => <svg data-testid="arrow" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import TransactionsFilters from '../index';
+
+const mockedSetQuery = setQueryAndRouter as jest.Mock;
+
+/** Opens one filter and returns it, so options are picked within it: several
+ * filters offer an option named "All". */
+const openFilter = (title: string): HTMLElement => {
+  const container = screen.getByText(title).parentElement as HTMLElement;
+  fireEvent.click(
+    container.querySelector('[data-testid="selector"]') as Element,
+  );
+
+  return container;
+};
+
+const renderFilters = (query: Record<string, string>) => {
+  Object.keys(routerQuery).forEach(key => delete routerQuery[key]);
+  Object.assign(routerQuery, query);
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <TransactionsFilters />
+    </ThemeProvider>,
+  );
+};
+
+describe('TransactionsFilters page reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns to the first page when a status is picked from a later page', () => {
+    renderFilters({ page: '3' });
+
+    const status = openFilter('Status');
+    fireEvent.click(within(status).getByText('Fail'));
+
+    expect(mockedSetQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'Fail', page: '1' }),
+      expect.anything(),
+    );
+  });
+
+  it('returns to the first page when a contract type is picked', () => {
+    renderFilters({ page: '4' });
+
+    const contract = openFilter('Contract');
+    fireEvent.click(within(contract).getByText('Transfer'));
+
+    expect(mockedSetQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ page: '1' }),
+      expect.anything(),
+    );
+  });
+
+  it('drops the filter key but still returns to the first page on All', () => {
+    renderFilters({ page: '3', status: 'Fail' });
+
+    const status = openFilter('Status');
+    fireEvent.click(within(status).getByText('All'));
+
+    const [query] = mockedSetQuery.mock.calls[0];
+    expect(query.page).toBe('1');
+    expect(query).not.toHaveProperty('status');
+  });
+
+  it('does not navigate when the current value is picked again', () => {
+    renderFilters({ page: '3', status: 'Success' });
+
+    const status = openFilter('Status');
+    fireEvent.click(within(status).getByText('Success'));
+
+    expect(mockedSetQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/TransactionsFilters/__tests__/index.test.tsx
+++ b/src/components/TransactionsFilters/__tests__/index.test.tsx
@@ -122,8 +122,10 @@ describe('TransactionsFilters page reset', () => {
     const contract = openFilter('Contract');
     fireEvent.click(within(contract).getByText('Transfer'));
 
+    // Transfer is index 0 in ContractsIndex, and the value is what makes this
+    // assertion mean something: page alone would pass with type omitted.
     expect(mockedSetQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ page: '1' }),
+      expect.objectContaining({ type: '0', page: '1' }),
       expect.anything(),
     );
   });

--- a/src/components/TransactionsFilters/index.tsx
+++ b/src/components/TransactionsFilters/index.tsx
@@ -35,7 +35,10 @@ const TransactionsFilters: React.FC<
   const getContractName = (): string => ContractsIndex[Number(query.type)];
 
   const handleSelected = (selected: string, filterType: string): void => {
-    const updatedQuery = { ...query };
+    // Every branch returns to the first page: a narrower result set can have
+    // fewer pages than the one being viewed, which would otherwise leave the
+    // table on an empty page with no pagination control to get back.
+    const updatedQuery: NextParsedUrlQuery = { ...query, page: String(1) };
     if (selected === 'All') {
       delete updatedQuery[filterType];
       if (filterType === 'type') {
@@ -49,13 +52,12 @@ const TransactionsFilters: React.FC<
       setQueryAndRouter(
         {
           ...updatedQuery,
-          page: String(1),
           [filterType]: String(getContractIndex(selected)),
         },
         router,
       );
     } else if (selected !== query[filterType]) {
-      setQueryAndRouter({ ...query, [filterType]: selected }, router);
+      setQueryAndRouter({ ...updatedQuery, [filterType]: selected }, router);
     }
   };
 

--- a/src/pages/block/[block].tsx
+++ b/src/pages/block/[block].tsx
@@ -19,6 +19,7 @@ import {
 import { IBlock, IBlockPage, IBlockResponse } from '@/types/blocks';
 import { setQueryAndRouter } from '@/utils';
 import { formatDate, toLocaleFixed } from '@/utils/formatFunctions';
+import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
 import {
   CenteredRowSpan,
   CommonSpan,
@@ -34,7 +35,7 @@ import {
   MdOutlineKeyboardArrowLeft,
   MdOutlineKeyboardArrowRight,
 } from 'react-icons/md';
-import { ITransactionsResponse, NotFound } from '../../types';
+import { ITransaction, ITransactionsResponse, NotFound } from '../../types';
 
 const Block: React.FC<PropsWithChildren<IBlockPage>> = ({ block }) => {
   const {
@@ -68,10 +69,34 @@ const Block: React.FC<PropsWithChildren<IBlockPage>> = ({ block }) => {
   const requestBlock = async (
     page: number,
     limit: number,
-  ): Promise<ITransactionsResponse> =>
-    api.get({
+  ): Promise<ITransactionsResponse> => {
+    const transactionsResponse = await api.get({
       route: `transaction/list?page=${page}&blockNum=${nonce}&limit=${limit}`,
     });
+
+    // The list endpoint omits each asset's precision, so it is resolved here
+    // and attached to every transaction. Without it the row sections fall
+    // back to the KLV default of 6 and misreport every asset with another
+    // precision.
+    let parsedTransactions: ITransaction[] | undefined;
+    try {
+      parsedTransactions =
+        await getParsedTransactionPrecision(transactionsResponse);
+    } catch (error) {
+      // The precision lookup throws on its own failures. Keep the rows that
+      // the list request already returned rather than reporting a block with
+      // transactions as empty, which is indistinguishable from one without.
+      console.error(error);
+    }
+
+    return {
+      ...transactionsResponse,
+      data: {
+        transactions:
+          parsedTransactions ?? transactionsResponse.data?.transactions ?? [],
+      },
+    };
+  };
 
   useEffect(() => {
     if (!router.isReady) return;

--- a/src/pages/block/[block].tsx
+++ b/src/pages/block/[block].tsx
@@ -19,7 +19,7 @@ import {
 import { IBlock, IBlockPage, IBlockResponse } from '@/types/blocks';
 import { setQueryAndRouter } from '@/utils';
 import { formatDate, toLocaleFixed } from '@/utils/formatFunctions';
-import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+import { blockTransactionsCall } from '@/services/requests/block';
 import {
   CenteredRowSpan,
   CommonSpan,
@@ -35,7 +35,7 @@ import {
   MdOutlineKeyboardArrowLeft,
   MdOutlineKeyboardArrowRight,
 } from 'react-icons/md';
-import { ITransaction, ITransactionsResponse, NotFound } from '../../types';
+import { ITransactionsResponse, NotFound } from '../../types';
 
 const Block: React.FC<PropsWithChildren<IBlockPage>> = ({ block }) => {
   const {
@@ -69,34 +69,8 @@ const Block: React.FC<PropsWithChildren<IBlockPage>> = ({ block }) => {
   const requestBlock = async (
     page: number,
     limit: number,
-  ): Promise<ITransactionsResponse> => {
-    const transactionsResponse = await api.get({
-      route: `transaction/list?page=${page}&blockNum=${nonce}&limit=${limit}`,
-    });
-
-    // The list endpoint omits each asset's precision, so it is resolved here
-    // and attached to every transaction. Without it the row sections fall
-    // back to the KLV default of 6 and misreport every asset with another
-    // precision.
-    let parsedTransactions: ITransaction[] | undefined;
-    try {
-      parsedTransactions =
-        await getParsedTransactionPrecision(transactionsResponse);
-    } catch (error) {
-      // The precision lookup throws on its own failures. Keep the rows that
-      // the list request already returned rather than reporting a block with
-      // transactions as empty, which is indistinguishable from one without.
-      console.error(error);
-    }
-
-    return {
-      ...transactionsResponse,
-      data: {
-        transactions:
-          parsedTransactions ?? transactionsResponse.data?.transactions ?? [],
-      },
-    };
-  };
+  ): Promise<ITransactionsResponse> =>
+    blockTransactionsCall(nonce, page, limit, router.query);
 
   useEffect(() => {
     if (!router.isReady) return;

--- a/src/services/requests/block/__tests__/index.test.ts
+++ b/src/services/requests/block/__tests__/index.test.ts
@@ -1,6 +1,11 @@
 import api from '@/services/api';
 import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+import { toast } from 'react-toastify';
 import { blockTransactionsCall } from '../index';
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
 
 jest.mock('@/services/api', () => ({
   __esModule: true,
@@ -138,6 +143,25 @@ describe('blockTransactionsCall', () => {
     const result = await blockTransactionsCall(42, 1, 10);
 
     expect(result.data.transactions).toEqual([rawTransaction]);
+  });
+
+  it('warns that the kept rows may be inaccurate', async () => {
+    // Those rows render at the KLV default precision, so the failure must not
+    // be silent: a wrong amount otherwise looks like a correct one.
+    mockedParse.mockRejectedValue(new Error('Fetch timeout'));
+
+    await blockTransactionsCall(42, 1, 10);
+
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('inaccurate'),
+      { toastId: 'block-precisions' },
+    );
+  });
+
+  it('does not warn when the precision lookup succeeds', async () => {
+    await blockTransactionsCall(42, 1, 10);
+
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('passes an error response through, so the table shows its error branch', async () => {

--- a/src/services/requests/block/__tests__/index.test.ts
+++ b/src/services/requests/block/__tests__/index.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/services/api', () => ({
 // cannot transform, so it is replaced wholesale rather than spied on.
 jest.mock('@/utils/precisionFunctions', () => ({
   __esModule: true,
+  PRECISION_TOAST_ID: 'assets-precisions',
   getParsedTransactionPrecision: jest.fn(),
 }));
 
@@ -111,14 +112,16 @@ describe('blockTransactionsCall', () => {
     expect(queryOf()).not.toHaveProperty('status');
   });
 
-  it('keeps the requested block and paging even when the URL carries its own', async () => {
+  it('takes the block and paging from its arguments, not from the URL', async () => {
+    // A spoofed blockNum/page/limit never enters the query at all: the
+    // allowlist drops them before these three are set from the arguments.
     await blockTransactionsCall(42, 3, 50, {
       blockNum: '999',
       page: '1',
       limit: '10',
     });
 
-    expect(queryOf()).toMatchObject({ blockNum: 42, page: 3, limit: 50 });
+    expect(queryOf()).toEqual({ blockNum: 42, page: 3, limit: 50 });
   });
 
   it('resolves the precision of the transactions it just fetched', async () => {
@@ -154,7 +157,8 @@ describe('blockTransactionsCall', () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       expect.stringContaining('inaccurate'),
-      { toastId: 'block-precisions' },
+      // Shared with the lookup's own toast so the two cannot stack.
+      { toastId: 'assets-precisions' },
     );
   });
 

--- a/src/services/requests/block/__tests__/index.test.ts
+++ b/src/services/requests/block/__tests__/index.test.ts
@@ -1,0 +1,152 @@
+import api from '@/services/api';
+import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+import { blockTransactionsCall } from '../index';
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+// The real module reaches @/pages/transactions, whose import chain Jest
+// cannot transform, so it is replaced wholesale rather than spied on.
+jest.mock('@/utils/precisionFunctions', () => ({
+  __esModule: true,
+  getParsedTransactionPrecision: jest.fn(),
+}));
+
+const mockedGet = api.get as jest.Mock;
+const mockedParse = getParsedTransactionPrecision as jest.Mock;
+
+const rawTransaction = { hash: 'abc', blockNum: 42 };
+
+const response = {
+  data: { transactions: [rawTransaction] },
+  pagination: { totalPages: 3 },
+  error: '',
+  code: 'successful',
+};
+
+const queryOf = (call = 0) => mockedGet.mock.calls[call][0].query;
+
+describe('blockTransactionsCall', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockedGet.mockResolvedValue(response);
+    mockedParse.mockResolvedValue([{ ...rawTransaction, precision: 8 }]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends the block number, page and limit', async () => {
+    await blockTransactionsCall(42, 2, 20);
+
+    expect(mockedGet).toHaveBeenCalledWith({
+      route: 'transaction/list',
+      query: { blockNum: 42, page: 2, limit: 20 },
+    });
+  });
+
+  it('forwards the transaction filters that the filter bar writes to the URL', async () => {
+    await blockTransactionsCall(42, 1, 10, {
+      status: 'Fail',
+      type: '0',
+      asset: 'KID-36W3',
+      buyType: 'ITOBuy',
+      startdate: '1000',
+      enddate: '2000',
+    });
+
+    expect(queryOf()).toMatchObject({
+      status: 'Fail',
+      type: '0',
+      asset: 'KID-36W3',
+      buyType: 'ITOBuy',
+      startdate: '1000',
+      enddate: '2000',
+    });
+  });
+
+  it('drops params that are not filters, so a crafted URL cannot add its own', async () => {
+    await blockTransactionsCall(42, 1, 10, {
+      block: '42',
+      tab: 'Transactions',
+      card: 'Info',
+      withResults: 'true',
+      status: 'Success',
+    });
+
+    expect(queryOf()).toEqual({
+      status: 'Success',
+      blockNum: 42,
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  it('encodes a filter value so it cannot inject another parameter', async () => {
+    await blockTransactionsCall(42, 1, 10, { status: '&blockNum=999' });
+
+    expect(queryOf().status).toBe('%26blockNum%3D999');
+  });
+
+  it('encodes a filter value so it cannot truncate the query with a fragment', async () => {
+    await blockTransactionsCall(42, 1, 10, { asset: 'KLV#' });
+
+    expect(queryOf().asset).toBe('KLV%23');
+  });
+
+  it('ignores a repeated param, which arrives as an array', async () => {
+    await blockTransactionsCall(42, 1, 10, { status: ['Success', 'Fail'] });
+
+    expect(queryOf()).not.toHaveProperty('status');
+  });
+
+  it('keeps the requested block and paging even when the URL carries its own', async () => {
+    await blockTransactionsCall(42, 3, 50, {
+      blockNum: '999',
+      page: '1',
+      limit: '10',
+    });
+
+    expect(queryOf()).toMatchObject({ blockNum: 42, page: 3, limit: 50 });
+  });
+
+  it('resolves the precision of the transactions it just fetched', async () => {
+    const result = await blockTransactionsCall(42, 1, 10);
+
+    expect(mockedParse).toHaveBeenCalledWith(response);
+    expect(result.data.transactions).toEqual([
+      { hash: 'abc', blockNum: 42, precision: 8 },
+    ]);
+  });
+
+  it('preserves pagination and error so the table can read them', async () => {
+    const result = await blockTransactionsCall(42, 1, 10);
+
+    expect(result.pagination).toEqual({ totalPages: 3 });
+    expect(result.error).toBe('');
+  });
+
+  it('keeps the fetched rows when the precision lookup fails', async () => {
+    mockedParse.mockRejectedValue(new Error('Fetch timeout'));
+
+    const result = await blockTransactionsCall(42, 1, 10);
+
+    expect(result.data.transactions).toEqual([rawTransaction]);
+  });
+
+  it('passes an error response through, so the table shows its error branch', async () => {
+    mockedGet.mockResolvedValue({ data: null, error: 'boom', pagination: {} });
+    mockedParse.mockResolvedValue(undefined);
+
+    const result = await blockTransactionsCall(42, 1, 10);
+
+    expect(result.error).toBe('boom');
+    expect(result.data.transactions).toEqual([]);
+  });
+});

--- a/src/services/requests/block/index.ts
+++ b/src/services/requests/block/index.ts
@@ -1,6 +1,7 @@
 import api from '@/services/api';
 import { ITransaction, ITransactionsResponse } from '@/types';
 import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+import { toast } from 'react-toastify';
 
 type RouterQuery = Record<string, string | string[] | undefined>;
 
@@ -41,6 +42,10 @@ export const blockTransactionsCall = async (
   FILTER_PARAMS.forEach(key => {
     const value = routerQuery[key];
     if (typeof value === 'string' && value !== '') {
+      // Encoded here rather than in `buildUrlQuery`, which would fix every
+      // caller at once but risks changing values other endpoints already
+      // accept. If that central fix ever lands, drop this call: encoding
+      // twice would turn a filter value into its escaped form on the wire.
       query[key] = encodeURIComponent(value);
     }
   });
@@ -67,7 +72,15 @@ export const blockTransactionsCall = async (
     // The precision lookup throws on its own failures. Keep the rows that the
     // list request already returned rather than reporting a block with
     // transactions as empty, which is indistinguishable from one without.
+    //
+    // Those rows then render at the KLV default of 6, so say so: without a
+    // signal the amounts look authoritative while being wrong for any asset
+    // with another precision. Only some of the throwing paths raise a toast
+    // themselves, hence one here for the rest.
     console.error(error);
+    toast.error('Amounts may be inaccurate: asset precisions failed to load', {
+      toastId: 'block-precisions',
+    });
   }
 
   return {

--- a/src/services/requests/block/index.ts
+++ b/src/services/requests/block/index.ts
@@ -1,6 +1,9 @@
 import api from '@/services/api';
 import { ITransaction, ITransactionsResponse } from '@/types';
-import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+import {
+  PRECISION_TOAST_ID,
+  getParsedTransactionPrecision,
+} from '@/utils/precisionFunctions';
 import { toast } from 'react-toastify';
 
 type RouterQuery = Record<string, string | string[] | undefined>;
@@ -50,8 +53,9 @@ export const blockTransactionsCall = async (
     }
   });
 
-  // The block being viewed and the table's own paging are set last so they
-  // cannot be overridden by a filter of the same name.
+  // A spoofed blockNum, page or limit in the URL is already dropped by the
+  // allowlist above, never having entered `query`. These three come from the
+  // function arguments instead; writing them last is defence in depth only.
   query.blockNum = blockNum;
   query.page = page;
   query.limit = limit;
@@ -75,11 +79,15 @@ export const blockTransactionsCall = async (
     //
     // Those rows then render at the KLV default of 6, so say so: without a
     // signal the amounts look authoritative while being wrong for any asset
-    // with another precision. Only some of the throwing paths raise a toast
-    // themselves, hence one here for the rest.
+    // with another precision.
+    //
+    // Shares its id with the lookup's own toast, which already fires on the
+    // common path. That keeps it to one message either way: this one only
+    // becomes visible on the paths that stay quiet, such as a corrupt
+    // localStorage cache.
     console.error(error);
     toast.error('Amounts may be inaccurate: asset precisions failed to load', {
-      toastId: 'block-precisions',
+      toastId: PRECISION_TOAST_ID,
     });
   }
 

--- a/src/services/requests/block/index.ts
+++ b/src/services/requests/block/index.ts
@@ -1,0 +1,80 @@
+import api from '@/services/api';
+import { ITransaction, ITransactionsResponse } from '@/types';
+import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
+
+type RouterQuery = Record<string, string | string[] | undefined>;
+
+/**
+ * The only params forwarded to the API, written by the filter bar above this
+ * table: TransactionsFilters writes asset, status, type and buyType, DateFilter
+ * writes startdate and enddate.
+ *
+ * An allowlist rather than a denylist because `buildUrlQuery` interpolates
+ * values into the query string unescaped, so anything reaching it from the URL
+ * can inject further params. A repeated param (?status=a&status=b) arrives as
+ * an array and is skipped for the same reason.
+ */
+const FILTER_PARAMS = [
+  'asset',
+  'status',
+  'type',
+  'buyType',
+  'startdate',
+  'enddate',
+];
+
+/**
+ * Transactions of a single block, with each asset's precision resolved.
+ *
+ * The filters rendered above this table write to `router.query`, so the query
+ * is forwarded rather than rebuilt from the block number alone; otherwise the
+ * filter bar changes the URL and refetches without ever filtering anything.
+ */
+export const blockTransactionsCall = async (
+  blockNum: number,
+  page: number,
+  limit: number,
+  routerQuery: RouterQuery = {},
+): Promise<ITransactionsResponse> => {
+  const query: Record<string, unknown> = {};
+
+  FILTER_PARAMS.forEach(key => {
+    const value = routerQuery[key];
+    if (typeof value === 'string' && value !== '') {
+      query[key] = encodeURIComponent(value);
+    }
+  });
+
+  // The block being viewed and the table's own paging are set last so they
+  // cannot be overridden by a filter of the same name.
+  query.blockNum = blockNum;
+  query.page = page;
+  query.limit = limit;
+
+  const transactionsResponse = await api.get({
+    route: 'transaction/list',
+    query,
+  });
+
+  // The list endpoint omits each asset's precision, so it is resolved here and
+  // attached to every transaction. Without it the row sections fall back to
+  // the KLV default of 6 and misreport every asset with another precision.
+  let parsedTransactions: ITransaction[] | undefined;
+  try {
+    parsedTransactions =
+      await getParsedTransactionPrecision(transactionsResponse);
+  } catch (error) {
+    // The precision lookup throws on its own failures. Keep the rows that the
+    // list request already returned rather than reporting a block with
+    // transactions as empty, which is indistinguishable from one without.
+    console.error(error);
+  }
+
+  return {
+    ...transactionsResponse,
+    data: {
+      transactions:
+        parsedTransactions ?? transactionsResponse.data?.transactions ?? [],
+    },
+  };
+};

--- a/src/utils/csv/index.test.ts
+++ b/src/utils/csv/index.test.ts
@@ -5,6 +5,12 @@ import {
   getDefaultCells,
   getContractCells,
 } from '../contracts';
+import { exportToCsv, sanitizeRow } from './index';
+import { toast } from 'react-toastify';
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
 
 jest.mock('../precisionFunctions', () => ({
   getPrecision: jest.fn().mockResolvedValue(6),
@@ -589,4 +595,79 @@ describe('header-data alignment', () => {
       expect(sanitizedHeaders.length).toBe(cells.length);
     },
   );
+});
+
+describe('sanitizeRow', () => {
+  it('neutralizes a leading = so a spreadsheet does not evaluate it', () => {
+    expect(sanitizeRow(['=HYPERLINK("https://evil.tld")'])).toBe(
+      '"\'=HYPERLINK(""https://evil.tld"")"\n',
+    );
+  });
+
+  it.each([
+    ['=cmd', "'=cmd\n"],
+    ['+cmd', "'+cmd\n"],
+    ['@cmd', "'@cmd\n"],
+    ['-cmd', "'-cmd\n"],
+    ['-1+1', "'-1+1\n"],
+    ['\tcmd', "'\tcmd\n"],
+  ])('neutralizes the formula prefix in %j', (value, expected) => {
+    expect(sanitizeRow([value])).toBe(expected);
+  });
+
+  it('keeps a value on one record so its tail cannot escape the check', () => {
+    // A bare CR is a record separator to a CSV reader, so without collapsing
+    // it the text behind it would start a new record and never be checked.
+    const result = sanitizeRow(["MyProposal\r=cmd|'/C calc'!A0", 'next']);
+
+    expect(result).not.toContain('\r');
+    expect(result.split('\n').filter(Boolean)).toHaveLength(1);
+    expect(result).toBe("MyProposal =cmd|'/C calc'!A0,next\n");
+  });
+
+  it('collapses an embedded newline for the same reason', () => {
+    expect(sanitizeRow(['line1\nline2'])).toBe('line1 line2\n');
+  });
+
+  it.each([-5, '+1e3', 0, 42])(
+    'leaves %j a number rather than turning it into text',
+    value => {
+      expect(sanitizeRow([value])).toBe(`${value}\n`);
+    },
+  );
+
+  it('leaves an ordinary value untouched', () => {
+    expect(sanitizeRow(['KID-36W3'])).toBe('KID-36W3\n');
+  });
+
+  it('still quotes and escapes a value containing a comma or a quote', () => {
+    expect(sanitizeRow(['a,b'])).toBe('"a,b"\n');
+    expect(sanitizeRow(['say "hi"'])).toBe('"say ""hi"""\n');
+  });
+
+  it('renders null and undefined as empty cells', () => {
+    expect(sanitizeRow([null, undefined, 'x'])).toBe(',,x\n');
+  });
+
+  it('joins multiple cells with a comma', () => {
+    expect(sanitizeRow(['a', 'b', 'c'])).toBe('a,b,c\n');
+  });
+});
+
+describe('exportToCsv', () => {
+  beforeEach(() => {
+    (toast.error as jest.Mock).mockClear();
+  });
+
+  it('reports an empty result with a toast, not a native dialog', async () => {
+    await exportToCsv('transactions.csv', [], mockRouter());
+
+    expect(toast.error).toHaveBeenCalledWith('No data to export!');
+  });
+
+  it('reports the same way when there are no rows at all', async () => {
+    await exportToCsv('transactions.csv', null, mockRouter());
+
+    expect(toast.error).toHaveBeenCalledWith('No data to export!');
+  });
 });

--- a/src/utils/csv/index.test.ts
+++ b/src/utils/csv/index.test.ts
@@ -610,7 +610,8 @@ describe('sanitizeRow', () => {
     ['@cmd', "'@cmd\n"],
     ['-cmd', "'-cmd\n"],
     ['-1+1', "'-1+1\n"],
-    ['\tcmd', "'\tcmd\n"],
+    // A tab is also a separator for some readers, so it is quoted as well.
+    ['\tcmd', '"\'\tcmd"\n'],
   ])('neutralizes the formula prefix in %j', (value, expected) => {
     expect(sanitizeRow([value])).toBe(expected);
   });
@@ -628,6 +629,18 @@ describe('sanitizeRow', () => {
   it('collapses an embedded newline for the same reason', () => {
     expect(sanitizeRow(['line1\nline2'])).toBe('line1 line2\n');
   });
+
+  it.each([';', '\t'])(
+    'quotes a value containing %j, which a reader may treat as the separator',
+    separator => {
+      // Excel and LibreOffice follow the locale list separator, a semicolon in
+      // most of continental Europe. Unquoted, the tail would start a new field
+      // and the formula check would never have seen it.
+      const result = sanitizeRow([`MyAsset${separator}=cmd|'/C calc'!A0`]);
+
+      expect(result).toBe(`"MyAsset${separator}=cmd|'/C calc'!A0"\n`);
+    },
+  );
 
   it.each([-5, '+1e3', 0, 42])(
     'leaves %j a number rather than turning it into text',

--- a/src/utils/csv/index.ts
+++ b/src/utils/csv/index.ts
@@ -19,7 +19,7 @@ const processHeaders = (router: NextRouter) => {
   return sanitizedHeaders;
 };
 
-const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r']);
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t']);
 
 /**
  * Cells starting with one of these are evaluated as a formula by Excel and
@@ -28,6 +28,10 @@ const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r']);
  * description) reaches these cells, so a leading quote is added to keep the
  * value inert. Values that parse as a number are left alone, so a negative
  * amount stays a number rather than becoming text.
+ *
+ * Carriage return is absent on purpose: the caller collapses line breaks
+ * before calling this, so one can never be the first character here. Move
+ * that collapse and a leading CR becomes reachable again.
  */
 const escapeFormula = (value: string): string =>
   FORMULA_PREFIXES.has(value.charAt(0)) && Number.isNaN(Number(value))
@@ -48,8 +52,13 @@ export const sanitizeRow = (parsedRow: any[]): string => {
     // cell, past the formula check.
     const singleLine = innerValue.replace(/[\r\n]+/g, ' ');
 
+    // Quote on any character a reader may treat as a field separator, not just
+    // the comma: Excel and LibreOffice follow the locale list separator, which
+    // is a semicolon across most of continental Europe. Without this, a cell
+    // holding one splits there and its tail starts a new field, which the
+    // formula check never saw.
     let result = escapeFormula(singleLine).replace(/"/g, '""');
-    if (result.search(/["\n,]/g) >= 0) result = '"' + result + '"';
+    if (result.search(/["\n,;\t]/g) >= 0) result = '"' + result + '"';
     if (j > 0) finalVal += ',';
     finalVal += result;
   }

--- a/src/utils/csv/index.ts
+++ b/src/utils/csv/index.ts
@@ -19,7 +19,22 @@ const processHeaders = (router: NextRouter) => {
   return sanitizedHeaders;
 };
 
-const sanitizeRow = (parsedRow: any[]) => {
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@', '\t', '\r']);
+
+/**
+ * Cells starting with one of these are evaluated as a formula by Excel and
+ * LibreOffice, and quoting does not help because they strip the quotes on
+ * import. Chain supplied text (asset ticker, account name, proposal
+ * description) reaches these cells, so a leading quote is added to keep the
+ * value inert. Values that parse as a number are left alone, so a negative
+ * amount stays a number rather than becoming text.
+ */
+const escapeFormula = (value: string): string =>
+  FORMULA_PREFIXES.has(value.charAt(0)) && Number.isNaN(Number(value))
+    ? `'${value}`
+    : value;
+
+export const sanitizeRow = (parsedRow: any[]): string => {
   let finalVal = '';
   for (let j = 0; j < parsedRow.length; j++) {
     const innerValue =
@@ -27,8 +42,14 @@ const sanitizeRow = (parsedRow: any[]) => {
         ? ''
         : parsedRow[j].toString();
 
-    let result = innerValue.replace(/"/g, '""');
-    if (result.search(/("|,|\n)/g) >= 0) result = '"' + result + '"';
+    // Collapse line breaks first. A bare CR is a record separator to a CSV
+    // reader but is not covered by the quoting test below, so a value carrying
+    // one would split the row and drop its tail into the next record's first
+    // cell, past the formula check.
+    const singleLine = innerValue.replace(/[\r\n]+/g, ' ');
+
+    let result = escapeFormula(singleLine).replace(/"/g, '""');
+    if (result.search(/["\n,]/g) >= 0) result = '"' + result + '"';
     if (j > 0) finalVal += ',';
     finalVal += result;
   }
@@ -75,7 +96,7 @@ export const exportToCsv = async (
   router: NextRouter,
 ): Promise<void> => {
   if (!rows || rows.length === 0) {
-    window.alert('No data to export!');
+    toast.error('No data to export!');
     return;
   }
 

--- a/src/utils/errorMessage/__tests__/index.test.ts
+++ b/src/utils/errorMessage/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { capitalizeError } from '../index';
+
+describe('capitalizeError', () => {
+  it('capitalizes a string error from an API error body', () => {
+    expect(capitalizeError('fetch timeout')).toBe('Fetch timeout');
+  });
+
+  it('reads the message of an Error, which a transport failure yields', () => {
+    expect(capitalizeError(new Error('network request failed'))).toBe(
+      'Network request failed',
+    );
+  });
+
+  it('reads the message of a TypeError, which fetch throws when offline', () => {
+    expect(capitalizeError(new TypeError('failed to fetch'))).toBe(
+      'Failed to fetch',
+    );
+  });
+
+  it('leaves an already capitalized message unchanged', () => {
+    expect(capitalizeError('Internal error')).toBe('Internal error');
+  });
+
+  it('returns an empty string for an empty message', () => {
+    expect(capitalizeError('')).toBe('');
+  });
+
+  it('stringifies a value that is neither a string nor an Error', () => {
+    expect(capitalizeError(404)).toBe('404');
+  });
+});

--- a/src/utils/errorMessage/index.ts
+++ b/src/utils/errorMessage/index.ts
@@ -9,4 +9,4 @@ import { capitalizeString } from '../convertString';
  * failures it was meant to report, so the message never reached the user.
  */
 export const capitalizeError = (error: unknown): string =>
-  capitalizeString(String((error as Error)?.message ?? error));
+  capitalizeString(error instanceof Error ? error.message : String(error));

--- a/src/utils/errorMessage/index.ts
+++ b/src/utils/errorMessage/index.ts
@@ -1,0 +1,12 @@
+import { capitalizeString } from '../convertString';
+
+/**
+ * Renders an api layer error as a readable sentence.
+ *
+ * The api layer puts a string in `error` when the backend answered with an
+ * error body, but the caught `Error` object when the request never completed.
+ * Formatting the value as a string directly therefore threw on exactly the
+ * failures it was meant to report, so the message never reached the user.
+ */
+export const capitalizeError = (error: unknown): string =>
+  capitalizeString(String((error as Error)?.message ?? error));

--- a/src/utils/precisionFunctions/__tests__/getPrecisionFromApi.test.ts
+++ b/src/utils/precisionFunctions/__tests__/getPrecisionFromApi.test.ts
@@ -1,6 +1,6 @@
 import api from '@/services/api';
 import { toast } from 'react-toastify';
-import { getPrecisionFromApi } from '../index';
+import { PRECISION_TOAST_ID, getPrecisionFromApi } from '../index';
 
 // The module reaches @/pages/transactions, whose import chain ends in an ESM
 // package Jest cannot transform. A factory mock never loads the real module.
@@ -49,7 +49,7 @@ describe('getPrecisionFromApi', () => {
 
     await expect(getPrecisionFromApi(['KLV'])).rejects.toThrow('Fetch timeout');
     expect(mockedToast).toHaveBeenCalledWith('Fetch timeout', {
-      toastId: 'Fetch timeout',
+      toastId: PRECISION_TOAST_ID,
     });
   });
 
@@ -66,7 +66,7 @@ describe('getPrecisionFromApi', () => {
       'Failed to fetch',
     );
     expect(mockedToast).toHaveBeenCalledWith('Failed to fetch', {
-      toastId: 'Fetch timeout',
+      toastId: PRECISION_TOAST_ID,
     });
   });
 

--- a/src/utils/precisionFunctions/__tests__/getPrecisionFromApi.test.ts
+++ b/src/utils/precisionFunctions/__tests__/getPrecisionFromApi.test.ts
@@ -1,0 +1,78 @@
+import api from '@/services/api';
+import { toast } from 'react-toastify';
+import { getPrecisionFromApi } from '../index';
+
+// The module reaches @/pages/transactions, whose import chain ends in an ESM
+// package Jest cannot transform. A factory mock never loads the real module.
+jest.mock('@/pages/transactions', () => ({
+  __esModule: true,
+  getAssetsAndCurrenciesList: jest.fn(() => []),
+  getTransactionPrecision: jest.fn(() => 8),
+}));
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: { post: jest.fn(), get: jest.fn() },
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
+
+const mockedPost = api.post as jest.Mock;
+const mockedToast = toast.error as jest.Mock;
+
+describe('getPrecisionFromApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the precisions the endpoint reports', async () => {
+    mockedPost.mockResolvedValue({
+      data: { precisions: { 'KID-36W3': 3 } },
+      error: '',
+    });
+
+    await expect(getPrecisionFromApi(['KID-36W3'])).resolves.toEqual({
+      precisions: { 'KID-36W3': 3 },
+    });
+    expect(mockedToast).not.toHaveBeenCalled();
+  });
+
+  it('reports a string error from the API and rejects with it', async () => {
+    mockedPost.mockResolvedValue({ data: null, error: 'fetch timeout' });
+
+    await expect(getPrecisionFromApi(['KLV'])).rejects.toThrow('Fetch timeout');
+    expect(mockedToast).toHaveBeenCalledWith('Fetch timeout', {
+      toastId: 'Fetch timeout',
+    });
+  });
+
+  it('still reports when the error is an Error, which a transport failure yields', async () => {
+    // The api layer puts the caught Error in `error` when the request never
+    // completed. Formatting it as a string threw a TypeError before the toast
+    // could fire, so this failure used to be entirely silent.
+    mockedPost.mockResolvedValue({
+      data: null,
+      error: new TypeError('failed to fetch'),
+    });
+
+    await expect(getPrecisionFromApi(['KLV'])).rejects.toThrow(
+      'Failed to fetch',
+    );
+    expect(mockedToast).toHaveBeenCalledWith('Failed to fetch', {
+      toastId: 'Fetch timeout',
+    });
+  });
+
+  it('rethrows when the request itself throws', async () => {
+    mockedPost.mockRejectedValue(new Error('boom'));
+
+    await expect(getPrecisionFromApi(['KLV'])).rejects.toThrow('boom');
+  });
+});

--- a/src/utils/precisionFunctions/index.ts
+++ b/src/utils/precisionFunctions/index.ts
@@ -8,6 +8,7 @@ import {
   Service,
 } from '@/types';
 import { toast } from 'react-toastify';
+import { capitalizeError } from '../errorMessage';
 import { KLV_PRECISION } from '../globalVariables';
 import {
   getAssetsAndCurrenciesList,
@@ -111,10 +112,9 @@ export const getPrecisionFromApi = async (
       tries: 10,
     });
     if (response.error) {
-      const messageError =
-        response.error.charAt(0).toUpperCase() + response.error.slice(1);
+      const messageError = capitalizeError(response.error);
       toast.error(messageError, { toastId: 'Fetch timeout' });
-      throw new Error(response.error);
+      throw new Error(messageError);
     }
 
     return response.data;

--- a/src/utils/precisionFunctions/index.ts
+++ b/src/utils/precisionFunctions/index.ts
@@ -15,6 +15,14 @@ import {
   getTransactionPrecision,
 } from '@/pages/transactions';
 
+/**
+ * Shared identity for every "precisions could not be resolved" toast, so a
+ * caller that adds its own message cannot stack a second one on top of this.
+ * Names the subject rather than one failure mode: the same lookup fails on a
+ * timeout, an error body and a transport error alike.
+ */
+export const PRECISION_TOAST_ID = 'assets-precisions';
+
 export function getPrecision<T extends string | string[]>(
   assetIds: T,
 ): T extends string ? Promise<number> : Promise<{ [assetId: string]: number }>;
@@ -113,7 +121,7 @@ export const getPrecisionFromApi = async (
     });
     if (response.error) {
       const messageError = capitalizeError(response.error);
-      toast.error(messageError, { toastId: 'Fetch timeout' });
+      toast.error(messageError, { toastId: PRECISION_TOAST_ID });
       throw new Error(messageError);
     }
 


### PR DESCRIPTION
Four defects on the block detail page and its export path. All four were found while mapping the transaction list; the first was confirmed on production mainnet.

## 1. Wrong amounts for every asset whose precision is not 6

`transaction/list` does not return each asset's decimal precision, so the frontend resolves it after fetching. Four of the five transaction lists did that; the block detail page did not. With `precision` unset, `filteredSections` fell back to its default parameter `precision = 6` and divided every amount by 10^6 regardless of the real precision.

156 of the 315 assets on chain have a precision other than 6, and the error goes both ways:

- KID-36W3 (precision 3) in block 32421006 showed `1.14` instead of `1.14 K`, a factor 1000 too low.
- EMT-NO9T (precision 8) in block 1770368 showed `199 M` instead of `1.99 M`, a factor 100 too high.
- The 94 assets with precision 0 were shown a million times too small, which renders as zero.

Pre-existing since at least the Next 13 upgrade (#261).

The request now resolves precision through `getParsedTransactionPrecision`, the same helper the asset, nonce and home lists already use. It keeps the fetched rows when that lookup fails, rather than reporting a block that has transactions as empty.

## 2. The filter bar on the block page did nothing (#681)

`requestBlock` built its route from the block number alone and ignored `router.query`, while the shared tab wrapper renders the full Coin / Status / Contract / Date filter bar. Changing a filter updated the URL, refetched, and returned the same unfiltered rows.

The request moved to `src/services/requests/block` and now forwards the filter params. They pass through an allowlist and are percent encoded, because `buildUrlQuery` interpolates values into the query string unescaped. Without that, `/block/42?status=%26blockNum%3D999` injects a second `blockNum`, and a value containing `#` truncates the query so the block number is dropped entirely and the page lists chain-wide transactions under a block header. Both were reproduced against the live API before fixing.

## 3. CSV export could carry a live formula (#682)

`sanitizeRow` escaped quotes, commas and newlines but not the characters a spreadsheet reads as the start of a formula, and chain-supplied text reaches those cells (proposal description, account name, marketplace name).

Cells starting with `=`, `+`, `-`, `@`, tab or CR are now prefixed with a quote, unless the value parses as a number so amounts stay numeric. Line breaks within a cell are collapsed first: a bare CR is a record separator to a CSV reader but was not covered by the quoting test, so a value carrying one split the row and placed its tail at the start of the next record, past the formula check.

The same commit replaces `window.alert` on an empty export with a toast, per the house rule against native browser dialogs.

## 4. A precision lookup failure was completely silent (#683)

`getPrecisionFromApi` formatted `response.error` with `charAt` before showing it. The api layer puts a string there when the backend answered with an error body, but the caught `Error` object when the request never completed, so the formatting threw a `TypeError` before the toast could fire. Measured with the endpoint blocked: console showed `TypeError: response.error.charAt is not a function`, and no toast appeared.

This is what made defect 1's failure mode hard to notice, and it affects every caller of `getPrecision`.

## Verification

Measured in a browser against mainnet data, with the precision cache cleared per case:

| Case | Before | After |
|---|---|---|
| Block 32421006, KID-36W3, precision 3 | `1.14` | `1.14 K` |
| Block 1770368, EMT-NO9T, precision 8 | `199 M` | `1.99 M` |
| Block 32549435, KLV claim, precision 6 | correct | unchanged |
| Block 32549448, no transactions | empty state | unchanged |
| `/block/32421006?status=Fail` | showed the Success tx | empty, as the API returns |
| `/block/32421006?status=Success` | showed the Success tx | unchanged |
| `assets/precisions` blocked | empty table, no toast | rows kept, toast shown |
| `?x=%26blockNum%3D999` | param forwarded | dropped by the allowlist |
| `?status=%26blockNum%3D999` | injected a second blockNum | encoded, block number intact |

Local: `tsc --noEmit` clean, `yarn build` clean, `yarn test` 388 passing across 31 suites. Patch coverage measured at 83.8% of changed lines against a Codecov target of 9.15%.

## Not covered

`src/pages/block/[block].tsx` still has no test; the two changed lines there are an import and a one-line delegation. Covering them needs roughly eight component mocks, because `react-syntax-highlighter` is ESM and outside the Jest `transformIgnorePatterns`, which is the same blocker that keeps page-level tests out of this repo generally. The two changed lines in `TransactionsFilters` are also uncovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction display by applying the correct asset precision.
  * Preserved transaction results when precision information is unavailable.
  * Added clearer, consistently formatted error messages for precision lookup failures.
  * Reset transaction results to the first page when transaction or date filters change.
  * Improved transaction filtering, pagination, and date-range behavior.
  * Protected CSV exports from spreadsheet formula injection, unwanted line breaks, and formatting issues.
  * Replaced browser alerts with clearer error notifications when CSV export data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #681
Closes #682
Closes #683

Related: #684 (the shared `buildUrlQuery` sink, fixed here only for the block page)
