### PR TITLE
fix(api): escape query values and route segments so a crafted link cannot inject or drop API parameters

### DIFF
--- a/src/components/SmartContracts/ContractInteraction/WriteResult.tsx
+++ b/src/components/SmartContracts/ContractInteraction/WriteResult.tsx
@@ -80,7 +80,7 @@ export function WriteResult({ hash, setHash, outputTypes }: WriteResultProps) {
       try {
         res = await api.get({
           service: Service.NODE,
-          route: `transaction/${hash}?withResults=true`,
+          route: `transaction/${encodeURIComponent(hash)}?withResults=true`,
         });
       } catch {
         scheduleNext();

--- a/src/components/SmartContracts/SmartContractsTransactions/index.tsx
+++ b/src/components/SmartContracts/SmartContractsTransactions/index.tsx
@@ -145,7 +145,10 @@ const SmartContractsTransactions: React.FC<SmartContractsTransactionsProps> = ({
     try {
       const localQuery = { ...router.query, page, limit };
       const res = await api.get({
-        route: `sc/invokes/${contractAddress}`,
+        // Escaped: the address comes from the URL and the query is appended
+        // after this segment, so a `?` or `&` smuggled into it would land
+        // ahead of page and limit, which the API resolves first-wins.
+        route: `sc/invokes/${encodeURIComponent(contractAddress)}`,
         query: localQuery,
       });
 

--- a/src/pages/account/[account]/collection/[collection].tsx
+++ b/src/pages/account/[account]/collection/[collection].tsx
@@ -132,7 +132,7 @@ const Collection: React.FC<PropsWithChildren<ICollectionPage>> = () => {
     try {
       const assetId = router.query.collection as string;
       const response = await api.get({
-        route: `assets/${assetId}`,
+        route: `assets/${encodeURIComponent(String(assetId))}`,
       });
       const uris = response.data.asset.uris;
       const metadataUri = uris?.find(

--- a/src/pages/account/[account]/collection/[collection].tsx
+++ b/src/pages/account/[account]/collection/[collection].tsx
@@ -98,7 +98,10 @@ const Collection: React.FC<PropsWithChildren<ICollectionPage>> = () => {
         const actualLimit = searchValue.trim() !== '' ? 1000 : limit;
 
         const response = await api.get({
-          route: `address/${address}/collection/${collection}?page=${page}&limit=${actualLimit}`,
+          route: `address/${encodeURIComponent(
+            String(address),
+          )}/collection/${encodeURIComponent(String(collection))}`,
+          query: { page, limit: actualLimit },
         });
         let filteredNfts = [];
         const collectionData = response?.data?.collection || [];

--- a/src/pages/accounts/index.tsx
+++ b/src/pages/accounts/index.tsx
@@ -54,7 +54,8 @@ const Accounts: React.FC<PropsWithChildren<IAccounts>> = () => {
   const { t } = useTranslation(['common', 'accounts', 'table']);
   const requestAccounts = async (page: number, limit: number) =>
     await api.get({
-      route: `address/list?page=${page}&limit=${limit}`,
+      route: 'address/list',
+      query: { page, limit },
     });
 
   const loadInitialData = async () => {

--- a/src/pages/api/__tests__/asset-info.test.ts
+++ b/src/pages/api/__tests__/asset-info.test.ts
@@ -1,0 +1,91 @@
+/**
+ * This route forwards `asset_id` into an upstream URL that carries the
+ * Kleverscan API key. `encodeURIComponent` leaves `.` and `..` alone and URL
+ * parsing then walks up a level, so `?asset_id=..` resolved to the collection
+ * endpoint rather than a single record, on an anonymous request.
+ *
+ * There was no spec for this file, so deleting or weakening the guard failed
+ * nothing.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+
+// Read at module load in the handler, so they are set before it is required.
+process.env.DEFAULT_KLEVERSCAN_API_URL = 'https://info.example.com';
+process.env.DEFAULT_KLEVERSCAN_API_KEY = 'test-key';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const handler = require('../asset-info').default as (
+  req: NextApiRequest,
+  res: NextApiResponse,
+) => Promise<void>;
+
+const makeReq = (query: Record<string, string>): NextApiRequest =>
+  ({ method: 'GET', query }) as unknown as NextApiRequest;
+
+const makeRes = () => {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return { res: { status } as unknown as NextApiResponse, json, status };
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: {} }),
+  });
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+const fetchedUrl = (): string =>
+  (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+describe('asset-info rejects a dot segment before calling upstream', () => {
+  it.each(['.', '..'])('rejects %s', async asset_id => {
+    const { res, status, json } = makeRes();
+
+    await handler(makeReq({ asset_id }), res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      error: 'Bad Request',
+      message: 'Invalid asset identifier',
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '   '])('still rejects an empty identifier (%s)', async id => {
+    const { res, status } = makeRes();
+
+    await handler(makeReq({ asset_id: id }), res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('asset-info builds the upstream URL from the identifier', () => {
+  it('passes an ordinary asset id straight through', async () => {
+    await handler(makeReq({ asset_id: 'KLV' }), makeRes().res);
+
+    expect(fetchedUrl()).toBe(
+      'https://info.example.com/api/v1/asset-info/asset/KLV',
+    );
+  });
+
+  it('keeps the nonce form inside one segment', async () => {
+    await handler(makeReq({ asset_id: 'KID-36W3/1' }), makeRes().res);
+
+    expect(fetchedUrl()).toContain('KID-36W3%2F1');
+    expect(new URL(fetchedUrl()).pathname).toBe(
+      '/api/v1/asset-info/asset/KID-36W3%2F1',
+    );
+  });
+
+  it('does not let a crafted id leave the asset path', async () => {
+    await handler(makeReq({ asset_id: '../../settings?' }), makeRes().res);
+
+    expect(new URL(fetchedUrl()).pathname).toContain('/asset-info/asset/');
+  });
+});

--- a/src/pages/api/asset-info.ts
+++ b/src/pages/api/asset-info.ts
@@ -17,7 +17,6 @@ export default async function handler(
   try {
     const { asset_id } = req.query;
 
-    // Validate asset_id
     // encodeURIComponent leaves `.` and `..` alone and URL parsing then walks
     // up a level, so `..` reaches the collection endpoint instead of a record.
     if (

--- a/src/pages/api/asset-info.ts
+++ b/src/pages/api/asset-info.ts
@@ -1,3 +1,4 @@
+import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_URL = process.env.DEFAULT_KLEVERSCAN_API_URL || '';
@@ -17,7 +18,13 @@ export default async function handler(
     const { asset_id } = req.query;
 
     // Validate asset_id
-    if (typeof asset_id !== 'string' || asset_id.trim() === '') {
+    // encodeURIComponent leaves `.` and `..` alone and URL parsing then walks
+    // up a level, so `..` reaches the collection endpoint instead of a record.
+    if (
+      typeof asset_id !== 'string' ||
+      asset_id.trim() === '' ||
+      isDotSegment(asset_id)
+    ) {
       res.status(400).json({
         error: 'Bad Request',
         message: 'Invalid asset identifier',

--- a/src/pages/api/contract-validator/[address]/info.ts
+++ b/src/pages/api/contract-validator/[address]/info.ts
@@ -27,10 +27,16 @@ export default async function handler(
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
-    const response = await fetch(`${validatorUrl}/contract/${address}/info`, {
-      headers: { 'X-API-KEY': API_KEY },
-      signal: controller.signal,
-    });
+    // Escaped because this request carries the API key: unescaped, a `..%2F`
+    // in the route param walks out of /contract/ and reaches any GET endpoint
+    // of the validator service, with the answer returned to the caller.
+    const response = await fetch(
+      `${validatorUrl}/contract/${encodeURIComponent(address)}/info`,
+      {
+        headers: { 'X-API-KEY': API_KEY },
+        signal: controller.signal,
+      },
+    );
     clearTimeout(timeoutId);
 
     const contentType = response.headers.get('content-type') || '';

--- a/src/pages/api/contract-validator/[address]/info.ts
+++ b/src/pages/api/contract-validator/[address]/info.ts
@@ -1,12 +1,7 @@
+import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
-
-// `.` and `..` survive encodeURIComponent and are then collapsed by URL
-// parsing, so an escaped segment alone does not keep the request inside
-// /contract/. Rejected here rather than escaped.
-const isDotSegment = (value: string): boolean =>
-  value === '.' || value === '..';
 
 export default async function handler(
   req: NextApiRequest,
@@ -20,7 +15,10 @@ export default async function handler(
   const { address } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address || isDotSegment(address)) {
+  // Pinned to the bech32 shape the six sibling handlers already require,
+  // rather than escaped only: this request carries the API key, so it should
+  // not depend on how the upstream normalises a percent-encoded path.
+  if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/info.ts
+++ b/src/pages/api/contract-validator/[address]/info.ts
@@ -2,6 +2,12 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
 
+// `.` and `..` survive encodeURIComponent and are then collapsed by URL
+// parsing, so an escaped segment alone does not keep the request inside
+// /contract/. Rejected here rather than escaped.
+const isDotSegment = (value: string): boolean =>
+  value === '.' || value === '..';
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -14,7 +20,7 @@ export default async function handler(
   const { address } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address) {
+  if (typeof address !== 'string' || !address || isDotSegment(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/info.ts
+++ b/src/pages/api/contract-validator/[address]/info.ts
@@ -1,4 +1,3 @@
-import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
@@ -31,9 +30,6 @@ export default async function handler(
   try {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
-    // Escaped because this request carries the API key: unescaped, a `..%2F`
-    // in the route param walks out of /contract/ and reaches any GET endpoint
-    // of the validator service, with the answer returned to the caller.
     const response = await fetch(
       `${validatorUrl}/contract/${encodeURIComponent(address)}/info`,
       {

--- a/src/pages/api/contract-validator/[address]/jobs/latest.ts
+++ b/src/pages/api/contract-validator/[address]/jobs/latest.ts
@@ -1,12 +1,7 @@
+import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
-
-// `.` and `..` survive encodeURIComponent and are then collapsed by URL
-// parsing, so an escaped segment alone does not keep the request inside
-// /contract/. Rejected here rather than escaped.
-const isDotSegment = (value: string): boolean =>
-  value === '.' || value === '..';
 
 export default async function handler(
   req: NextApiRequest,
@@ -20,7 +15,10 @@ export default async function handler(
   const { address } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address || isDotSegment(address)) {
+  // Pinned to the bech32 shape the six sibling handlers already require,
+  // rather than escaped only: this request carries the API key, so it should
+  // not depend on how the upstream normalises a percent-encoded path.
+  if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/jobs/latest.ts
+++ b/src/pages/api/contract-validator/[address]/jobs/latest.ts
@@ -2,6 +2,12 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
 
+// `.` and `..` survive encodeURIComponent and are then collapsed by URL
+// parsing, so an escaped segment alone does not keep the request inside
+// /contract/. Rejected here rather than escaped.
+const isDotSegment = (value: string): boolean =>
+  value === '.' || value === '..';
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -14,7 +20,7 @@ export default async function handler(
   const { address } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address) {
+  if (typeof address !== 'string' || !address || isDotSegment(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/jobs/latest.ts
+++ b/src/pages/api/contract-validator/[address]/jobs/latest.ts
@@ -28,7 +28,10 @@ export default async function handler(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
     const response = await fetch(
-      `${validatorUrl}/contract/${address}/jobs/latest`,
+      // Escaped because this request carries the API key: unescaped, a `..%2F`
+      // in the route param walks out of /contract/ and reaches any GET endpoint
+      // of the validator service, with the answer returned to the caller.
+      `${validatorUrl}/contract/${encodeURIComponent(address)}/jobs/latest`,
       {
         headers: { 'X-API-KEY': API_KEY },
         signal: controller.signal,

--- a/src/pages/api/contract-validator/[address]/jobs/latest.ts
+++ b/src/pages/api/contract-validator/[address]/jobs/latest.ts
@@ -1,4 +1,3 @@
-import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
@@ -32,9 +31,6 @@ export default async function handler(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
     const response = await fetch(
-      // Escaped because this request carries the API key: unescaped, a `..%2F`
-      // in the route param walks out of /contract/ and reaches any GET endpoint
-      // of the validator service, with the answer returned to the caller.
       `${validatorUrl}/contract/${encodeURIComponent(address)}/jobs/latest`,
       {
         headers: { 'X-API-KEY': API_KEY },

--- a/src/pages/api/contract-validator/[address]/validate.ts
+++ b/src/pages/api/contract-validator/[address]/validate.ts
@@ -32,7 +32,9 @@ export default async function handler(
   const { address } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address) {
+  // Same shape check as check.ts. This request carries the API key, so the
+  // segment is pinned to a bech32 address rather than merely escaped.
+  if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }
@@ -94,7 +96,7 @@ export default async function handler(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 30_000);
     const response = await fetch(
-      `${validatorUrl}/contract/${address}/validate`,
+      `${validatorUrl}/contract/${encodeURIComponent(address)}/validate`,
       {
         method: 'POST',
         headers: {

--- a/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
@@ -2,6 +2,12 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
 
+// `.` and `..` survive encodeURIComponent and are then collapsed by URL
+// parsing, so an escaped segment alone does not keep the request inside
+// /contract/. Rejected here rather than escaped.
+const isDotSegment = (value: string): boolean =>
+  value === '.' || value === '..';
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -14,12 +20,12 @@ export default async function handler(
   const { address, version } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address) {
+  if (typeof address !== 'string' || !address || isDotSegment(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }
 
-  if (typeof version !== 'string' || !version) {
+  if (typeof version !== 'string' || !version || isDotSegment(version)) {
     res.status(400).json({ message: 'Invalid version' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
@@ -1,4 +1,3 @@
-import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
@@ -40,9 +39,6 @@ export default async function handler(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
     const response = await fetch(
-      // Escaped because this request carries the API key: unescaped, a `..%2F`
-      // in either route param walks out of /contract/ and reaches any GET
-      // endpoint of the validator service, answer returned to the caller.
       `${validatorUrl}/contract/${encodeURIComponent(
         address,
       )}/versions/${encodeURIComponent(version)}/source`,

--- a/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
@@ -33,7 +33,12 @@ export default async function handler(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
     const response = await fetch(
-      `${validatorUrl}/contract/${address}/versions/${version}/source`,
+      // Escaped because this request carries the API key: unescaped, a `..%2F`
+      // in either route param walks out of /contract/ and reaches any GET
+      // endpoint of the validator service, answer returned to the caller.
+      `${validatorUrl}/contract/${encodeURIComponent(
+        address,
+      )}/versions/${encodeURIComponent(version)}/source`,
       {
         headers: { 'X-API-KEY': API_KEY },
         signal: controller.signal,

--- a/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/source.ts
@@ -1,12 +1,7 @@
+import { isDotSegment } from '@/pages/api/contract-validator/_proxy';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 const API_KEY = process.env.DEFAULT_CONTRACT_VALIDATOR_KEY || '';
-
-// `.` and `..` survive encodeURIComponent and are then collapsed by URL
-// parsing, so an escaped segment alone does not keep the request inside
-// /contract/. Rejected here rather than escaped.
-const isDotSegment = (value: string): boolean =>
-  value === '.' || value === '..';
 
 export default async function handler(
   req: NextApiRequest,
@@ -20,12 +15,18 @@ export default async function handler(
   const { address, version } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address || isDotSegment(address)) {
+  // Pinned to the bech32 shape the six sibling handlers already require,
+  // rather than escaped only: this request carries the API key, so it should
+  // not depend on how the upstream normalises a percent-encoded path.
+  if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }
 
-  if (typeof version !== 'string' || !version || isDotSegment(version)) {
+  // The only caller passes a number (fetchSourceFiles), so the segment is
+  // pinned to digits. Note the sibling audits handler expects a 64-char hash
+  // instead, so this shape is per endpoint rather than shared.
+  if (typeof version !== 'string' || !/^\d+$/.test(version)) {
     res.status(400).json({ message: 'Invalid version' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/versions/[version]/visibility.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/visibility.ts
@@ -22,21 +22,15 @@ export default async function handler(
   const { address, version } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  // Same shape checks as the sibling handlers. This request carries the API
-  // key, so both segments are pinned rather than merely escaped.
+  // Address is pinned to bech32, same as the other contract-validator handlers.
   if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }
-  // Not pinned to a format: the sibling audits handler expects a 64-char hex
-  // hash, but this endpoint's own spec exercises '1', so the shape is not
-  // established. Escaped below, with dot segments rejected here.
-  if (
-    typeof version !== 'string' ||
-    !version ||
-    version === '.' ||
-    version === '..'
-  ) {
+  // Same digit pin as source.ts: the only caller is changeCodeVisibility, which
+  // takes version: number. The audits handler wants a 64-char hash instead,
+  // which is a different endpoint rather than a different opinion.
+  if (typeof version !== 'string' || !/^\d+$/.test(version)) {
     res.status(400).json({ message: 'Invalid version' });
     return;
   }

--- a/src/pages/api/contract-validator/[address]/versions/[version]/visibility.ts
+++ b/src/pages/api/contract-validator/[address]/versions/[version]/visibility.ts
@@ -22,11 +22,21 @@ export default async function handler(
   const { address, version } = req.query;
   const validatorUrl = process.env.DEFAULT_CONTRACT_VALIDATOR_URL;
 
-  if (typeof address !== 'string' || !address) {
+  // Same shape checks as the sibling handlers. This request carries the API
+  // key, so both segments are pinned rather than merely escaped.
+  if (typeof address !== 'string' || !/^klv1[0-9a-z]{58}$/.test(address)) {
     res.status(400).json({ message: 'Invalid contract address' });
     return;
   }
-  if (typeof version !== 'string' || !version) {
+  // Not pinned to a format: the sibling audits handler expects a 64-char hex
+  // hash, but this endpoint's own spec exercises '1', so the shape is not
+  // established. Escaped below, with dot segments rejected here.
+  if (
+    typeof version !== 'string' ||
+    !version ||
+    version === '.' ||
+    version === '..'
+  ) {
     res.status(400).json({ message: 'Invalid version' });
     return;
   }
@@ -71,7 +81,9 @@ export default async function handler(
 
   await proxyToValidator(
     res,
-    `${validatorUrl}/contract/${address}/versions/${version}/visibility`,
+    `${validatorUrl}/contract/${encodeURIComponent(
+      address,
+    )}/versions/${encodeURIComponent(version)}/visibility`,
     {
       method: 'POST',
       headers: {

--- a/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
+++ b/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
@@ -1,19 +1,21 @@
 /**
- * These three handlers forward a route param into an upstream URL that carries
- * the validator API key. Interpolated raw, a `..%2F` in that param walked out
- * of /contract/ and reached any GET endpoint of that service, with the body
+ * These handlers forward a route param into an upstream URL that carries the
+ * validator API key. Interpolated raw, a `..%2F` in that param walked out of
+ * /contract/ and reached any GET endpoint of that service, with the body
  * returned to an anonymous caller.
  *
- * Five sibling handlers already escaped; these three validated only that the
- * param was a non-empty string, so the property is pinned here rather than left
- * to the next person noticing the inconsistency.
+ * The param is now pinned to a shape rather than merely escaped, because
+ * escaping leaves the request depending on how the upstream normalises a
+ * percent-encoded path, and that behaviour is not established here. `validate`
+ * and `visibility` were found raw by the same audit and pin `address` the same
+ * way; `check` already did.
  */
 import { NextApiRequest, NextApiResponse } from 'next';
 import infoHandler from '../[address]/info';
 import latestJobHandler from '../[address]/jobs/latest';
 import sourceHandler from '../[address]/versions/[version]/source';
 
-const TRAVERSAL = '../../settings?';
+const VALID_ADDRESS = `klv1${'a'.repeat(58)}`;
 
 const makeReq = (query: Record<string, string>): NextApiRequest =>
   ({ method: 'GET', query }) as unknown as NextApiRequest;
@@ -49,48 +51,28 @@ afterEach(() => {
 const fetchedUrl = (): string =>
   (global.fetch as jest.Mock).mock.calls[0][0] as string;
 
-describe('contract-validator proxies escape their route params', () => {
-  it('info keeps a traversal payload inside its segment', async () => {
-    await infoHandler(makeReq({ address: TRAVERSAL }), makeRes().res);
+const HOSTILE_ADDRESSES = [
+  '../../settings?',
+  '..%2F..%2Fsettings',
+  '..',
+  '.',
+  '../settings#',
+  `klv1${'a'.repeat(57)}`,
+  `${VALID_ADDRESS}/extra`,
+];
 
-    expect(fetchedUrl()).toBe(
-      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/info',
-    );
-    expect(new URL(fetchedUrl()).pathname).toContain('/contract/');
-  });
-
-  it('latest job keeps a traversal payload inside its segment', async () => {
-    await latestJobHandler(makeReq({ address: TRAVERSAL }), makeRes().res);
-
-    expect(fetchedUrl()).toBe(
-      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/jobs/latest',
-    );
-  });
-
-  it('source escapes both the address and the version', async () => {
-    await sourceHandler(
-      makeReq({ address: TRAVERSAL, version: '../../secrets' }),
-      makeRes().res,
-    );
-
-    expect(fetchedUrl()).toBe(
-      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/versions/..%2F..%2Fsecrets/source',
-    );
-  });
-
-  it.each([
-    ['.', 'info', infoHandler],
-    ['..', 'info', infoHandler],
-    ['.', 'jobs/latest', latestJobHandler],
-    ['..', 'jobs/latest', latestJobHandler],
-  ])(
-    'rejects a bare %s on %s instead of escaping it',
+describe('the proxies reject an address that is not an address', () => {
+  it.each(
+    HOSTILE_ADDRESSES.flatMap(address => [
+      [address, 'info', infoHandler] as const,
+      [address, 'jobs/latest', latestJobHandler] as const,
+    ]),
+  )(
+    'rejects %s on %s without calling upstream',
     async (address, _route, handler) => {
-      // `.` and `..` survive encodeURIComponent and are then collapsed by URL
-      // parsing, so escaping alone does not keep the request inside /contract/.
       const { res, status, json } = makeRes();
 
-      await handler(makeReq({ address: address as string }), res);
+      await handler(makeReq({ address }), res);
 
       expect(status).toHaveBeenCalledWith(400);
       expect(json).toHaveBeenCalledWith({
@@ -100,26 +82,59 @@ describe('contract-validator proxies escape their route params', () => {
     },
   );
 
-  it('rejects a dot-only version', async () => {
-    const { res, status, json } = makeRes();
+  it.each(HOSTILE_ADDRESSES)(
+    'rejects %s on versions/source without calling upstream',
+    async address => {
+      const { res, status } = makeRes();
 
+      await sourceHandler(makeReq({ address, version: '1' }), res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('the source handler pins its version too', () => {
+  it.each(['..', '.', '../../secrets', 'abc', '1a', ''])(
+    'rejects version %s',
+    async version => {
+      const { res, status } = makeRes();
+
+      await sourceHandler(makeReq({ address: VALID_ADDRESS, version }), res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts a numeric version, which is what the client sends', async () => {
     await sourceHandler(
-      makeReq({ address: `klv1${'a'.repeat(58)}`, version: '..' }),
-      res,
+      makeReq({ address: VALID_ADDRESS, version: '12' }),
+      makeRes().res,
     );
 
-    expect(status).toHaveBeenCalledWith(400);
-    expect(json).toHaveBeenCalledWith({ message: 'Invalid version' });
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(fetchedUrl()).toBe(
+      `https://validator.example.com/contract/${VALID_ADDRESS}/versions/12/source`,
+    );
   });
+});
 
-  it('leaves an ordinary address untouched', async () => {
-    const address = `klv1${'a'.repeat(58)}`;
-
-    await infoHandler(makeReq({ address }), makeRes().res);
+describe('an ordinary address still reaches upstream unchanged', () => {
+  it('builds the info URL from the address as given', async () => {
+    await infoHandler(makeReq({ address: VALID_ADDRESS }), makeRes().res);
 
     expect(fetchedUrl()).toBe(
-      `https://validator.example.com/contract/${address}/info`,
+      `https://validator.example.com/contract/${VALID_ADDRESS}/info`,
+    );
+    expect(new URL(fetchedUrl()).pathname).toContain('/contract/');
+  });
+
+  it('builds the latest-job URL from the address as given', async () => {
+    await latestJobHandler(makeReq({ address: VALID_ADDRESS }), makeRes().res);
+
+    expect(fetchedUrl()).toBe(
+      `https://validator.example.com/contract/${VALID_ADDRESS}/jobs/latest`,
     );
   });
 });

--- a/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
+++ b/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
@@ -1,0 +1,90 @@
+/**
+ * These three handlers forward a route param into an upstream URL that carries
+ * the validator API key. Interpolated raw, a `..%2F` in that param walked out
+ * of /contract/ and reached any GET endpoint of that service, with the body
+ * returned to an anonymous caller.
+ *
+ * Five sibling handlers already escaped; these three validated only that the
+ * param was a non-empty string, so the property is pinned here rather than left
+ * to the next person noticing the inconsistency.
+ */
+import { NextApiRequest, NextApiResponse } from 'next';
+import infoHandler from '../[address]/info';
+import latestJobHandler from '../[address]/jobs/latest';
+import sourceHandler from '../[address]/versions/[version]/source';
+
+const TRAVERSAL = '../../settings?';
+
+const makeReq = (query: Record<string, string>): NextApiRequest =>
+  ({ method: 'GET', query }) as unknown as NextApiRequest;
+
+const makeRes = () => {
+  const json = jest.fn();
+  const send = jest.fn();
+  const status = jest.fn(() => ({ json, send }));
+  return { res: { status } as unknown as NextApiResponse, json, status };
+};
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = {
+    ...originalEnv,
+    DEFAULT_CONTRACT_VALIDATOR_URL: 'https://validator.example.com',
+    DEFAULT_CONTRACT_VALIDATOR_KEY: 'test-key',
+  };
+  global.fetch = jest.fn().mockResolvedValue({
+    status: 200,
+    headers: { get: () => 'application/json' },
+    json: async () => ({}),
+    text: async () => '',
+  });
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  jest.restoreAllMocks();
+});
+
+const fetchedUrl = (): string =>
+  (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+describe('contract-validator proxies escape their route params', () => {
+  it('info keeps a traversal payload inside its segment', async () => {
+    await infoHandler(makeReq({ address: TRAVERSAL }), makeRes().res);
+
+    expect(fetchedUrl()).toBe(
+      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/info',
+    );
+    expect(new URL(fetchedUrl()).pathname).toContain('/contract/');
+  });
+
+  it('latest job keeps a traversal payload inside its segment', async () => {
+    await latestJobHandler(makeReq({ address: TRAVERSAL }), makeRes().res);
+
+    expect(fetchedUrl()).toBe(
+      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/jobs/latest',
+    );
+  });
+
+  it('source escapes both the address and the version', async () => {
+    await sourceHandler(
+      makeReq({ address: TRAVERSAL, version: '../../secrets' }),
+      makeRes().res,
+    );
+
+    expect(fetchedUrl()).toBe(
+      'https://validator.example.com/contract/..%2F..%2Fsettings%3F/versions/..%2F..%2Fsecrets/source',
+    );
+  });
+
+  it('leaves an ordinary address untouched', async () => {
+    const address = `klv1${'a'.repeat(58)}`;
+
+    await infoHandler(makeReq({ address }), makeRes().res);
+
+    expect(fetchedUrl()).toBe(
+      `https://validator.example.com/contract/${address}/info`,
+    );
+  });
+});

--- a/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
+++ b/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
@@ -78,6 +78,41 @@ describe('contract-validator proxies escape their route params', () => {
     );
   });
 
+  it.each([
+    ['.', 'info', infoHandler],
+    ['..', 'info', infoHandler],
+    ['.', 'jobs/latest', latestJobHandler],
+    ['..', 'jobs/latest', latestJobHandler],
+  ])(
+    'rejects a bare %s on %s instead of escaping it',
+    async (address, _route, handler) => {
+      // `.` and `..` survive encodeURIComponent and are then collapsed by URL
+      // parsing, so escaping alone does not keep the request inside /contract/.
+      const { res, status, json } = makeRes();
+
+      await handler(makeReq({ address: address as string }), res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({
+        message: 'Invalid contract address',
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a dot-only version', async () => {
+    const { res, status, json } = makeRes();
+
+    await sourceHandler(
+      makeReq({ address: `klv1${'a'.repeat(58)}`, version: '..' }),
+      res,
+    );
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ message: 'Invalid version' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('leaves an ordinary address untouched', async () => {
     const address = `klv1${'a'.repeat(58)}`;
 

--- a/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
+++ b/src/pages/api/contract-validator/__tests__/pathEscaping.test.ts
@@ -13,7 +13,9 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import infoHandler from '../[address]/info';
 import latestJobHandler from '../[address]/jobs/latest';
+import validateHandler from '../[address]/validate';
 import sourceHandler from '../[address]/versions/[version]/source';
+import visibilityHandler from '../[address]/versions/[version]/visibility';
 
 const VALID_ADDRESS = `klv1${'a'.repeat(58)}`;
 
@@ -136,5 +138,78 @@ describe('an ordinary address still reaches upstream unchanged', () => {
     expect(fetchedUrl()).toBe(
       `https://validator.example.com/contract/${VALID_ADDRESS}/jobs/latest`,
     );
+  });
+});
+
+/**
+ * The two POST handlers reject before any signature or body work, so these
+ * drive them with no wallet headers at all: a 400 here proves the address was
+ * refused on its shape rather than on a missing signature, which would be a
+ * 401. Without these, reverting either pin leaves the suite green.
+ */
+const makePostReq = (query: Record<string, string>): NextApiRequest =>
+  ({
+    method: 'POST',
+    query,
+    headers: {},
+    body: {},
+  }) as unknown as NextApiRequest;
+
+describe('the POST handlers pin their params before doing any wallet work', () => {
+  it.each(HOSTILE_ADDRESSES)(
+    'validate rejects %s without calling upstream',
+    async address => {
+      const { res, status, json } = makeRes();
+
+      await validateHandler(makePostReq({ address }), res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({
+        message: 'Invalid contract address',
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(HOSTILE_ADDRESSES)(
+    'visibility rejects %s without calling upstream',
+    async address => {
+      const { res, status } = makeRes();
+
+      await visibilityHandler(makePostReq({ address, version: '1' }), res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['.', '..', '../settings?', 'abc', '1a', ''])(
+    'visibility rejects version %s without calling upstream',
+    async version => {
+      const { res, status, json } = makeRes();
+
+      await visibilityHandler(
+        makePostReq({ address: VALID_ADDRESS, version }),
+        res,
+      );
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ message: 'Invalid version' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it('lets a well-formed pair through to the wallet check, not to upstream', async () => {
+    // A 401 rather than a 400 is the point: the shape passed, the signature
+    // did not, so the pin is not swallowing valid input.
+    const { res, status } = makeRes();
+
+    await visibilityHandler(
+      makePostReq({ address: VALID_ADDRESS, version: '12' }),
+      res,
+    );
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/api/contract-validator/_proxy.ts
+++ b/src/pages/api/contract-validator/_proxy.ts
@@ -35,3 +35,11 @@ export async function proxyToValidator(
     clearTimeout(timeoutId);
   }
 }
+
+/**
+ * `.` and `..` survive encodeURIComponent and are then collapsed by URL
+ * parsing, so escaping a segment does not on its own keep the request inside
+ * /contract/. Handlers that forward a route param reject these outright.
+ */
+export const isDotSegment = (value: string): boolean =>
+  value === '.' || value === '..';

--- a/src/pages/api/contract-validator/_proxy.ts
+++ b/src/pages/api/contract-validator/_proxy.ts
@@ -37,9 +37,10 @@ export async function proxyToValidator(
 }
 
 /**
- * `.` and `..` survive encodeURIComponent and are then collapsed by URL
- * parsing, so escaping a segment does not on its own keep the request inside
- * /contract/. Handlers that forward a route param reject these outright.
+ * `.` and `..` survive encodeURIComponent, and URL parsing then collapses them.
+ * This is the fallback for a param with no established format, currently
+ * `asset-info`'s `asset_id`. The validator handlers do not need it: a bech32
+ * address or a digit version cannot be `.` or `..`.
  */
 export const isDotSegment = (value: string): boolean =>
   value === '.' || value === '..';

--- a/src/pages/proposal/[number].tsx
+++ b/src/pages/proposal/[number].tsx
@@ -365,15 +365,22 @@ const ProposalDetails: React.FC<PropsWithChildren> = () => {
 
   const requestVoters = useCallback(
     async (page: number, limit: number): Promise<IParsedVoterResponse> => {
+      // Escaped: the proposal number comes from the URL, and `getHost` appends
+      // the query after the route, so a `?voteType=1&` smuggled into the
+      // segment lands ahead of the one below. The API resolves a repeated
+      // parameter first-wins, which rendered the No voters under the Yes tab.
+      const proposalRoute = `proposals/${encodeURIComponent(
+        String(router.query.number),
+      )}`;
       let response;
       if (selectedFilter === `${t('common:Statements.Yes')}`) {
         response = await api.get({
-          route: `proposals/${router.query.number}`,
+          route: proposalRoute,
           query: { pageVoters: page, limitVoters: limit, voteType: 0 },
         });
       } else {
         response = await api.get({
-          route: `proposals/${router.query.number}`,
+          route: proposalRoute,
           query: { pageVoters: page, limitVoters: limit, voteType: 1 },
         });
       }

--- a/src/pages/transaction/[hash].tsx
+++ b/src/pages/transaction/[hash].tsx
@@ -223,7 +223,7 @@ export const getServerSideProps: GetServerSideProps<ITransactionPage> = async ({
   }
 
   const transaction: ITransactionResponse = await api.get({
-    route: `transaction/${hash}`,
+    route: `transaction/${encodeURIComponent(String(hash))}`,
   });
 
   const tx = transaction?.data?.transaction;

--- a/src/pages/transaction/[hash].tsx
+++ b/src/pages/transaction/[hash].tsx
@@ -234,7 +234,7 @@ export const getServerSideProps: GetServerSideProps<ITransactionPage> = async ({
   if (tx?.contract.some(contract => contract.type == 63)) {
     const nodeTransaction: any = await api.get({
       service: Service.NODE,
-      route: `transaction/${hash}?withResults=true`,
+      route: `transaction/${encodeURIComponent(String(hash))}?withResults=true`,
     });
 
     const logs = nodeTransaction?.data?.transaction?.logs;

--- a/src/pages/validator/[hash].tsx
+++ b/src/pages/validator/[hash].tsx
@@ -95,7 +95,7 @@ const Validator: React.FC<PropsWithChildren<IValidatorPage>> = () => {
     if (router.isReady) {
       const requestValidator = async () => {
         const res = await api.get({
-          route: `validator/${router.query.hash}`,
+          route: `validator/${encodeURIComponent(String(router.query.hash))}`,
         });
         if (!res.error || res.error === '') {
           setValidator(res.data.validator);

--- a/src/pages/validator/[hash].tsx
+++ b/src/pages/validator/[hash].tsx
@@ -218,8 +218,14 @@ const Validator: React.FC<PropsWithChildren<IValidatorPage>> = () => {
 
   const requestValidatorDelegations = async (page: number, limit: number) => {
     if (router?.query?.hash) {
+      // The hash is a route segment, so it is escaped here; paging goes through
+      // `query`, which escapes on its own. Interpolating both raw let a `?` or
+      // `&` in the URL segment rewrite the request's own parameters.
       const response: IDelegateResponse = await api.get({
-        route: `validator/delegated/${router.query.hash}?page=${page}&limit=${limit}`,
+        route: `validator/delegated/${encodeURIComponent(
+          String(router.query.hash),
+        )}`,
+        query: { page, limit },
       });
 
       const delegators: IBucket[] = [];

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,0 +1,86 @@
+import { buildUrlQuery, getHost } from '@/services/api';
+import { Service } from '@/types/index';
+
+const queryOf = (host: string): string => host.split('?')[1] ?? '';
+
+describe('buildUrlQuery', () => {
+  it('leaves a value that needs no escaping alone', () => {
+    expect(buildUrlQuery({ asset: 'KLV', page: 1, limit: 10 })).toBe(
+      'asset=KLV&page=1&limit=10',
+    );
+  });
+
+  it('escapes a value that would otherwise add a parameter of its own', () => {
+    // Next hands `router.query` over already decoded, so this is what a link
+    // carrying ?x=%26asset%3DKFI reaches the sink as. Interpolated raw it put a
+    // second `asset` ahead of the real one, and the proxy resolves a repeated
+    // parameter first-wins.
+    const query = buildUrlQuery({ x: '&asset=KFI', asset: 'KLV' });
+
+    expect(query).toBe('x=%26asset%3DKFI&asset=KLV');
+    expect(query).not.toContain('&asset=KFI');
+  });
+
+  it('escapes a value that would otherwise truncate the query', () => {
+    // A `#` made the browser treat the rest of the URL as a fragment and send
+    // none of it, so every parameter written after this one silently vanished.
+    const query = buildUrlQuery({ x: '1#', asset: 'KLV', page: 1 });
+
+    expect(query).toBe('x=1%23&asset=KLV&page=1');
+    expect(query.split('#')).toHaveLength(1);
+  });
+
+  it('keeps a label the app itself writes to the URL in one piece', () => {
+    // The asset page writes its card name to `router.query` and spreads it into
+    // the request, so this fired without anyone crafting a link.
+    expect(buildUrlQuery({ card: 'Staking & Royalties' })).toBe(
+      'card=Staking%20%26%20Royalties',
+    );
+  });
+
+  it('escapes the key as well as the value', () => {
+    expect(buildUrlQuery({ 'a&b': 'c' })).toBe('a%26b=c');
+  });
+
+  it('escapes the slash in the nonce form of an asset id', () => {
+    // The NFT page asks for `KID-36W3/1`. The proxy reads %2F exactly as it
+    // reads a bare slash, so encoding it costs nothing.
+    expect(buildUrlQuery({ asset: 'KID-36W3/1' })).toBe('asset=KID-36W3%2F1');
+  });
+
+  it('still joins an array on a comma, as the template literal did', () => {
+    // A repeated URL param arrives as an array. The comma now travels as %2C,
+    // which the proxy accepts identically.
+    expect(buildUrlQuery({ asset: ['KLV', 'KFI'] })).toBe('asset=KLV%2CKFI');
+  });
+
+  it('coerces booleans, numbers and undefined the way it always did', () => {
+    expect(buildUrlQuery({ hidden: false, page: 2, missing: undefined })).toBe(
+      'hidden=false&page=2&missing=undefined',
+    );
+  });
+
+  it('produces an empty string for an empty query', () => {
+    expect(buildUrlQuery({})).toBe('');
+  });
+});
+
+describe('getHost', () => {
+  it('appends the escaped query to the route', () => {
+    const host = getHost(
+      'transaction/list',
+      { x: '&asset=KFI', asset: 'KLV', page: 1 },
+      Service.PROXY,
+      'v1.0',
+    );
+
+    expect(host).toContain('/transaction/list?');
+    expect(queryOf(host)).toBe('x=%26asset%3DKFI&asset=KLV&page=1');
+  });
+
+  it('omits the question mark when there is no query', () => {
+    expect(
+      getHost('assets/KLV', undefined, Service.PROXY, 'v1.0'),
+    ).not.toContain('?');
+  });
+});

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -79,8 +79,11 @@ describe('getHost', () => {
   });
 
   it('omits the question mark when there is no query', () => {
-    expect(
-      getHost('assets/KLV', undefined, Service.PROXY, 'v1.0'),
-    ).not.toContain('?');
+    // Asserted from the route onwards rather than over the whole string: the
+    // host comes from the environment, so a configured host carrying its own
+    // query would fail this for a reason that has nothing to do with the sink.
+    const host = getHost('assets/KLV', undefined, Service.PROXY, 'v1.0');
+
+    expect(host.slice(host.indexOf('/assets/KLV'))).toBe('/assets/KLV');
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -63,9 +63,11 @@ const pagination = {
  * interpolating it raw let it act as query syntax rather than as data: an `&`
  * added a parameter of its own and a `#` cut the request short at a fragment,
  * dropping every parameter written after it. The API resolves a repeated
- * parameter first-wins, and Next lists a search param ahead of a route param
- * of the same name in `router.query`, so the injected copy was emitted first
- * and decided the response.
+ * parameter first-wins, so a value carrying `&asset=KFI` decided the response
+ * rather than the real `asset` written later in the same query. The injection
+ * rides in the value of some other key, not in a second key of the same name:
+ * a route param and a search param that share a name are merged by Next long
+ * before this, and the route one wins.
  *
  * It is not only reachable through a crafted link. Labels the app writes to the
  * URL itself carry the same characters, `Staking & Royalties` among them.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -56,9 +56,29 @@ const pagination = {
   totalRecords: 0,
 };
 
-const buildUrlQuery = (query: IQuery): string =>
-  Object.keys(query)
-    .map(key => `${key}=${query[key]}`)
+/**
+ * Percent-encodes both sides of every pair.
+ *
+ * Next has already decoded `router.query` by the time a value reaches here, so
+ * interpolating it raw let it act as query syntax rather than as data: an `&`
+ * added a parameter of its own and a `#` cut the request short at a fragment,
+ * dropping every parameter written after it. The proxy resolves a repeated
+ * parameter first-wins, and search params sort ahead of route params, so an
+ * injected copy decided the response.
+ *
+ * It is not only reachable through a crafted link. Labels the app writes to the
+ * URL itself carry the same characters, `Staking & Royalties` among them.
+ *
+ * `String(value)` keeps exactly the coercion the template literal performed,
+ * including an array joining on a comma, so only characters that were already
+ * being sent as syntax change on the wire.
+ */
+export const buildUrlQuery = (query: IQuery): string =>
+  Object.entries(query)
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`,
+    )
     .join('&');
 
 export const getHost = (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,9 +62,10 @@ const pagination = {
  * Next has already decoded `router.query` by the time a value reaches here, so
  * interpolating it raw let it act as query syntax rather than as data: an `&`
  * added a parameter of its own and a `#` cut the request short at a fragment,
- * dropping every parameter written after it. The proxy resolves a repeated
- * parameter first-wins, and search params sort ahead of route params, so an
- * injected copy decided the response.
+ * dropping every parameter written after it. The API resolves a repeated
+ * parameter first-wins, and Next lists a search param ahead of a route param
+ * of the same name in `router.query`, so the injected copy was emitted first
+ * and decided the response.
  *
  * It is not only reachable through a crafted link. Labels the app writes to the
  * URL itself carry the same characters, `Staking & Royalties` among them.

--- a/src/services/apiCalls.ts
+++ b/src/services/apiCalls.ts
@@ -7,14 +7,17 @@ export const blockCall = async (
   limit = 10,
 ): Promise<IBlockResponse> => {
   const res = await api.get({
-    route: `block/list?page=${page}&limit=${limit}`,
+    route: 'block/list',
+    query: { page, limit },
   });
 
   if (!res.error || res.error === '') {
     return res;
   }
 
-  throw new Error(typeof res.error === 'string' ? res.error : 'Failed to fetch blocks');
+  throw new Error(
+    typeof res.error === 'string' ? res.error : 'Failed to fetch blocks',
+  );
 };
 
 export const yesterdayStatisticsCall = async (): Promise<IBlockStats> => {
@@ -26,7 +29,11 @@ export const yesterdayStatisticsCall = async (): Promise<IBlockStats> => {
     return res.data.block_stats_by_day[0];
   }
 
-  throw new Error(typeof res.error === 'string' ? res.error : 'Failed to fetch yesterday statistics');
+  throw new Error(
+    typeof res.error === 'string'
+      ? res.error
+      : 'Failed to fetch yesterday statistics',
+  );
 };
 
 export const totalStatisticsCall = async (): Promise<IBlockStats> => {
@@ -38,7 +45,11 @@ export const totalStatisticsCall = async (): Promise<IBlockStats> => {
     return res.data.block_stats_total;
   }
 
-  throw new Error(typeof res.error === 'string' ? res.error : 'Failed to fetch total statistics');
+  throw new Error(
+    typeof res.error === 'string'
+      ? res.error
+      : 'Failed to fetch total statistics',
+  );
 };
 
 export const defaultPagination: IPagination = {

--- a/src/services/requests/__tests__/requestShapes.test.ts
+++ b/src/services/requests/__tests__/requestShapes.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Pins the request shape of every call site that moved from a hand-built route
+ * string to a `route` plus `query` pair, and of every route segment that is now
+ * escaped.
+ *
+ * Without this the conversions are unguarded: none of these modules had a test
+ * reading the outgoing request, so a renamed key, a dropped parameter or a
+ * segment that quietly stopped being escaped would ship green.
+ */
+const mockGet = jest.fn();
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => mockGet(...args) },
+}));
+
+// Both pull in an ESM chain Jest cannot transform in this repo, and neither is
+// under test here: only the request that goes out is.
+jest.mock('@/utils/parseValues', () => ({
+  __esModule: true,
+  parseAllProposals: (x: unknown) => x,
+  parseProposal: (x: unknown) => x,
+  parseHardCodedInfo: (x: unknown) => x,
+  parseITOs: (x: unknown) => x,
+}));
+jest.mock('@/utils/precisionFunctions', () => ({
+  __esModule: true,
+  getPrecision: jest.fn(),
+}));
+
+import { blockCall } from '@/services/apiCalls';
+import {
+  KFIAllowancePromise,
+  KLVAllowancePromise,
+  assetsRequest,
+} from '@/services/requests/account';
+import { requestAssets } from '@/services/requests/assets';
+import { collectionListCall } from '@/services/requests/collection';
+import { requestAssetsList } from '@/services/requests/ito';
+import { getMarketplace } from '@/services/requests/marketplace';
+import { getSomeAssetsPool } from '@/services/requests/pool';
+import {
+  dataProposalCall,
+  requestProposals,
+} from '@/services/requests/proposals';
+import { NextRouter } from 'next/router';
+
+const routerWith = (query: Record<string, unknown>): NextRouter =>
+  ({ query, isReady: true }) as unknown as NextRouter;
+
+const callArg = (call = 0) => mockGet.mock.calls[call][0];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue({ error: '', code: 'successful', data: {} });
+});
+
+describe('converted query shapes', () => {
+  it('blockCall sends page and limit as query values', async () => {
+    await blockCall(2, 25);
+
+    expect(callArg()).toEqual({
+      route: 'block/list',
+      query: { page: 2, limit: 25 },
+    });
+  });
+
+  it('getSomeAssetsPool keeps the asset list, page and limit', async () => {
+    await getSomeAssetsPool('KLV,KFI', 3, 15);
+
+    expect(callArg()).toEqual({
+      route: 'assets/pool/list',
+      query: { asset: 'KLV,KFI', page: 3, limit: 15 },
+    });
+  });
+
+  it('requestAssets sends the asset list as a query value', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { assets: [] } });
+
+    await requestAssets('KLV,KFI');
+
+    expect(callArg()).toEqual({
+      route: 'assets/list',
+      query: { asset: 'KLV,KFI' },
+    });
+  });
+
+  it('requestProposals sends status, page and limit', async () => {
+    await requestProposals(2, 20, routerWith({ status: 'ActiveProposal' }));
+
+    expect(callArg()).toEqual({
+      route: 'proposals/list',
+      query: { status: 'ActiveProposal', page: 2, limit: 20 },
+    });
+  });
+
+  it('requestProposals keeps sending an empty status when the URL has none', async () => {
+    await requestProposals(1, 10, routerWith({}));
+
+    expect(callArg().query.status).toBe('');
+  });
+
+  it('getMarketplace sends the page as a query value', async () => {
+    await getMarketplace('abcdef0123456789', 4);
+
+    expect(callArg()).toEqual({
+      route: 'marketplaces/abcdef0123456789',
+      query: { page: 4 },
+    });
+  });
+
+  it('collectionListCall sends the page as a query value', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { collection: [] } });
+
+    await collectionListCall(
+      routerWith({ contractDetails: '{"collection":"CYB-3CAO"}' }),
+      'klv1owner',
+      '2',
+    );
+
+    expect(callArg()).toEqual({
+      route: 'address/klv1owner/collection/CYB-3CAO',
+      query: { page: 2 },
+    });
+  });
+});
+
+describe('escaped route segments', () => {
+  it('dataProposalCall escapes a proposal number carrying query syntax', async () => {
+    // Unescaped this produced proposals/28?voteType=1&?voteType=0, and the API
+    // resolves a repeated parameter first-wins, so the injected copy decided
+    // which voters came back.
+    await dataProposalCall(routerWith({ number: '28?voteType=1&' }));
+
+    expect(callArg().route).toBe('proposals/28%3FvoteType%3D1%26');
+    expect(callArg().query).toEqual({ voteType: 0 });
+  });
+
+  it('dataProposalCall leaves an ordinary proposal number alone', async () => {
+    await dataProposalCall(routerWith({ number: '28' }));
+
+    expect(callArg().route).toBe('proposals/28');
+  });
+
+  it('getMarketplace escapes an id carrying query syntax', async () => {
+    await getMarketplace('abc?page=999&', 1);
+
+    expect(callArg().route).toBe('marketplaces/abc%3Fpage%3D999%26');
+  });
+
+  it('collectionListCall escapes both segments', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { collection: [] } });
+
+    await collectionListCall(
+      routerWith({ contractDetails: '{"collection":"CYB?page=9&"}' }),
+      'klv1?x=1',
+      '0',
+    );
+
+    expect(callArg().route).toBe(
+      'address/klv1%3Fx%3D1/collection/CYB%3Fpage%3D9%26',
+    );
+  });
+
+  it('the allowance calls escape the address and send the asset as a query value', async () => {
+    await KLVAllowancePromise('klv1?x=1');
+    await KFIAllowancePromise('klv1?x=1');
+
+    expect(callArg(0).route).toBe('address/klv1%3Fx%3D1/allowance');
+    expect(callArg(0).query).toEqual({ assetID: 'KLV' });
+    expect(callArg(1).route).toBe('address/klv1%3Fx%3D1/allowance');
+    expect(callArg(1).query).toEqual({ assetID: 'KFI' });
+  });
+
+  it('assetsRequest escapes the account address from the URL', async () => {
+    mockGet.mockResolvedValue({
+      error: '',
+      data: { account: { assets: {} } },
+      pagination: {},
+    });
+
+    await assetsRequest('klv1?page=999&')(1, 10);
+
+    expect(callArg().route).toBe('address/klv1%3Fpage%3D999%26');
+  });
+});
+
+describe('shapes that must not drift', () => {
+  it('requestAssetsList still asks for the joined asset list', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { assets: [] } });
+
+    await requestAssetsList({
+      data: { itos: [{ assetId: 'KLV' }, { assetId: 'KFI' }] },
+    } as never);
+
+    expect(callArg()).toEqual({
+      route: 'assets/list',
+      query: { asset: 'KLV,KFI' },
+    });
+  });
+});

--- a/src/services/requests/__tests__/requestShapes.test.ts
+++ b/src/services/requests/__tests__/requestShapes.test.ts
@@ -34,6 +34,10 @@ import {
   KLVAllowancePromise,
   assetsRequest,
 } from '@/services/requests/account';
+import {
+  getAssetByPartialSymbol,
+  transactionCall,
+} from '@/services/requests/asset';
 import { requestAssets } from '@/services/requests/assets';
 import { collectionListCall } from '@/services/requests/collection';
 import { requestAssetsList } from '@/services/requests/ito';
@@ -43,6 +47,7 @@ import {
   dataProposalCall,
   requestProposals,
 } from '@/services/requests/proposals';
+import { smartContractTransactionDetailsCall } from '@/services/requests/smartContracts';
 import { NextRouter } from 'next/router';
 
 const routerWith = (query: Record<string, unknown>): NextRouter =>
@@ -186,6 +191,39 @@ describe('escaped route segments', () => {
 });
 
 describe('shapes that must not drift', () => {
+  it('getAssetByPartialSymbol sends the typed text as a query value', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { assets: [{}] } });
+
+    await getAssetByPartialSymbol('KL&x=1');
+
+    expect(callArg()).toEqual({
+      route: 'assets/list',
+      query: { asset: 'KL&x=1' },
+    });
+  });
+
+  it('transactionCall sends the asset and limit as query values', async () => {
+    mockGet.mockResolvedValue({ error: '', pagination: {} });
+
+    await transactionCall('KID-36W3');
+
+    expect(callArg()).toEqual({
+      route: 'transaction/list',
+      query: { asset: 'KID-36W3', limit: 5 },
+    });
+  });
+
+  it('smartContractTransactionDetailsCall escapes the hash and sends withResults', async () => {
+    mockGet.mockResolvedValue({ error: '', data: { transaction: {} } });
+
+    await smartContractTransactionDetailsCall('abc?x=1&');
+
+    expect(callArg()).toEqual({
+      route: 'transaction/abc%3Fx%3D1%26',
+      query: { withResults: true },
+    });
+  });
+
   it('requestAssetsList still asks for the joined asset list', async () => {
     mockGet.mockResolvedValue({ error: '', data: { assets: [] } });
 

--- a/src/services/requests/account/index.ts
+++ b/src/services/requests/account/index.ts
@@ -89,7 +89,8 @@ export const assetsRequest = (
 
     assetsToRequest = assetsToRequest.slice(0, -1);
     const allAccountAssets = await api.get({
-      route: `assets/list?page=${page}&limit=${limit}&asset=${assetsToRequest}`,
+      route: 'assets/list',
+      query: { page, limit, asset: assetsToRequest },
     });
     if (!allAccountAssets.error || allAccountAssets.error === '') {
       assetsArray.forEach((asset: IAccountAsset, index) => {
@@ -334,7 +335,8 @@ export const KLVAllowancePromise = async (
 ): Promise<IAllowanceResponse | undefined> => {
   try {
     const res = await api.get({
-      route: `address/${address}/allowance?assetID=KLV`,
+      route: `address/${encodeURIComponent(address)}/allowance`,
+      query: { assetID: 'KLV' },
       service: Service.PROXY,
     });
     if (!res.error || res.error === '') {
@@ -351,7 +353,8 @@ export const KFIAllowancePromise = async (
 ): Promise<IAllowanceResponse | undefined> => {
   try {
     const res = await api.get({
-      route: `address/${address}/allowance?assetID=KFI`,
+      route: `address/${encodeURIComponent(address)}/allowance`,
+      query: { assetID: 'KFI' },
       service: Service.PROXY,
     });
     if (!res.error || res.error === '') {
@@ -435,7 +438,8 @@ export const rewardsFPRPool = (
     const responseAll = await Promise.all(
       assetIdBuckets.map(async assetId => {
         const res = await api.get({
-          route: `address/${address}/allowance?assetID=${assetId}`,
+          route: `address/${encodeURIComponent(address)}/allowance`,
+          query: { assetID: assetId },
         });
         if (!res.error || res.error === '') {
           return {

--- a/src/services/requests/account/index.ts
+++ b/src/services/requests/account/index.ts
@@ -61,7 +61,7 @@ export const assetsRequest = (
       };
     }
     const accountResponse = await api.get({
-      route: `address/${address}`,
+      route: `address/${encodeURIComponent(address)}`,
     });
     if (accountResponse.error) {
       return {
@@ -180,7 +180,7 @@ export const bucketsRequest = (
     limit: number,
   ): Promise<IPaginatedResponse | []> => {
     const accountResponse: IAccountResponse = await api.get({
-      route: `address/${address}`,
+      route: `address/${encodeURIComponent(address)}`,
     });
     if (!accountResponse) return [];
 
@@ -296,7 +296,7 @@ export const accountCall = async (
 ): Promise<IAccount | undefined> => {
   try {
     const res = await api.get({
-      route: `address/${router.query.account || ''}`,
+      route: `address/${encodeURIComponent(String(router.query.account || ''))}`,
     });
     if (!res.error || res.error === '') {
       return res.data.account;
@@ -388,7 +388,7 @@ export const rewardsFPRPool = (
 ): ((page: number, limit: number) => Promise<IResponse | []>) => {
   const get = async (page: number, limit: number): Promise<IResponse | []> => {
     const accountResponse: IAccountResponse = await api.get({
-      route: `address/${address}`,
+      route: `address/${encodeURIComponent(address)}`,
     });
     if (!accountResponse) return [];
     const bucketsTable: IAssetsBuckets[] = [];
@@ -536,7 +536,7 @@ export const nftCollectionsRequest = (
     }
 
     const res = await api.get({
-      route: `address/${address}`,
+      route: `address/${encodeURIComponent(address)}`,
     });
 
     if (res.error && res.error !== '') {

--- a/src/services/requests/asset/index.ts
+++ b/src/services/requests/asset/index.ts
@@ -44,8 +44,10 @@ export const getAssetByPartialSymbol = async (
   } as IAssetResponse;
 
   if (assetRef?.length) {
+    // Through `query`: `assetRef` is whatever was typed into the search box.
     const res = await api.get({
-      route: `assets/list?asset=${assetRef}`,
+      route: 'assets/list',
+      query: { asset: assetRef },
     });
 
     if (res?.data?.assets?.length)

--- a/src/services/requests/asset/index.ts
+++ b/src/services/requests/asset/index.ts
@@ -104,7 +104,8 @@ export const transactionCall = async (
 ): Promise<IPagination | undefined> => {
   try {
     const res = await api.get({
-      route: `transaction/list?asset=${assetId}&limit=5`,
+      route: 'transaction/list',
+      query: { asset: assetId, limit: 5 },
     });
     if (!res.error || res.error === '') {
       const transactions = res as ITransactionsResponse;

--- a/src/services/requests/assets/index.ts
+++ b/src/services/requests/assets/index.ts
@@ -4,7 +4,8 @@ import { NextRouter } from 'next/router';
 
 export const requestAssets = async (assets: string): Promise<IAsset[]> => {
   const res = await api.get({
-    route: `assets/list?asset=${assets}`,
+    route: 'assets/list',
+    query: { asset: assets },
   });
   if (!res || res.error) {
     return [];

--- a/src/services/requests/block/__tests__/index.test.ts
+++ b/src/services/requests/block/__tests__/index.test.ts
@@ -94,16 +94,18 @@ describe('blockTransactionsCall', () => {
     });
   });
 
-  it('encodes a filter value so it cannot inject another parameter', async () => {
-    await blockTransactionsCall(42, 1, 10, { status: '&blockNum=999' });
+  it('passes a filter value on unchanged, leaving the escaping to the sink', async () => {
+    // This module used to percent-encode here because `buildUrlQuery` did not.
+    // It does now, so encoding twice would put the escaped form on the wire.
+    // That the injection and the fragment are neutralised is asserted against
+    // the built URL instead, in the api spec.
+    await blockTransactionsCall(42, 1, 10, {
+      status: '&blockNum=999',
+      asset: 'KLV#',
+    });
 
-    expect(queryOf().status).toBe('%26blockNum%3D999');
-  });
-
-  it('encodes a filter value so it cannot truncate the query with a fragment', async () => {
-    await blockTransactionsCall(42, 1, 10, { asset: 'KLV#' });
-
-    expect(queryOf().asset).toBe('KLV%23');
+    expect(queryOf().status).toBe('&blockNum=999');
+    expect(queryOf().asset).toBe('KLV#');
   });
 
   it('ignores a repeated param, which arrives as an array', async () => {

--- a/src/services/requests/block/index.ts
+++ b/src/services/requests/block/index.ts
@@ -13,10 +13,11 @@ type RouterQuery = Record<string, string | string[] | undefined>;
  * table: TransactionsFilters writes asset, status, type and buyType, DateFilter
  * writes startdate and enddate.
  *
- * An allowlist rather than a denylist because `buildUrlQuery` interpolates
- * values into the query string unescaped, so anything reaching it from the URL
- * can inject further params. A repeated param (?status=a&status=b) arrives as
- * an array and is skipped for the same reason.
+ * An allowlist rather than a denylist so the request carries filters only. This
+ * page keeps its tab and card state in the URL as well, and forwarding those
+ * would hand the API this table's view state as if it were a filter. A repeated
+ * param (?status=a&status=b) arrives as an array, which the filter bar never
+ * writes, so it is skipped rather than joined into a single value.
  */
 const FILTER_PARAMS = [
   'asset',
@@ -45,11 +46,7 @@ export const blockTransactionsCall = async (
   FILTER_PARAMS.forEach(key => {
     const value = routerQuery[key];
     if (typeof value === 'string' && value !== '') {
-      // Encoded here rather than in `buildUrlQuery`, which would fix every
-      // caller at once but risks changing values other endpoints already
-      // accept. If that central fix ever lands, drop this call: encoding
-      // twice would turn a filter value into its escaped form on the wire.
-      query[key] = encodeURIComponent(value);
+      query[key] = value;
     }
   });
 

--- a/src/services/requests/collection/index.ts
+++ b/src/services/requests/collection/index.ts
@@ -15,6 +15,8 @@ export const collectionListCall = async (
   try {
     // Parsed out of the URL, so it is escaped before going into a route
     // segment: unescaped, a `?` or `&` in it rewrote the request's parameters.
+    // The wallet address below is escaped only for consistency, it comes from
+    // the extension rather than the URL and is not attacker-reachable.
     const parsedCollection = encodeURIComponent(
       JSON.parse(router?.query?.contractDetails as string).collection,
     );
@@ -30,7 +32,9 @@ export const collectionListCall = async (
     }
 
     const res: ICollectionIdListResponse = await api.get({
-      route: `address/${walletAddress}/collection/${parsedCollection}`,
+      route: `address/${encodeURIComponent(
+        walletAddress,
+      )}/collection/${parsedCollection}`,
       query: { page: partialId ? Number(partialId) : 0 },
     });
 

--- a/src/services/requests/collection/index.ts
+++ b/src/services/requests/collection/index.ts
@@ -13,9 +13,11 @@ export const collectionListCall = async (
   isSFT = false,
 ): Promise<ICollection[] | undefined> => {
   try {
-    const parsedCollection = JSON.parse(
-      router?.query?.contractDetails as string,
-    ).collection;
+    // Parsed out of the URL, so it is escaped before going into a route
+    // segment: unescaped, a `?` or `&` in it rewrote the request's parameters.
+    const parsedCollection = encodeURIComponent(
+      JSON.parse(router?.query?.contractDetails as string).collection,
+    );
 
     if (isSFT) {
       const res: IAssetsResponse = await api.get({
@@ -28,9 +30,8 @@ export const collectionListCall = async (
     }
 
     const res: ICollectionIdListResponse = await api.get({
-      route: `address/${walletAddress}/collection/${parsedCollection}?page=${
-        partialId ? Number(partialId) : 0
-      }`,
+      route: `address/${walletAddress}/collection/${parsedCollection}`,
+      query: { page: partialId ? Number(partialId) : 0 },
     });
 
     if (!res.error || res.error === '') {

--- a/src/services/requests/ito/index.ts
+++ b/src/services/requests/ito/index.ts
@@ -35,7 +35,8 @@ export const requestAssetsList = async (
         .join(',');
 
       const res = await api.get({
-        route: `assets/list?asset=${assetsInput}`,
+        route: 'assets/list',
+        query: { asset: assetsInput },
       });
       if (!res.error || res.error === '') {
         return res.data.assets;

--- a/src/services/requests/marketplace/index.ts
+++ b/src/services/requests/marketplace/index.ts
@@ -18,7 +18,8 @@ export const getMarketplace = async (
   page: number,
 ): Promise<IMarketplaceResponse> => {
   const res: IMarketplaceResponse = await api.get({
-    route: `marketplaces/${marketplaceId}?page=${page}`,
+    route: `marketplaces/${encodeURIComponent(marketplaceId)}`,
+    query: { page },
   });
   return res;
 };

--- a/src/services/requests/pool/index.ts
+++ b/src/services/requests/pool/index.ts
@@ -7,7 +7,8 @@ export const getSomeAssetsPool = async (
   limit: number = 10,
 ): Promise<IAssetPoolsResponse> => {
   const res = await api.get({
-    route: `assets/pool/list?asset=${assets}&page=${page}&limit=${limit}`,
+    route: 'assets/pool/list',
+    query: { asset: assets, page, limit },
   });
 
   if (!res.error || res.error === '') {

--- a/src/services/requests/proposals/index.ts
+++ b/src/services/requests/proposals/index.ts
@@ -98,7 +98,10 @@ export const dataNetworkParams = async (): Promise<
 export const dataProposalCall = async (router: NextRouter): Promise<any> => {
   try {
     const res = await api.get({
-      route: `proposals/${router.query.number}`,
+      // Escaped for the same reason as the query values below: this segment
+      // comes from the URL, and an injected `?voteType=1&` would land ahead of
+      // the voteType below, which the API then answers first-wins.
+      route: `proposals/${encodeURIComponent(String(router.query.number))}`,
       query: { voteType: 0 },
     });
     return parseProposal(res);

--- a/src/services/requests/proposals/index.ts
+++ b/src/services/requests/proposals/index.ts
@@ -113,8 +113,12 @@ export const requestProposals = async (
   router: NextRouter,
 ): Promise<IResponse> => {
   const { status } = router.query;
+  // Through `query` rather than interpolated into the route: `status` comes
+  // from the URL, and a value carrying `&page=999` used to add a second `page`
+  // ahead of this one, which the proxy then answered instead.
   const proposals: IProposalsResponse = await api.get({
-    route: `proposals/list?status=${status || ''}&page=${page}&limit=${limit}`,
+    route: 'proposals/list',
+    query: { status: status || '', page, limit },
   });
   let parsedProposalResponse: any[] = [];
   parsedProposalResponse = parseAllProposals(proposals?.data?.proposals);

--- a/src/services/requests/smartContracts/index.ts
+++ b/src/services/requests/smartContracts/index.ts
@@ -176,7 +176,8 @@ const smartContractTransactionDetailsCall = async (
 ): Promise<{ transaction: SmartContractTransactionData } | undefined> => {
   try {
     const res = await api.get({
-      route: `transaction/${txHash}?withResults=true`,
+      route: `transaction/${encodeURIComponent(txHash)}`,
+      query: { withResults: true },
     });
 
     if (!res.error || res.error === '') {

--- a/src/utils/parseValues/index.ts
+++ b/src/utils/parseValues/index.ts
@@ -199,7 +199,8 @@ export const parseITOs = async (ITOs: any[]): Promise<IParsedITO | never[]> => {
   const assetsInput: string = ITOs.map(ITO => ITO.assetId).join(',');
   const packsPrecisionCalls: Promise<IITO>[] = [];
   const res = await api.get({
-    route: `assets/list?asset=${assetsInput}`,
+    route: 'assets/list',
+    query: { asset: assetsInput },
   });
   if (!res.error || res.error === '') {
     const assets = res.data.assets;


### PR DESCRIPTION
Closes #684.

## What was wrong

`buildUrlQuery` in `src/services/api.ts` interpolated both sides of every pair into the URL unescaped. Next hands `router.query` over already decoded, so a value carrying `&` added a parameter of its own, and one carrying `#` truncated the request at a fragment and dropped every parameter written after it.

Two properties turn that into a wrong answer rather than a cosmetic flaw. The API resolves a repeated parameter first-wins, and Next lists a search param ahead of a route param of the same name in `router.query`. The injected copy is therefore emitted first and decides the response.

Measured against the live API on the asset detail page:

- `/asset/KLV?x=%26asset%3DKFI` sent `transaction/list?x=&asset=KFI&asset=KLV&page=1&limit=10` and returned 1,209,463 records, which is KFI's count, under a KLV header.
- `/asset/KLV?x=1%23` sent `transaction/list?x=1`, dropping the asset filter, the page and the limit, so the table listed transactions chain wide.

**It also fired without a crafted link.** The asset page writes its card name into the URL and spreads it into the request, and one of those names is `Staking & Royalties`. An ordinary page load sent `card=Staking%20&%20Royalties`, splitting the query on the ampersand in the label.

## What changed

**The sink.** `buildUrlQuery` percent-encodes key and value. `String(value)` keeps exactly the coercion the template literal performed, including an array joining on a comma, so only characters that were already travelling as syntax change on the wire.

**Hand-built query strings.** Eighteen call sites built their query into the route string and so never reached that sink. They now pass their parameters through it.

**Route segments.** A segment holding a URL-derived value next to a `query` object is the same defect, because the query is appended after the route. `/proposal/28%3FvoteType%3D1%26` emitted `proposals/28?voteType=1&?pageVoters=1&limitVoters=10&voteType=0` and came back with one voter of type 1 where the page asked for type 0, so the Yes tab rendered the No set with no error anywhere.

Those segments are now escaped, and every remaining segment in the same file is escaped with them, so the rule holds per file rather than per line. That mattered: a first pass escaped one hash in `transaction/[hash]` and in `validator/[hash]` while leaving an identical one eleven lines away in each.

**Three server-side handlers.** `contract-validator/[address]/info`, `jobs/latest` and `versions/[version]/source` interpolated their route param into an upstream URL that carries the API key. `..%2F..%2Fsettings%3F` walked out of `/contract/` and reached any GET endpoint of that service, with the body returned to an anonymous caller. Five siblings in the same directory already escaped; these three validated only that the param was a non-empty string. Pre-existing rather than introduced here, but it is the highest-severity instance of the class this PR closes.

The local `encodeURIComponent` in `src/services/requests/block/index.ts` is removed, because encoding twice would put the escaped form on the wire.

## Tests

Two new specs, both mutation-checked: reverting an escape or restoring a hand-built route string fails exactly one test, and the validator failure prints the traversed URL.

- `src/services/__tests__/api.test.ts` covers the sink directly, including both primitives and the label case.
- `src/services/requests/__tests__/requestShapes.test.ts` pins the outgoing `route` and `query` of every converted call site. None of those modules had a test reading the request before, so a renamed key or a segment that quietly stopped being escaped would have shipped green.
- `src/pages/api/contract-validator/__tests__/pathEscaping.test.ts` pins the three server-side handlers.

Two tests in the block spec were replaced by one. They used to assert that the module encodes; it no longer does, so the replacement asserts that both hostile values are passed through untouched, with the escaping proven against the built URL in the api spec instead.

## Deliberately not changed

The two `Service.NODE` calls keep their static `?withResults=true` in the route and only escape the hash. Nothing in this repo sends a query object to that host, and extending the change to a server whose decoding behaviour was not measured buys nothing here.

Nineteen route segments that take a URL-derived value in files this PR does not otherwise touch stay raw, spread over the asset, nonce, search-bar and smart-contract request modules. None has a `query` object beside it today, so none is exploitable the same way, but the rule is uniform per file rather than repo wide. One of them carries a trap worth knowing about: the Holders tab receives an asset id that `parseHardCodedInfo` has already encoded, so escaping it without removing that pre-encode would double-encode. That block is worth its own change.

The `.filter(v => v !== undefined && v !== null)` from the snippet in the issue is not included. No call site produces those values, so it would only add a behaviour difference. The API does distinguish them if one ever appears: `asset=undefined` returns zero records while `asset=` returns everything.

`IQuery` is still `{ [key: string]: any }`, which is what makes the `String()` coercion total rather than provably safe. Narrowing it reaches call sites beyond this change.

## Verification

Both primitives were reproduced in a browser against the running app before the change and confirmed closed after it, and the same was done for the `Staking & Royalties` load and the proposals injection, which now fails loudly on a bad id instead of returning the wrong voters. Regression checks covered the block page filters (no double encoding), the NFT nonce page (`asset=KID-36W3%2F1` still returns rows), the proposals list (byte identical in normal use) and the accounts, blocks, assets, validators and transaction detail pages.

Encoding is safe against this API for every value type that occurs: `%2F`, `%2C`, `%3A` and a percent-encoded path segment all return exactly what the bare form returns, verified per case. Spaces and non-ASCII are unchanged, because the URL constructor already encoded them.

## Note for the reviewer

`src/services/apiCalls.ts` shows three reformatted `throw new Error(...)` lines that this change does not touch. That file already did not satisfy Prettier on `develop`, and the pre-commit hook reformats any file it stages, so reverting them is not stable. They are the only uncovered patch lines besides one line in a page component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling for transaction hashes, contract addresses, proposal numbers, collection identifiers, asset IDs, and other dynamic values.
  - Blocked malformed, traversal-style, and invalid contract or version inputs from reaching validator services.
  - Improved query-parameter encoding to prevent injection and preserve special characters.
  - Standardized pagination and filters for more reliable API requests.

- **Tests**
  - Added coverage for URL encoding, query construction, validation, traversal protection, and request formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->