### PR TITLE
feat(transactions): make the shared table translatable and fix column, hydration and menu bugs

### DIFF
--- a/cypress/e2e/pages/transactions.cy.ts
+++ b/cypress/e2e/pages/transactions.cy.ts
@@ -12,9 +12,25 @@ import { contracts } from '../../../src/configs/transactions';
 import { ContractsIndex } from '../../../src/types/contracts';
 
 const PAGE_TITLE_SELECTOR = 'h1';
-const STATUS_FILTER_SELECTOR = ':nth-child(2) > [data-testid="selector"]';
-const TYPE_FILTER_SELECTOR = ':nth-child(3) > [data-testid="selector"]';
+/**
+ * Reached by the filter's own identifier rather than by its position among its
+ * siblings. The positional form broke on any wrapper element, on reordering,
+ * and on the Buy Type filter appearing, and it would break again once the
+ * titles are translated.
+ */
+const STATUS_FILTER_SELECTOR =
+  '[data-testid="filter-status"] [data-testid="selector"]';
+const TYPE_FILTER_SELECTOR =
+  '[data-testid="filter-contract"] [data-testid="selector"]';
 const TABLE_ROW_SELECTOR = '[data-testid^="table-row-"]';
+
+/**
+ * Cypress defaults to 1000px wide and the app switches to its tablet layout
+ * below 1025, so without an explicit viewport the suite only ever exercises
+ * the card DOM and never the column table. Both are covered.
+ */
+const TABLET_VIEWPORT: [number, number] = [1000, 660];
+const DESKTOP_VIEWPORT: [number, number] = [1440, 900];
 
 const ADDRESS =
   'klv1nnu8d0mcqnxunqyy5tc7kj7vqtp4auy4a24gv35fn58n2qytl9xsx7wsjl';
@@ -166,6 +182,9 @@ const visitTransactionDetail = (hash: string, retriesLeft = 3): void => {
 
 describe('Transactions Page', () => {
   beforeEach(() => {
+    // Stated rather than inherited from the Cypress default, so the layout
+    // these assertions describe cannot change by editing the config.
+    cy.viewport(...TABLET_VIEWPORT);
     stubTransactionListApis();
     cy.visit('/transactions');
     cy.wait('@txList', { timeout: 15000 });
@@ -202,6 +221,177 @@ describe('Transactions Page', () => {
         'have.length.at.least',
         1,
       );
+    });
+  });
+
+  it('labels every cell with its column, and shows no header row', () => {
+    // Below the tablet breakpoint the table renders as cards: there is no
+    // column header row, and each cell carries its own label instead.
+    cy.get(TABLE_ROW_SELECTOR, { timeout: 15000 }).should(
+      'have.length.at.least',
+      1,
+    );
+    cy.get('[data-testid="table-header"]').should('not.exist');
+    cy.get('[data-testid="table-row-0"]')
+      .first()
+      .should('contain.text', 'Transaction Hash');
+  });
+});
+
+describe('Transactions Page (desktop)', () => {
+  beforeEach(() => {
+    cy.viewport(...DESKTOP_VIEWPORT);
+    stubTransactionListApis();
+    cy.visit('/transactions');
+    cy.wait('@txList', { timeout: 15000 });
+  });
+
+  it('renders the column header row', () => {
+    cy.get('[data-testid="table-header"]', { timeout: 15000 })
+      .should('be.visible')
+      .children()
+      .should('have.length.at.least', 1);
+  });
+
+  /**
+   * The header count and the per-row cell count are produced by two separate
+   * code paths, so nothing stops them drifting apart. When they do, every
+   * column past the divergence sits under the wrong heading.
+   */
+  it('gives each row exactly one cell per column heading', () => {
+    cy.get('[data-testid="table-header"]', { timeout: 15000 })
+      .children()
+      .its('length')
+      .then(headerCount => {
+        expect(headerCount).to.be.greaterThan(0);
+        cy.get('[data-testid="table-row-0"]').should(
+          'have.length',
+          headerCount,
+        );
+      });
+  });
+
+  /**
+   * The shape the split actually broke. Without an account in the URL both
+   * lists were five long, so an assertion on `/transactions` alone passes on
+   * the bug too: this is the one that fails before the fix, where six cells
+   * rendered under five headings.
+   */
+  it('keeps headings and cells aligned once the list is scoped to an account', () => {
+    cy.visit(`/transactions?account=${ADDRESS}`);
+    cy.wait('@txList', { timeout: 15000 });
+
+    cy.get('[data-testid="table-header"]', { timeout: 15000 })
+      .children()
+      .then(headings => {
+        expect(headings).to.have.length(6);
+        expect(
+          [...headings].map(cell => cell.textContent?.trim()),
+        ).to.deep.equal([
+          'Transaction Hash',
+          'Block/Fees',
+          'From/To',
+          'In/Out',
+          'Type',
+          'Misc',
+        ]);
+        cy.get('[data-testid="table-row-0"]').should('have.length', 6);
+      });
+  });
+
+  /**
+   * Locks the namespace wiring. A t() whose namespace was never loaded does
+   * not fall back to English, it renders its own key, and every other
+   * assertion here would still pass on one: contains('Success') also matches
+   * "transactions:Status.Success". Exact matches do not.
+   */
+  it('renders translated filter texts, never raw keys', () => {
+    cy.get('[data-testid="filter-status"] > span')
+      .first()
+      .should('have.text', 'Status');
+    cy.get('[data-testid="filter-contract"] > span')
+      .first()
+      .should('have.text', 'Contract');
+
+    cy.get(STATUS_FILTER_SELECTOR).click();
+    cy.get('[data-testid="filter-status"]').contains(/^Success$/);
+    cy.get('body').should('not.contain.text', 'transactions:');
+  });
+
+  it('links the hash cell to the full transaction hash', () => {
+    const expectedHash = hashForType(0);
+    cy.get(`a[href*="/transaction/${expectedHash}"]`, {
+      timeout: 15000,
+    }).should('be.visible');
+  });
+});
+
+describe('Block Page i18n', () => {
+  // getStaticProps runs against the live API (intercepts cannot stub Node),
+  // like the detail suite below. One representative block is enough: the page
+  // loaded no translation namespace at all before this branch, so its filter
+  // bar rendered raw keys.
+  const API_BASE =
+    Cypress.env('DEFAULT_API_HOST') || 'https://api.testnet.klever.org';
+  const API_VERSION = Cypress.env('DEFAULT_API_VERSION') || 'v1.0';
+
+  /** Same bounded 429 backoff as the detail suite: the shared testnet API
+   * rate-limits, and cy.request fails outright on a non-2xx without
+   * failOnStatusCode. */
+  const requestLatestBlockNum = (
+    retriesLeft = 5,
+  ): Cypress.Chainable<number> => {
+    return cy
+      .request({
+        url: `${API_BASE}/${API_VERSION}/transaction/list`,
+        qs: { limit: 1, page: 1 },
+        failOnStatusCode: false,
+        timeout: 20000,
+      })
+      .then(res => {
+        if (res.status === 429 && retriesLeft > 0) {
+          cy.wait(2500);
+          return requestLatestBlockNum(retriesLeft - 1);
+        }
+        const blockNum = res.body?.data?.transactions?.[0]?.blockNum;
+        expect(blockNum, 'blockNum from the live list').to.be.a('number');
+        return cy.wrap(blockNum as number);
+      });
+  };
+
+  /** Bounded revisit, like visitTransactionDetail: getStaticProps runs its
+   * own lookup against the live API and answers notFound after its retries,
+   * so with failOnStatusCode off a rate-limited build lands on the 404 page
+   * and the filter assertion would only time out. */
+  const visitBlockPage = (blockNum: number, retriesLeft = 3): void => {
+    cy.visit(`/block/${blockNum}`, {
+      timeout: 60000,
+      failOnStatusCode: false,
+    });
+    cy.get('body', { timeout: 15000 }).then($body => {
+      if ($body.find('[data-testid="filter-status"]').length) {
+        return;
+      }
+      if (retriesLeft <= 0) {
+        throw new Error(
+          `Block page did not load for ${blockNum} after retries (likely API 429 / notFound)`,
+        );
+      }
+      cy.wait(3000);
+      visitBlockPage(blockNum, retriesLeft - 1);
+    });
+  };
+
+  it('serves the transactions tab with translated filters', () => {
+    requestLatestBlockNum().then(blockNum => {
+      cy.viewport(...DESKTOP_VIEWPORT);
+      visitBlockPage(blockNum);
+
+      cy.get('[data-testid="filter-status"] > span', { timeout: 20000 })
+        .first()
+        .should('have.text', 'Status');
+      cy.contains('Date Filter').should('be.visible');
+      cy.get('body').should('not.contain.text', 'transactions:');
     });
   });
 });

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,11 +1,15 @@
-const path = require('path');
-
 module.exports = {
   i18n: {
-    locales: [
-      'en',
-    ],
+    locales: ['en'],
     defaultLocale: 'en',
   },
-  localePath: path.resolve('./public/locales'),
+  // Relative on purpose, and not built with path.resolve. next-i18next hands
+  // this whole config to the browser inside __NEXT_DATA__, so an absolute path
+  // here shipped the build machine's directory layout to every visitor; on
+  // /block/<n> it was baked into the prerendered artifacts as well.
+  //
+  // Nothing server-side needs it pre-resolved: createConfig already does
+  // path.resolve(process.cwd(), localePath + …) for the loader, and there is no
+  // browser backend configured that would use it as a URL prefix.
+  localePath: './public/locales',
 };

--- a/public/locales/en/transactions.json
+++ b/public/locales/en/transactions.json
@@ -3,5 +3,50 @@
   "Daily Transactions": "Daily Transactions",
   "From": "From",
   "To": "To",
-  "Last Transactions": "Last Transactions"
+  "Last Transactions": "Last Transactions",
+  "Filters": {
+    "Coin": "Coin",
+    "CoinPlaceholder": "Type the token ID",
+    "Status": "Status",
+    "Contract": "Contract",
+    "ContractPlaceholder": "Type the contract",
+    "BuyType": "Buy Type",
+    "NotFound": "No match found"
+  },
+  "Status": {
+    "Success": "Success",
+    "Fail": "Fail"
+  },
+  "BuyTypes": {
+    "MarketBuy": "MarketBuy",
+    "ITOBuy": "ITOBuy"
+  },
+  "Contracts": {
+    "Transfer": "Transfer",
+    "Create Asset": "Create Asset",
+    "Create Validator": "Create Validator",
+    "Config Validator": "Config Validator",
+    "Freeze": "Freeze",
+    "Unfreeze": "Unfreeze",
+    "Delegate": "Delegate",
+    "Undelegate": "Undelegate",
+    "Withdraw": "Withdraw",
+    "Claim": "Claim",
+    "Unjail": "Unjail",
+    "Asset Trigger": "Asset Trigger",
+    "Set Account Name": "Set Account Name",
+    "Proposal": "Proposal",
+    "Vote": "Vote",
+    "Config ITO": "Config ITO",
+    "Set ITO": "Set ITO",
+    "Buy": "Buy",
+    "Sell": "Sell",
+    "Cancel Marketplace Order": "Cancel Marketplace Order",
+    "Create Marketplace": "Create Marketplace",
+    "Config Marketplace": "Config Marketplace",
+    "Update Account Permission": "Update Account Permission",
+    "Deposit": "Deposit",
+    "ITO Trigger": "ITO Trigger",
+    "Smart Contract": "Smart Contract"
+  }
 }

--- a/src/components/AssetsPools/index.tsx
+++ b/src/components/AssetsPools/index.tsx
@@ -86,6 +86,9 @@ const PoolsFilters: React.FC<PropsWithChildren> = () => {
 
   const filter: IFilter = {
     title: `${t('common:Titles.Assets')}`,
+    // See the assets list: Filter used to infer this from `title === 'Asset'`,
+    // which this never was, so the box has been showing the generic prompt.
+    placeholder: 'Type the token ID',
     data: (pools || [])
       .map(pool => pool.kda)
       .sort((a, b) => a.localeCompare(b)),

--- a/src/components/DateFilter/__tests__/index.test.tsx
+++ b/src/components/DateFilter/__tests__/index.test.tsx
@@ -10,8 +10,14 @@ import { ThemeProvider } from 'styled-components';
 
 const routerQuery: Record<string, string> = {};
 
+let routerIsReady = true;
+
 jest.mock('next/router', () => ({
-  useRouter: () => ({ isReady: true, query: routerQuery, push: jest.fn() }),
+  useRouter: () => ({
+    isReady: routerIsReady,
+    query: routerQuery,
+    push: jest.fn(),
+  }),
 }));
 
 jest.mock('@/utils', () => ({
@@ -114,5 +120,24 @@ describe('DateFilter page reset', () => {
     expect(query.page).toBe('1');
     expect(query).not.toHaveProperty('startdate');
     expect(query).not.toHaveProperty('enddate');
+  });
+});
+
+describe('DateFilter first paint', () => {
+  afterEach(() => {
+    routerIsReady = true;
+  });
+
+  it('renders before the router is ready, identically on both sides', () => {
+    // The server renders with isReady false and the client's first render can
+    // have it true. Gating the whole component on it made /block/<n> hydrate
+    // against a tree with no date filter in it, and React threw the tree away.
+    // The rest of this suite mocks isReady true, so putting the gate back
+    // would go green without this.
+    routerIsReady = false;
+
+    renderFilter({});
+
+    expect(screen.getByText('Date Filter')).toBeInTheDocument();
   });
 });

--- a/src/components/DateFilter/index.tsx
+++ b/src/components/DateFilter/index.tsx
@@ -303,7 +303,17 @@ const DateFilter: React.FC<PropsWithChildren> = () => {
     setEndTime(e.target.value);
   };
 
-  return router.isReady ? (
+  // Not gated on router.isReady. Next answers that differently on each side
+  // for a statically generated page: false while rendering on the server, true
+  // on the client's first render, so /block/<n> hydrated against a tree with no
+  // date filter in it and React discarded the whole page.
+  //
+  // `router.query` is read above, when building `dateFromRouter`, but the only
+  // things that fold it into what renders are `selectDays()` and
+  // `formatInputInitialValue()`, and both run from the effect. So the first
+  // render's output is router-independent on both sides. Keep it that way: move
+  // either call into the render body and the mismatch comes back.
+  return (
     <FilterContainer open={calendarOpen}>
       <span>Date Filter</span>
       <Container
@@ -427,7 +437,7 @@ const DateFilter: React.FC<PropsWithChildren> = () => {
         )}
       </Container>
     </FilterContainer>
-  ) : null;
+  );
 };
 
 export default DateFilter;

--- a/src/components/ExplorerLink/__tests__/index.test.tsx
+++ b/src/components/ExplorerLink/__tests__/index.test.tsx
@@ -1,0 +1,108 @@
+import theme from '@/styles/theme';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@/contexts/mobile', () => ({
+  useMobile: () => ({ isMobile: false, isTablet: false }),
+}));
+
+jest.mock('@/contexts/theme', () => ({
+  useTheme: () => ({ theme: { black: '#000' } }),
+}));
+
+jest.mock('@/contexts/contractModal', () => ({
+  useContractModal: () => ({
+    getInteractionsButtons: () => [
+      () => <button type="button">Transfer</button>,
+    ],
+  }),
+}));
+
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: () => <svg data-testid="qr-code" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import ExplorerLink from '../index';
+
+const HASH = 'abc123';
+
+describe('ExplorerLink compact mode', () => {
+  /**
+   * The production wiring under test is one prop: compact mode passing its own
+   * `type` through to the hover menu. The menu's own suite is thorough but
+   * receives `entity` directly, so dropping the pass-through would fall back
+   * to the account menu everywhere while every existing test stayed green.
+   * This is the test that fails in that case.
+   */
+  it('hands its type to the hover menu, so a hash is not treated as an address', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <ExplorerLink type="transaction" value={HASH} compact />
+      </ThemeProvider>,
+    );
+
+    const wrapper = screen.getByText(HASH).closest('div')
+      ?.parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+
+    expect(screen.getByText('Copy Transaction Hash')).toBeInTheDocument();
+    expect(screen.queryByText('Copy Address')).not.toBeInTheDocument();
+    expect(screen.queryByText('QR Code')).not.toBeInTheDocument();
+    expect(screen.queryByText('Transfer')).not.toBeInTheDocument();
+  });
+
+  it('keeps the full address menu for an account link', () => {
+    render(
+      <ThemeProvider theme={theme}>
+        <ExplorerLink type="account" value="klv1abc" compact />
+      </ThemeProvider>,
+    );
+
+    const wrapper = screen.getByText('klv1abc').closest('div')
+      ?.parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+
+    expect(screen.getByText('Copy Address')).toBeInTheDocument();
+    expect(screen.getByText('QR Code')).toBeInTheDocument();
+    expect(screen.getByText('Transfer')).toBeInTheDocument();
+  });
+});

--- a/src/components/ExplorerLink/index.tsx
+++ b/src/components/ExplorerLink/index.tsx
@@ -1,5 +1,6 @@
 import Copy from '@/components/Copy';
 import LinkWithDropdown from '@/components/LinkWithDropdown';
+import { menuForEntity } from '@/components/LinkWithDropdown/menu';
 import { CenteredRow, Mono } from '@/styles/common';
 import Link from 'next/link';
 import React from 'react';
@@ -59,7 +60,7 @@ const ExplorerLink: React.FC<ExplorerLinkProps> = ({
 
   if (compact) {
     return (
-      <LinkWithDropdown link={href} address={value || ''}>
+      <LinkWithDropdown link={href} address={value || ''} entity={type}>
         <Link href={href}>{text}</Link>
       </LinkWithDropdown>
     );
@@ -71,12 +72,14 @@ const ExplorerLink: React.FC<ExplorerLinkProps> = ({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={`Open ${type} in a new tab`}
+        aria-label={`Open ${menuForEntity(type).noun} in a new tab`}
         title="Open in a new tab"
       >
         <IoOpenOutline size={20} />
       </a>
-      <Copy data={value} info={type} />
+      {/* The same table the hover menu uses, so this path cannot say
+          "account copied to clipboard" while the other says "Wallet Address". */}
+      <Copy data={value} info={menuForEntity(type).copyInfo} />
     </CenteredRow>
   );
 };

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -51,10 +51,14 @@ const renderWithTheme = (ui: React.ReactElement) =>
   render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 
 describe('Filter', () => {
-  it('shows search placeholder and focuses input when opened', async () => {
+  it('shows the given search placeholder and focuses input when opened', async () => {
     renderWithTheme(
       <Filter
         title="Version"
+        // Deliberately not "Search version…": that is exactly what the removed
+        // title-matching branch produced, so asserting it would pass against
+        // the code this replaces.
+        placeholder="Pick a version"
         data={['v1.7.21-rc1', 'v1.7.20', 'Unknown']}
         current={undefined}
         onClick={jest.fn()}
@@ -64,11 +68,27 @@ describe('Filter', () => {
     fireEvent.click(screen.getByTestId('selector'));
 
     const input = await screen.findByLabelText('Search Version');
-    expect(input).toHaveAttribute('placeholder', 'Search version…');
+    expect(input).toHaveAttribute('placeholder', 'Pick a version');
 
     await waitFor(() => {
       expect(input).toHaveFocus();
     });
+  });
+
+  it('falls back to a generic placeholder when none is given', async () => {
+    renderWithTheme(
+      <Filter
+        title="Version"
+        data={['v1.7.20']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('selector'));
+
+    const input = await screen.findByLabelText('Search Version');
+    expect(input).toHaveAttribute('placeholder', 'Type to search…');
   });
 
   it('filters list items as the user types', async () => {
@@ -153,6 +173,165 @@ describe('Filter', () => {
     );
 
     expect(screen.getByText('v1.7.20')).toBeInTheDocument();
+  });
+
+  describe('displayed label separated from the selected value', () => {
+    // The label is what a reader sees; the value is what reaches the URL and
+    // the API. These pin that translating the first cannot move the second.
+    const LABELS: Record<string, string> = {
+      All: 'Alle',
+      Success: 'Geslaagd',
+      Fail: 'Mislukt',
+    };
+    const renderLabel = (value: string) => LABELS[value] ?? value;
+
+    const renderFilter = (onClick = jest.fn()) => {
+      renderWithTheme(
+        <Filter
+          title="Status"
+          data={['Success', 'Fail']}
+          renderLabel={renderLabel}
+          current={undefined}
+          onClick={onClick}
+        />,
+      );
+      return onClick;
+    };
+
+    it('lists labels, not values', async () => {
+      renderFilter();
+      fireEvent.click(screen.getByTestId('selector'));
+
+      expect(await screen.findByText('Geslaagd')).toBeInTheDocument();
+      expect(screen.getByText('Mislukt')).toBeInTheDocument();
+      expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    });
+
+    it('reports the value when a label is clicked', async () => {
+      const onClick = renderFilter();
+      fireEvent.click(screen.getByTestId('selector'));
+
+      fireEvent.click(await screen.findByText('Geslaagd'));
+
+      expect(onClick).toHaveBeenCalledWith('Success');
+    });
+
+    it('shows the label of the current value once closed', () => {
+      renderWithTheme(
+        <Filter
+          title="Status"
+          data={['Success', 'Fail']}
+          renderLabel={renderLabel}
+          current="Fail"
+          onClick={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Mislukt')).toBeInTheDocument();
+      expect(screen.queryByText('Fail')).not.toBeInTheDocument();
+    });
+
+    it('searches on the label, because that is what the user reads', async () => {
+      renderFilter();
+      fireEvent.click(screen.getByTestId('selector'));
+      const input = await screen.findByLabelText('Search Status');
+
+      fireEvent.change(input, { target: { value: 'gesl' } });
+
+      expect(screen.getByText('Geslaagd')).toBeInTheDocument();
+      expect(screen.queryByText('Mislukt')).not.toBeInTheDocument();
+    });
+
+    it('still searches on the value, so existing habits keep working', async () => {
+      renderFilter();
+      fireEvent.click(screen.getByTestId('selector'));
+      const input = await screen.findByLabelText('Search Status');
+
+      fireEvent.change(input, { target: { value: 'fail' } });
+
+      expect(screen.getByText('Mislukt')).toBeInTheDocument();
+      expect(screen.queryByText('Geslaagd')).not.toBeInTheDocument();
+    });
+
+    it('searches labels carrying characters the old input filter stripped', async () => {
+      renderWithTheme(
+        <Filter
+          title="Status"
+          data={['Success']}
+          renderLabel={value =>
+            value === 'Success' ? 'Sucesso concluído' : 'Todos'
+          }
+          current={undefined}
+          onClick={jest.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('selector'));
+      const input = await screen.findByLabelText('Search Status');
+
+      fireEvent.change(input, { target: { value: 'concluído' } });
+
+      // The input value is the assertion that pins the removal: the old
+      // sanitiser truncated this to "conclu", which still matched the option,
+      // so asserting only on the list passed either way.
+      expect(input).toHaveValue('concluído');
+      expect(screen.getByText('Sucesso concluído')).toBeInTheDocument();
+      expect(screen.queryByText('Todos')).not.toBeInTheDocument();
+    });
+  });
+
+  it('survives a null-ish entry in data while searching', () => {
+    // `data: string[]` is unchecked at runtime: a caller building its list
+    // from optional API fields can hand this a hole, as the Coin filter did
+    // before it started filtering at the source. Searching must not throw.
+    renderWithTheme(
+      <Filter
+        title="Coin"
+        data={['KLV', undefined as unknown as string, 'KFI']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('selector'));
+
+    expect(() => {
+      fireEvent.change(screen.getByLabelText('Search Coin'), {
+        target: { value: 'kf' },
+      });
+    }).not.toThrow();
+    expect(screen.getByText('KFI')).toBeInTheDocument();
+  });
+
+  it('shows the given not-found text, and falls back to the title otherwise', async () => {
+    const { rerender } = renderWithTheme(
+      <Filter
+        title="Coin"
+        data={['KLV']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('selector'));
+    fireEvent.change(await screen.findByLabelText('Search Coin'), {
+      target: { value: 'zzz' },
+    });
+    expect(screen.getByText('Coin not found!')).toBeInTheDocument();
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <Filter
+          title="Coin"
+          notFoundLabel="No match found"
+          data={['KLV']}
+          current={undefined}
+          onClick={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('No match found')).toBeInTheDocument();
+    expect(screen.queryByText('Coin not found!')).not.toBeInTheDocument();
   });
 
   it('does not open when disabledInput is set', () => {

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -24,13 +24,74 @@ export interface IFilterItem {
   item: string;
 }
 
+interface ISelectorItemProps {
+  value: string;
+  label: string;
+  isSelected: boolean;
+  onSelect: (value: string) => void;
+}
+
+/**
+ * One option in the open dropdown. Defined here rather than inside `Filter`:
+ * a component built during render gets a fresh identity every time, so the
+ * whole option list used to unmount and remount on each keystroke.
+ *
+ * It reports the value, never the label, so translating what a user reads
+ * cannot change what reaches the URL and the API.
+ */
+const SelectorItem: React.FC<ISelectorItemProps> = ({
+  value,
+  label,
+  isSelected,
+  onSelect,
+}) => (
+  <Item
+    onClick={() => onSelect(value)}
+    selected={isSelected}
+    data-testid="selector-item"
+  >
+    <p>{label}</p>
+  </Item>
+);
+
 export interface IFilter {
   title?: string;
+  /**
+   * Stable identifier for tests, independent of the displayed title. The e2e
+   * suite used to reach a filter by its position among its siblings, which
+   * broke on any wrapper element or reordering, and would break again once the
+   * titles are translated.
+   */
+  testId?: string;
   firstItem?: string;
   hideAllOption?: boolean;
   inputType?: string;
   overFlow?: string;
+  /**
+   * The values this filter selects between: selection keys, never displayed
+   * text. `onClick` receives one of these, not `renderLabel` output. They are
+   * not automatically the wire format either: several callers map them
+   * further before anything reaches the URL or the API (the contract filter
+   * turns a name into its numeric index, the proposals filter maps
+   * "Approved" onto "ApprovedProposal").
+   */
   data: string[];
+  /**
+   * Displayed text for a value. Without it a value shows as itself, which is
+   * what every filter did before there was anything to translate. Must be
+   * total: it also receives the "All" entry, and it receives whatever a
+   * hand-edited URL put in `current`, so return the input unchanged for
+   * anything unrecognised rather than throwing or returning undefined.
+   */
+  renderLabel?: (value: string) => string;
+  /** Placeholder for the search box. Defaults to a generic prompt. */
+  placeholder?: string;
+  /**
+   * Shown when a search matches nothing. Passed in rather than built here,
+   * because this component has no translator and five of its callers load no
+   * namespace at all, so a `t()` in here would render raw keys on their pages.
+   */
+  notFoundLabel?: string;
   onClick?(selected: string): void;
   onChange?(value: string): void;
   current: string | undefined;
@@ -42,7 +103,11 @@ export interface IFilter {
 
 const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   title,
+  testId,
   data,
+  renderLabel,
+  placeholder,
+  notFoundLabel,
   onClick,
   onChange,
   current: initial,
@@ -121,24 +186,26 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     }
   };
 
-  const SelectorItem: React.FC<PropsWithChildren<IFilterItem>> = ({ item }) => {
-    const handleClick = () => {
+  /**
+   * The single place a value becomes text on screen. Everything else in this
+   * component works in values, so what a user reads and what the URL carries
+   * can never drift apart.
+   */
+  const labelOf = useCallback(
+    (value: string): string => (renderLabel ? renderLabel(value) : value),
+    [renderLabel],
+  );
+
+  const handleSelect = useCallback(
+    (value: string) => {
       if (onClick) {
-        onClick(item);
+        onClick(value);
       }
-      setSelected(item);
+      setSelected(value);
       closeDropDown();
-    };
-    return (
-      <Item
-        onClick={handleClick}
-        selected={item === selected}
-        data-testid="selector-item"
-      >
-        <p>{item}</p>
-      </Item>
-    );
-  };
+    },
+    [onClick, closeDropDown],
+  );
 
   const handleClear = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -154,15 +221,11 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   }: {
     target: { value: string };
   }) => {
-    if (value === '') {
-      setInputValue('');
-    } else {
-      // Allow dots for versions (v1.7.20) and common name chars.
-      const parsedValue = value.match(/[\w.\-\s]+/gi)?.[0];
-      if (parsedValue) {
-        setInputValue(parsedValue);
-      }
-    }
+    // Kept verbatim. It used to be stripped to `[\w.\-\s]`, which silently
+    // truncated at the first accented character and so made any non-ASCII
+    // label unsearchable. Nothing needs the sanitising: the match below is a
+    // literal `includes`, never a RegExp, so the input cannot be a pattern.
+    setInputValue(value);
     if (onChange) {
       onChange(value);
     }
@@ -176,9 +239,19 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     // Literal case-insensitive match — do not pass user input to RegExp
     // (dots in versions like v1.7.20 must not mean "any character").
     const needle = input.toLowerCase();
-    return getDataArray().filter(item =>
-      String(item).toLowerCase().includes(needle),
-    );
+    // Matched against what the user reads first, because that is what they
+    // type. The raw value stays searchable too, so a link or a habit built on
+    // the wire spelling keeps working.
+    // Both sides go through String() because `data: string[]` is not enforced
+    // at runtime: any caller building its list from optional API fields can
+    // hand this a hole, and one did before it started filtering at the
+    // source. The value side always had this guard; without it on the label
+    // side a keystroke throws mid-render, and there is no error boundary.
+    return getDataArray().filter(value => {
+      const haystack = String(value).toLowerCase();
+      const label = String(labelOf(value)).toLowerCase();
+      return label.includes(needle) || haystack.includes(needle);
+    });
   };
   const filteredArray = filterArrayByInput(inputValue);
 
@@ -196,24 +269,19 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     overFlow,
     onClick: () => closeDropDown(),
   };
-  const getPlaceholder = () => {
-    if (title === 'Coin' || title === 'Asset') {
-      return 'Type the token ID';
-    }
-    if (title === 'Contract') {
-      return 'Type the contract';
-    }
-    if (title === 'Name') {
-      return 'Search name…';
-    }
-    if (title === 'Version') {
-      return 'Search version…';
-    }
-    return 'Type to search…';
-  };
+  // The specific prompts used to be picked by comparing `title` against five
+  // English literals. That already failed silently on the assets and pools
+  // pages, whose title reads "Assets" while the branch tested for "Asset", and
+  // it would fail everywhere the moment titles are translated. Call sites now
+  // say what they want.
+  const searchPlaceholder = placeholder ?? 'Type to search…';
 
   return (
-    <Container maxWidth={maxWidth} open={!closed}>
+    <Container
+      maxWidth={maxWidth}
+      open={!closed}
+      data-testid={testId ? `filter-${testId}` : undefined}
+    >
       <span>{title}</span>
       <Content
         onMouseEnter={() => setDontBlur(true)}
@@ -225,10 +293,10 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
           <HiddenInput
             onBlur={() => !dontBlur && closeDropDown()}
             value={inputValue}
-            type={title !== 'Status' ? inputType : 'button'}
+            type={inputType}
             ref={focusRef}
             show={!closed}
-            placeholder={getPlaceholder()}
+            placeholder={searchPlaceholder}
             onChange={handleChange}
             isHiddenInput={isHiddenInput}
             aria-label={title ? `Search ${title}` : 'Search filter'}
@@ -237,7 +305,7 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
           />
         )}
         <span style={{ overflow: overFlow ? overFlow : 'hidden' }}>
-          {closed && selected ? selected : ''}
+          {closed && selected ? labelOf(selected) : ''}
         </span>
 
         {!hideAllOption && (
@@ -252,10 +320,18 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
         {!closed && (
           <SelectorContainer {...selectorProps}>
             {!filteredArray.length && !loading ? (
-              <span>{title} not found!</span>
+              <span>{notFoundLabel ?? `${title} not found!`}</span>
             ) : (
-              filteredArray.map((item, index) => (
-                <SelectorItem key={String(index)} item={item} />
+              filteredArray.map((value, index) => (
+                <SelectorItem
+                  // Values are not guaranteed unique: the validators filter
+                  // lists on-chain names, which nothing dedupes.
+                  key={`${index}-${value}`}
+                  value={value}
+                  label={labelOf(value)}
+                  isSelected={value === selected}
+                  onSelect={handleSelect}
+                />
               ))
             )}
             {loading && (

--- a/src/components/LinkWithDropdown/__tests__/index.test.tsx
+++ b/src/components/LinkWithDropdown/__tests__/index.test.tsx
@@ -1,0 +1,143 @@
+import theme from '@/styles/theme';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@/contexts/mobile', () => ({
+  useMobile: () => ({ isMobile: false, isTablet: false }),
+}));
+
+jest.mock('@/contexts/theme', () => ({
+  useTheme: () => ({ theme: { black: '#000' } }),
+}));
+
+// The Transfer button is built by a factory on the contract-modal context.
+jest.mock('@/contexts/contractModal', () => ({
+  useContractModal: () => ({
+    getInteractionsButtons: () => [
+      () => <button type="button">Transfer</button>,
+    ],
+  }),
+}));
+
+// qrcode.react does real encoding work; its presence is what matters here.
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: () => <svg data-testid="qr-code" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import LinkWithDropdown from '../index';
+
+const ADDRESS = 'klv1abc';
+
+const renderLink = (entity?: 'account' | 'transaction' | 'block') => {
+  const view = render(
+    <ThemeProvider theme={theme}>
+      <LinkWithDropdown
+        link="/account/klv1abc"
+        address={ADDRESS}
+        entity={entity}
+      >
+        <span>the link</span>
+      </LinkWithDropdown>
+    </ThemeProvider>,
+  );
+  return {
+    ...view,
+    wrapper: screen.getByText('the link').parentElement
+      ?.parentElement as HTMLElement,
+  };
+};
+
+const open = (wrapper: HTMLElement) => fireEvent.mouseEnter(wrapper);
+
+describe('LinkWithDropdown', () => {
+  describe('the menu is built only while it is open', () => {
+    it('renders none of it before the first hover', () => {
+      renderLink();
+
+      expect(screen.queryByText('Open in New Tab')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
+      expect(screen.getByText('the link')).toBeInTheDocument();
+    });
+
+    it('builds it on hover and tears it down again on leave', () => {
+      const { wrapper } = renderLink();
+
+      open(wrapper);
+      expect(screen.getByText('Open in New Tab')).toBeInTheDocument();
+
+      fireEvent.mouseLeave(wrapper);
+      expect(screen.queryByText('Open in New Tab')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('what the menu offers depends on what the link points at', () => {
+    it('offers the QR code and Transfer for a wallet address', () => {
+      const { wrapper } = renderLink('account');
+
+      open(wrapper);
+
+      expect(screen.getByText('Copy Address')).toBeInTheDocument();
+      expect(screen.getByText('QR Code')).toBeInTheDocument();
+      expect(screen.getByText('Transfer')).toBeInTheDocument();
+    });
+
+    it.each([
+      ['transaction' as const, 'Copy Transaction Hash'],
+      ['block' as const, 'Copy Block Number'],
+    ])(
+      'offers neither for a %s, whose value is not an address',
+      (entity, copyLabel) => {
+        // A QR of a block number scans to nothing, and a Transfer prefilled
+        // with a hash as its receiver cannot be submitted correctly. Both were
+        // offered for every link before the entity split.
+        const { wrapper } = renderLink(entity);
+
+        open(wrapper);
+
+        expect(screen.getByText(copyLabel)).toBeInTheDocument();
+        expect(screen.queryByText('QR Code')).not.toBeInTheDocument();
+        expect(screen.queryByText('Transfer')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('qr-code')).not.toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/src/components/LinkWithDropdown/__tests__/menu.test.ts
+++ b/src/components/LinkWithDropdown/__tests__/menu.test.ts
@@ -1,0 +1,74 @@
+import { LinkEntity, MENU_BY_ENTITY, menuForEntity } from '../menu';
+
+// Read off the table rather than restated by hand: a hand-kept list is still a
+// valid LinkEntity[] when it is missing a member, and __tests__ is excluded
+// from tsconfig, so the annotation would check nothing.
+const ALL_ENTITIES = Object.keys(MENU_BY_ENTITY) as LinkEntity[];
+
+describe('link hover menu per entity', () => {
+  it('covers the entities ExplorerLink can route to', () => {
+    expect(ALL_ENTITIES.sort()).toEqual(
+      [
+        'account',
+        'asset',
+        'block',
+        'proposal',
+        'smart-contract',
+        'transaction',
+        'validator',
+      ].sort(),
+    );
+  });
+
+  it('offers QR and Transfer only for wallet-format addresses', () => {
+    // A QR of a block number scans to nothing, and a Transfer prefilled with
+    // a transaction hash as its receiver is a form that cannot be submitted
+    // correctly. Both existed for every link before this split.
+    const addressLike = ALL_ENTITIES.filter(e => menuForEntity(e).addressLike);
+
+    expect(addressLike.sort()).toEqual(
+      ['account', 'smart-contract', 'validator'].sort(),
+    );
+  });
+
+  it('never names the copy action after something it does not copy', () => {
+    // The defect this replaced: every menu said "Copy Address", including on
+    // hashes and block numbers.
+    for (const entity of ALL_ENTITIES) {
+      const { copyLabel, copyInfo, addressLike } = menuForEntity(entity);
+
+      expect(copyLabel.startsWith('Copy ')).toBe(true);
+      expect(copyInfo).toBeTruthy();
+      if (!addressLike) {
+        expect(copyLabel).not.toContain('Address');
+        expect(copyInfo).not.toContain('Address');
+      }
+    }
+  });
+
+  it('reads as prose for a screen reader, not as an identifier', () => {
+    // ExplorerLink builds "Open <noun> in a new tab" from this. The union
+    // members are identifiers, so reading `type` straight out gave
+    // "Open smart-contract in a new tab".
+    for (const entity of ALL_ENTITIES) {
+      const { noun } = menuForEntity(entity);
+      expect(noun).toBeTruthy();
+      expect(noun).not.toContain('-');
+      expect(noun).toBe(noun.toLowerCase());
+    }
+  });
+
+  it.each([
+    ['transaction', 'Copy Transaction Hash', 'Transaction Hash'],
+    ['block', 'Copy Block Number', 'Block Number'],
+    ['asset', 'Copy Asset ID', 'Asset ID'],
+  ] as const)(
+    'names the %s action and its confirmation after the same thing',
+    (entity, label, info) => {
+      expect(menuForEntity(entity)).toMatchObject({
+        copyLabel: label,
+        copyInfo: info,
+      });
+    },
+  );
+});

--- a/src/components/LinkWithDropdown/index.tsx
+++ b/src/components/LinkWithDropdown/index.tsx
@@ -2,7 +2,7 @@ import { useContractModal } from '@/contexts/contractModal';
 import { useMobile } from '@/contexts/mobile';
 import { useTheme } from '@/contexts/theme';
 import { QRCodeSVG } from 'qrcode.react';
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useMemo, useState } from 'react';
 import {
   MdContentCopy,
   MdOpenInBrowser,
@@ -10,6 +10,7 @@ import {
   MdQrCode,
 } from 'react-icons/md';
 import Copy from '../Copy';
+import { LinkEntity, menuForEntity } from './menu';
 import {
   Dropdown,
   DropdownActionItem,
@@ -25,28 +26,51 @@ interface LinkWithDropdownProps {
   children: ReactNode;
   link: string;
   address: string;
+  /**
+   * What the link points at, which decides what the menu offers and what the
+   * copy action is called. Defaults to an account: the direct consumers wrap
+   * sender and receiver addresses.
+   */
+  entity?: LinkEntity;
 }
 
 const LinkWithDropdown: React.FC<LinkWithDropdownProps> = ({
   children,
   link,
   address,
+  entity = 'account',
 }) => {
+  const menu = menuForEntity(entity);
   const { isMobile } = useMobile();
   const [qrCodeDropDown, setQrCodeDropDown] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
+  /**
+   * The menu below was built for every link on the page and then hidden with
+   * CSS, QR code included. A transactions list puts three or four of these in
+   * each of its ten rows, so a page rendered dozens of QR codes nobody had
+   * asked to see. It is built while it is open and torn down after, which caps
+   * the cost at one menu instead of letting a pointer sweep across a column
+   * mount every one of them for the rest of the visit.
+   */
   const { theme } = useTheme();
   const { getInteractionsButtons } = useContractModal();
-  const [TransferButton] = getInteractionsButtons([
-    {
-      title: 'Transfer',
-      contractType: 'TransferContract',
-      buttonStyle: 'contextModal',
-      defaultValues: {
-        receiver: address,
-      },
-    },
-  ]);
+  // Memoised because the factory returns a freshly built component type on
+  // every call: without this the button is a different type each render, so
+  // React tears its node down and rebuilds it instead of updating it.
+  const [TransferButton] = useMemo(
+    () =>
+      getInteractionsButtons([
+        {
+          title: 'Transfer',
+          contractType: 'TransferContract',
+          buttonStyle: 'contextModal',
+          defaultValues: {
+            receiver: address,
+          },
+        },
+      ]),
+    [getInteractionsButtons, address],
+  );
 
   const handleMouseEnterDropdown = () => {
     setShowDropdown(true);
@@ -70,58 +94,70 @@ const LinkWithDropdown: React.FC<LinkWithDropdownProps> = ({
     >
       <div onClick={isMobile ? handleContextMenu : undefined}>{children}</div>
       <Dropdown show={showDropdown}>
-        {isMobile && (
-          <DropdownActionItemPadding>
-            <DropdownActionItem>
-              <DropdownLink href={link}>
-                <MdOpenInBrowser size={'1.2rem'} />
-                Open
-              </DropdownLink>
-            </DropdownActionItem>
-          </DropdownActionItemPadding>
+        {showDropdown && (
+          <>
+            {isMobile && (
+              <DropdownActionItemPadding>
+                <DropdownActionItem>
+                  <DropdownLink href={link}>
+                    <MdOpenInBrowser size={'1.2rem'} />
+                    Open
+                  </DropdownLink>
+                </DropdownActionItem>
+              </DropdownActionItemPadding>
+            )}
+            <DropdownActionItemPadding>
+              <DropdownActionItem>
+                <DropdownLink
+                  href={link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <MdOpenInNew size={'1.2rem'} />
+                  Open in New Tab
+                </DropdownLink>
+              </DropdownActionItem>
+            </DropdownActionItemPadding>
+            <DropdownActionItemPadding>
+              <Copy
+                info={menu.copyInfo}
+                data={address}
+                color={theme.black}
+                style={{ width: '100%' }}
+              >
+                <DropdownActionItem>
+                  <MdContentCopy size={'1.2rem'} />
+                  <p>{menu.copyLabel}</p>
+                </DropdownActionItem>
+              </Copy>
+            </DropdownActionItemPadding>
+            {menu.addressLike && (
+              <>
+                <DropdownActionItemPadding>
+                  <DropdownActionItem
+                    onClick={() => {
+                      setQrCodeDropDown(old => !old);
+                    }}
+                  >
+                    <MdQrCode size={'1.2rem'} />
+                    QR Code
+                    <QrCodeDropdown active={qrCodeDropDown}>
+                      <QrCodeDropdownContainer>
+                        <QrCodeTitle>View QR code</QrCodeTitle>
+                        <div>
+                          <QRCodeSVG height={165} width={165} value={address} />
+                        </div>
+                      </QrCodeDropdownContainer>
+                    </QrCodeDropdown>
+                  </DropdownActionItem>
+                </DropdownActionItemPadding>
+                <DropdownActionItemPadding>
+                  <TransferButton />
+                </DropdownActionItemPadding>
+              </>
+            )}
+          </>
         )}
-        <DropdownActionItemPadding>
-          <DropdownActionItem>
-            <DropdownLink href={link} target="_blank" rel="noopener noreferrer">
-              <MdOpenInNew size={'1.2rem'} />
-              Open in New Tab
-            </DropdownLink>
-          </DropdownActionItem>
-        </DropdownActionItemPadding>
-        <DropdownActionItemPadding>
-          <Copy
-            info="Wallet Address"
-            data={address}
-            color={theme.black}
-            style={{ width: '100%' }}
-          >
-            <DropdownActionItem>
-              <MdContentCopy size={'1.2rem'} />
-              <p>Copy Address</p>
-            </DropdownActionItem>
-          </Copy>
-        </DropdownActionItemPadding>
-        <DropdownActionItemPadding>
-          <DropdownActionItem
-            onClick={() => {
-              setQrCodeDropDown(old => !old);
-            }}
-          >
-            <MdQrCode size={'1.2rem'} />
-            QR Code
-            <QrCodeDropdown active={qrCodeDropDown}>
-              <QrCodeDropdownContainer>
-                <QrCodeTitle>View QR code</QrCodeTitle>
-                <div>
-                  <QRCodeSVG height={165} width={165} value={address} />
-                </div>
-              </QrCodeDropdownContainer>
-            </QrCodeDropdown>
-          </DropdownActionItem>
-        </DropdownActionItemPadding>
-        <DropdownActionItemPadding>
-          <TransferButton />
-        </DropdownActionItemPadding>
       </Dropdown>
     </LinkWrapper>
   );

--- a/src/components/LinkWithDropdown/menu.ts
+++ b/src/components/LinkWithDropdown/menu.ts
@@ -1,0 +1,88 @@
+import type { ExplorerLinkType } from '@/components/ExplorerLink';
+
+/**
+ * What the hover menu offers depends on what the link points at. The menu
+ * used to be identical for everything: hovering a transaction hash or a block
+ * number offered "Copy Address", a QR code of a value that is not an address,
+ * and a Transfer form prefilled with that value as the receiver.
+ *
+ * "Address-like" means the value is a wallet-format address someone could
+ * actually send funds to or scan: an account, a smart contract, or a
+ * validator link (which carries the owner's wallet address). Only those get
+ * the QR code and the Transfer entry.
+ */
+
+/**
+ * The same set ExplorerLink routes by, not a copy of it: a copy drifts, and
+ * only one direction of the drift would fail to compile. `import type` is
+ * erased, so this does not create a runtime cycle.
+ */
+export type LinkEntity = ExplorerLinkType;
+
+export interface ILinkMenuConfig {
+  /**
+   * How to say the thing in a sentence, for screen readers. The union members
+   * are identifiers ("smart-contract"), and reading one out as prose gives
+   * "Open smart-contract in a new tab".
+   */
+  noun: string;
+  /** Menu item text for the copy action. */
+  copyLabel: string;
+  /** Subject in the "… copied to clipboard" toast. */
+  copyInfo: string;
+  /** Whether the value is a wallet-format address (QR and Transfer apply). */
+  addressLike: boolean;
+}
+
+export const MENU_BY_ENTITY: Record<LinkEntity, ILinkMenuConfig> = {
+  account: {
+    noun: 'account',
+    copyLabel: 'Copy Address',
+    copyInfo: 'Wallet Address',
+    addressLike: true,
+  },
+  'smart-contract': {
+    noun: 'smart contract',
+    copyLabel: 'Copy Contract Address',
+    copyInfo: 'Contract Address',
+    addressLike: true,
+  },
+  validator: {
+    noun: 'validator',
+    // Qualified like the contract entry, and matching the wording the
+    // validators page already uses. These links render a validator's name,
+    // so the label is the only signal about what lands on the clipboard.
+    copyLabel: 'Copy Validator Address',
+    copyInfo: 'Validator Address',
+    addressLike: true,
+  },
+  transaction: {
+    noun: 'transaction',
+    // Named in full: the block page has its own field labelled "Hash", and
+    // renders this table underneath it.
+    copyLabel: 'Copy Transaction Hash',
+    copyInfo: 'Transaction Hash',
+    addressLike: false,
+  },
+  block: {
+    noun: 'block',
+    copyLabel: 'Copy Block Number',
+    copyInfo: 'Block Number',
+    addressLike: false,
+  },
+  asset: {
+    noun: 'asset',
+    copyLabel: 'Copy Asset ID',
+    copyInfo: 'Asset ID',
+    addressLike: false,
+  },
+  proposal: {
+    noun: 'proposal',
+    copyLabel: 'Copy Proposal ID',
+    copyInfo: 'Proposal ID',
+    addressLike: false,
+  },
+};
+
+export const menuForEntity = (entity: LinkEntity): ILinkMenuConfig =>
+  MENU_BY_ENTITY[entity];

--- a/src/components/LinkWithDropdown/styles.ts
+++ b/src/components/LinkWithDropdown/styles.ts
@@ -30,7 +30,11 @@ export const Dropdown = styled.div<DropdownProps>`
   border-radius: 12px;
   max-width: 15rem;
   @media screen and (max-width: ${props => props.theme.breakpoints.mobile}) {
-    width: 12rem;
+    /* A floor, not a fixed width. At this breakpoint the root font drops to
+       87.5%, so 12rem is 168px, and a label like "Copy Contract Address" needs
+       more than that. Fixed, the panel could not grow and the icon beside the
+       label was squeezed to nothing; the max-width above still caps it. */
+    min-width: 12rem;
     left: 0;
   }
 `;
@@ -103,6 +107,14 @@ export const DropdownActionItem = styled.div<{
   gap: 0.45rem;
   height: 2.5rem;
   font-size: 14px;
+  /* The copy item sits inside Copy's icon-button wrapper, which sets
+     line-height: 0 for its icon. A label that fits on one line hides that; one
+     that wraps renders both lines on the same baseline, glyphs interleaved. */
+  line-height: normal;
+  /* Menu items are actions, not prose: never wrap a label mid-phrase. The
+     panel grows to fit between its min-width and its max-width, so a longer
+     label widens the menu instead of being clipped or wrapped. */
+  white-space: nowrap;
   width: 100%;
   font-weight: 400;
   padding: 0.75rem;
@@ -110,6 +122,12 @@ export const DropdownActionItem = styled.div<{
   border-radius: 6px;
   cursor: pointer;
   user-select: none;
+
+  /* The label is the flexible part. Without this the icon is what a long
+     label pushes out, because it is the only shrinkable box in the row. */
+  > svg {
+    flex-shrink: 0;
+  }
 
   ${props =>
     props.active &&

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -297,7 +297,7 @@ const Table = <TCard,>({
           {!isMobile &&
             !isTablet &&
             (isLoading || (response?.items && response.items.length !== 0)) && (
-              <TableRow>
+              <TableRow data-testid="table-header">
                 {header?.map((item, index) => (
                   <HeaderItem
                     key={JSON.stringify(item)}

--- a/src/components/Tabs/Proposals/index.tsx
+++ b/src/components/Tabs/Proposals/index.tsx
@@ -69,6 +69,12 @@ const Proposals: React.FC<PropsWithChildren<IProposalsProps>> = ({
       onClick: selected => filterProposals(selected),
       current: router?.query?.status as string,
       isHiddenInput: false,
+      // Stated rather than inferred. Filter used to give this control a button
+      // input by comparing its title against the literal "Status", which this
+      // title only matches while the translation happens to be the English
+      // word: pt-BR already renders "Estado" and would have turned it into a
+      // free-text box.
+      inputType: 'button',
     },
   ];
 

--- a/src/components/Tabs/Transactions/index.tsx
+++ b/src/components/Tabs/Transactions/index.tsx
@@ -1,11 +1,10 @@
 import { PropsWithChildren } from 'react';
 import Table, { ITable } from '@/components/Table';
 import TransactionsFilters from '@/components/TransactionsFilters';
+import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import { transactionRowSections } from '@/pages/transactions';
 import { IInnerTableProps } from '@/types/index';
-import { transactionTableHeaders } from '@/utils/contracts';
 import React from 'react';
-import { useRouter } from 'next/router';
 
 interface ITransactionsProps {
   transactionsTableProps: IInnerTableProps;
@@ -13,20 +12,16 @@ interface ITransactionsProps {
 
 const Transactions: React.FC<PropsWithChildren<ITransactionsProps>> = props => {
   const transactionTableProps = props.transactionsTableProps;
-  const router = useRouter();
+  // This wrapper used to widen the heading list itself, by copying the base
+  // list and splicing "In/Out" in at index 3 whenever the URL named an
+  // account. It was the only one of the four call sites that did, which is
+  // why the other three rendered a heading short.
+  const header = useTransactionHeaders();
 
-  let updatedTransactionTableHeaders = [...transactionTableHeaders];
-
-  if (
-    router?.query?.account &&
-    !updatedTransactionTableHeaders.includes('In/Out')
-  ) {
-    updatedTransactionTableHeaders.splice(3, 0, 'In/Out');
-  }
   const tableProps: ITable = {
     ...transactionTableProps,
     rowSections: transactionRowSections,
-    header: updatedTransactionTableHeaders,
+    header,
     type: 'transactions',
     Filters: TransactionsFilters,
   };

--- a/src/components/TransactionsFilters/__tests__/index.test.tsx
+++ b/src/components/TransactionsFilters/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { buyType, contracts, status } from '@/configs/transactions';
 import theme from '@/styles/theme';
 import { setQueryAndRouter } from '@/utils';
 import { fireEvent, render, screen, within } from '@testing-library/react';
@@ -10,8 +11,14 @@ import { ThemeProvider } from 'styled-components';
 
 const routerQuery: Record<string, string> = {};
 
+let routerIsReady = true;
+
 jest.mock('next/router', () => ({
-  useRouter: () => ({ isReady: true, query: routerQuery, push: jest.fn() }),
+  useRouter: () => ({
+    isReady: routerIsReady,
+    query: routerQuery,
+    push: jest.fn(),
+  }),
 }));
 
 jest.mock('@/utils', () => ({
@@ -38,6 +45,40 @@ jest.mock('@/components/DateFilter', () => ({
 jest.mock('@/assets/icons', () => ({
   FilterArrowDown: () => <svg data-testid="arrow" />,
 }));
+
+// Resolved against the real English locale files rather than stubbed, so a key
+// this component asks for that nobody ever added fails the suite here instead
+// of rendering "transactions:Filters.Status" at a reader.
+jest.mock('next-i18next', () => {
+  const bundles: Record<string, Record<string, unknown>> = {
+    common: jest.requireActual('../../../../public/locales/en/common.json'),
+    transactions: jest.requireActual(
+      '../../../../public/locales/en/transactions.json',
+    ),
+  };
+
+  const translate = (
+    key: string,
+    options?: { defaultValue?: string },
+  ): string => {
+    const [namespace, path] = key.includes(':')
+      ? key.split(':')
+      : ['common', key];
+    const value = (path ?? '')
+      .split('.')
+      .reduce<unknown>(
+        (node, part) =>
+          node && typeof node === 'object'
+            ? (node as Record<string, unknown>)[part]
+            : undefined,
+        bundles[namespace],
+      );
+    if (typeof value === 'string') return value;
+    return options?.defaultValue ?? key;
+  };
+
+  return { useTranslation: () => ({ t: translate }) };
+});
 
 jest.mock('react-dom', () => {
   const actual = jest.requireActual('react-dom');
@@ -78,9 +119,10 @@ import TransactionsFilters from '../index';
 const mockedSetQuery = setQueryAndRouter as jest.Mock;
 
 /** Opens one filter and returns it, so options are picked within it: several
- * filters offer an option named "All". */
-const openFilter = (title: string): HTMLElement => {
-  const container = screen.getByText(title).parentElement as HTMLElement;
+ * filters offer an option named "All". Reached by its identifier rather than
+ * its displayed title, which is translated. */
+const openFilter = (testId: string): HTMLElement => {
+  const container = screen.getByTestId(`filter-${testId}`);
   fireEvent.click(
     container.querySelector('[data-testid="selector"]') as Element,
   );
@@ -107,7 +149,7 @@ describe('TransactionsFilters page reset', () => {
   it('returns to the first page when a status is picked from a later page', () => {
     renderFilters({ page: '3' });
 
-    const status = openFilter('Status');
+    const status = openFilter('status');
     fireEvent.click(within(status).getByText('Fail'));
 
     expect(mockedSetQuery).toHaveBeenCalledWith(
@@ -119,7 +161,7 @@ describe('TransactionsFilters page reset', () => {
   it('returns to the first page when a contract type is picked', () => {
     renderFilters({ page: '4' });
 
-    const contract = openFilter('Contract');
+    const contract = openFilter('contract');
     fireEvent.click(within(contract).getByText('Transfer'));
 
     // Transfer is index 0 in ContractsIndex, and the value is what makes this
@@ -133,7 +175,7 @@ describe('TransactionsFilters page reset', () => {
   it('drops the filter key but still returns to the first page on All', () => {
     renderFilters({ page: '3', status: 'Fail' });
 
-    const status = openFilter('Status');
+    const status = openFilter('status');
     fireEvent.click(within(status).getByText('All'));
 
     const [query] = mockedSetQuery.mock.calls[0];
@@ -144,9 +186,110 @@ describe('TransactionsFilters page reset', () => {
   it('does not navigate when the current value is picked again', () => {
     renderFilters({ page: '3', status: 'Success' });
 
-    const status = openFilter('Status');
+    const status = openFilter('status');
     fireEvent.click(within(status).getByText('Success'));
 
     expect(mockedSetQuery).not.toHaveBeenCalled();
   });
+});
+
+describe('TransactionsFilters first paint', () => {
+  afterEach(() => {
+    routerIsReady = true;
+  });
+
+  it('renders the filters before the router is ready, identically on both sides', () => {
+    // This branch introduced, and then removed, a hydration mismatch here:
+    // the list was built during render while still gated on router.isReady,
+    // which the server answers false and the client's first render can answer
+    // true. Every other test in this suite mocks isReady true, so putting the
+    // gate back would go green without this.
+    routerIsReady = false;
+
+    renderFilters({});
+
+    expect(screen.getByTestId('filter-status')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-contract')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-coin')).toBeInTheDocument();
+  });
+});
+
+describe('TransactionsFilters Buy Type', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // The only conditional control in the bar. Its condition ran in every other
+  // test but was never taken, so the filter itself was never constructed.
+  it('appears only once the contract type is Buy', () => {
+    renderFilters({ type: '17' });
+    expect(screen.getByTestId('filter-buyType')).toBeInTheDocument();
+  });
+
+  it('stays away for any other contract type', () => {
+    renderFilters({ type: '0' });
+    expect(screen.queryByTestId('filter-buyType')).not.toBeInTheDocument();
+  });
+
+  it('writes the picked buy type and returns to the first page', () => {
+    renderFilters({ type: '17', page: '5' });
+
+    const buyType = openFilter('buyType');
+    fireEvent.click(within(buyType).getByText('ITOBuy'));
+
+    expect(mockedSetQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ buyType: 'ITOBuy', page: '1' }),
+      expect.anything(),
+    );
+  });
+
+  it('drops the buy type when the contract type moves away from Buy', () => {
+    renderFilters({ type: '17', buyType: 'ITOBuy' });
+
+    const contract = openFilter('contract');
+    fireEvent.click(within(contract).getByText('Transfer'));
+
+    const [query] = mockedSetQuery.mock.calls[0];
+    expect(query).not.toHaveProperty('buyType');
+  });
+});
+
+describe('TransactionsFilters translation coverage', () => {
+  // A value with no key still renders, because the lookup falls back to the
+  // value itself. That is the right behaviour at runtime and the wrong thing
+  // to find out from a user, so the gap is caught here instead.
+  const bundle = jest.requireActual(
+    '../../../../public/locales/en/transactions.json',
+  );
+
+  it.each([
+    ['Contracts', contracts],
+    ['Status', status],
+    ['BuyTypes', buyType],
+  ])('has an English label for every %s value', (section, values) => {
+    const missing = (values as string[]).filter(
+      value => typeof bundle[section]?.[value] !== 'string',
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it.each([
+    ['Contracts', contracts],
+    ['Status', status],
+    ['BuyTypes', buyType],
+  ])(
+    'keeps the English %s labels identical to the values they replace',
+    (section, values) => {
+      // Only `en` is an active locale, so any drift here is a visible copy
+      // change smuggled in under a translation, not a translation. It has to
+      // cover all three lists: an earlier version checked only the contract
+      // names, so renaming "MarketBuy" to "Market Buy" passed.
+      const drifted = (values as string[]).filter(
+        value => bundle[section]?.[value] !== value,
+      );
+
+      expect(drifted).toEqual([]);
+    },
+  );
 });

--- a/src/components/TransactionsFilters/index.tsx
+++ b/src/components/TransactionsFilters/index.tsx
@@ -4,9 +4,10 @@ import { buyType, contracts, status } from '@/configs/transactions';
 import { IAsset } from '@/types';
 import { setQueryAndRouter } from '@/utils';
 import { useFetchPartial } from '@/utils/hooks';
+import { useTranslation } from 'next-i18next';
 import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { ContractsIndex } from '../../types/contracts';
 import DateFilter from '../DateFilter';
 import { FilterContainer } from './styles';
@@ -15,15 +16,21 @@ interface ITransactionsFilters {
   disabledInput?: boolean;
 }
 
+/**
+ * The entry Filter prepends to every list, and the value `handleSelected`
+ * recognises as "drop this filter". It is a value like any other, so it must
+ * survive translation untouched.
+ */
+const ALL_VALUE = 'All';
+
 const TransactionsFilters: React.FC<
   PropsWithChildren<ITransactionsFilters>
 > = ({ disabledInput }) => {
   const router = useRouter();
+  const { t } = useTranslation(['common', 'transactions']);
   const [query, setLocalQuery] = useState<NextParsedUrlQuery>({});
   const [assets, fetchPartialAsset, loading, setLoading] =
     useFetchPartial<IAsset>('assets', 'assets/list', 'assetId');
-
-  const [filters, setFilters] = useState<IFilter[]>([]);
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -39,7 +46,7 @@ const TransactionsFilters: React.FC<
     // fewer pages than the one being viewed, which would otherwise leave the
     // table on an empty page with no pagination control to get back.
     const updatedQuery: NextParsedUrlQuery = { ...query, page: String(1) };
-    if (selected === 'All') {
+    if (selected === ALL_VALUE) {
       delete updatedQuery[filterType];
       if (filterType === 'type') {
         delete updatedQuery['buyType'];
@@ -61,55 +68,103 @@ const TransactionsFilters: React.FC<
     }
   };
 
-  useEffect(() => {
-    const filters: IFilter[] = [
-      {
-        title: 'Coin',
-        data: assets.map(asset => asset?.assetId),
-        onClick: selected => {
-          handleSelected(selected, 'asset');
-        },
-        onChange: async value => {
-          setLoading(true);
-          await fetchPartialAsset(value);
-        },
-        current: query.asset as string | undefined,
-        loading,
-        disabledInput,
-      },
-      {
-        title: 'Status',
-        data: status,
-        onClick: selected => handleSelected(selected, 'status'),
-        current: query.status as string | undefined,
-        isHiddenInput: false,
-      },
-      {
-        title: 'Contract',
-        data: contracts,
-        onClick: selected => handleSelected(selected, 'type'),
-        current: getContractName(),
-      },
-    ];
-    if (getContractName() === 'Buy') {
-      filters.push({
-        title: 'Buy Type',
-        data: buyType,
-        inputType: 'button',
-        onClick: selected => handleSelected(selected, 'buyType'),
-        current: query.buyType as string | undefined,
-      });
-    }
+  /**
+   * A value's label, with the value itself as the fallback. Every list here
+   * also carries the "All" sentinel, and `current` can be anything a
+   * hand-edited URL put there, so this has to answer for inputs that have no
+   * key rather than rendering `transactions:Status.whatever` at the reader.
+   */
+  const labelIn = useCallback(
+    (section: string) =>
+      (value: string): string =>
+        value === ALL_VALUE
+          ? t('common:Buttons.All')
+          : t(`transactions:${section}.${value}`, { defaultValue: value }),
+    [t],
+  );
 
-    setFilters(filters);
-  }, [query, assets, loading]);
+  // Built during render rather than pushed into state from an effect. As state
+  // it was a snapshot taken when `query`, `assets` or `loading` last changed,
+  // so every label produced by `t` would have frozen at whatever the
+  // translator returned at that moment.
+  const filters: IFilter[] = [
+    {
+      title: t('transactions:Filters.Coin'),
+      testId: 'coin',
+      notFoundLabel: t('transactions:Filters.NotFound'),
+      placeholder: t('transactions:Filters.CoinPlaceholder'),
+      // Filtered at the source rather than defended against downstream: the
+      // optional chain says a null-ish row is possible, and such an entry
+      // renders as an empty option a reader can select.
+      data: assets
+        .map(asset => asset?.assetId)
+        .filter((assetId): assetId is string => typeof assetId === 'string'),
+      // Asset ids have no keys, so this only translates the "All" entry. Without
+      // it this is the one filter here whose sentinel stays English.
+      renderLabel: labelIn('Coin'),
+      onClick: selected => {
+        handleSelected(selected, 'asset');
+      },
+      onChange: async value => {
+        setLoading(true);
+        await fetchPartialAsset(value);
+      },
+      current: query.asset as string | undefined,
+      loading,
+      disabledInput,
+    },
+    {
+      title: t('transactions:Filters.Status'),
+      testId: 'status',
+      notFoundLabel: t('transactions:Filters.NotFound'),
+      data: status,
+      renderLabel: labelIn('Status'),
+      onClick: selected => handleSelected(selected, 'status'),
+      current: query.status as string | undefined,
+      isHiddenInput: false,
+      // See Tabs/Proposals: this used to be inferred from the title reading
+      // exactly "Status".
+      inputType: 'button',
+    },
+    {
+      title: t('transactions:Filters.Contract'),
+      testId: 'contract',
+      notFoundLabel: t('transactions:Filters.NotFound'),
+      placeholder: t('transactions:Filters.ContractPlaceholder'),
+      data: contracts,
+      renderLabel: labelIn('Contracts'),
+      onClick: selected => handleSelected(selected, 'type'),
+      current: getContractName(),
+    },
+  ];
+  if (getContractName() === 'Buy') {
+    filters.push({
+      title: t('transactions:Filters.BuyType'),
+      testId: 'buyType',
+      notFoundLabel: t('transactions:Filters.NotFound'),
+      data: buyType,
+      renderLabel: labelIn('BuyTypes'),
+      inputType: 'button',
+      onClick: selected => handleSelected(selected, 'buyType'),
+      current: query.buyType as string | undefined,
+    });
+  }
 
   return (
     <FilterContainer>
-      {router.isReady &&
-        filters.map(filter => (
-          <Filter key={`${filter?.title}-${filter?.current}`} {...filter} />
-        ))}
+      {/* Not gated on router.isReady. Next answers that differently on each
+          side for a statically generated page: false while rendering on the
+          server, true on the client's first render. While the filter list was
+          state seeded with [], both sides rendered nothing and the difference
+          stayed hidden; built during render it made /block/<n> hydrate against
+          a tree that had no filters in it. Nothing here reads router.query
+          directly, only the local `query` copy, which is {} on both sides
+          until the effect runs. */}
+      {filters.map(filter => (
+        // Keyed on the identifier, not the title: a translated title would
+        // otherwise change the key and remount the control.
+        <Filter key={`${filter?.testId}-${filter?.current}`} {...filter} />
+      ))}
       <DateFilter />
     </FilterContainer>
   );

--- a/src/components/TransactionsList/__tests__/columns.test.ts
+++ b/src/components/TransactionsList/__tests__/columns.test.ts
@@ -1,0 +1,96 @@
+import {
+  getTransactionColumns,
+  getTransactionHeaders,
+  showsInOut,
+} from '../columns';
+
+const BASE_KEYS = ['hash', 'blockFees', 'fromTo', 'type', 'misc'];
+
+describe('transaction table columns', () => {
+  it('lists the five base columns in order', () => {
+    expect(getTransactionColumns({ showInOut: false }).map(c => c.key)).toEqual(
+      BASE_KEYS,
+    );
+  });
+
+  it('puts In/Out directly after From/To when the list is scoped to an account', () => {
+    expect(getTransactionColumns({ showInOut: true }).map(c => c.key)).toEqual([
+      'hash',
+      'blockFees',
+      'fromTo',
+      'inOut',
+      'type',
+      'misc',
+    ]);
+  });
+
+  it('gives every column a non-empty heading, in both shapes', () => {
+    // Only that much. `getTransactionHeaders` is defined as this map, so
+    // asserting the two match would restate the implementation. What the
+    // headings and the cells actually agreeing is worth is enforced end to
+    // end, in cypress/e2e/pages/transactions.cy.ts, since Jest cannot import
+    // the module the cells live in.
+    for (const showInOut of [false, true]) {
+      const headers = getTransactionHeaders({ showInOut });
+
+      expect(headers).toHaveLength(getTransactionColumns({ showInOut }).length);
+      expect(headers.every(header => header.length > 0)).toBe(true);
+    }
+  });
+
+  it.each([false, true])(
+    'hands out a fresh array, so a caller cannot reorder it for everyone (showInOut: %s)',
+    showInOut => {
+      // Reversing the branch under test is the point: an earlier version of
+      // this test reversed the copying branch and asserted on the other one,
+      // so it passed while the base list really was shared by reference.
+      getTransactionColumns({ showInOut }).reverse();
+
+      expect(
+        getTransactionColumns({ showInOut: false }).map(c => c.key),
+      ).toEqual(BASE_KEYS);
+    },
+  );
+
+  describe('showsInOut', () => {
+    // The direction only means something where the request layer narrows the
+    // list to that account, which is where `account` is renamed to `address`.
+    // Measured against the live API: `?account=` leaves the record count
+    // untouched, `?address=` cuts it by four orders of magnitude.
+    it.each([['/transactions'], ['/account/[account]']])(
+      'is true on %s, which scopes by account',
+      pathname => {
+        expect(showsInOut({ pathname, query: { account: 'klv1abc' } })).toBe(
+          true,
+        );
+      },
+    );
+
+    it.each([
+      ['/asset/[asset]'],
+      ['/asset/[asset]/[nonce]'],
+      ['/block/[block]'],
+    ])('is false on %s, where the account is ignored by the API', pathname => {
+      expect(showsInOut({ pathname, query: { account: 'klv1abc' } })).toBe(
+        false,
+      );
+    });
+
+    it.each([
+      ['absent', undefined],
+      ['empty', ''],
+      // Next gives an array when a parameter appears twice. The direction is
+      // decided by comparing a sender against one account, which an array can
+      // never equal, so every row would read "In".
+      ['repeated', ['klv1abc', 'klv1def']],
+    ])('is false when the account is %s', (_label, account) => {
+      expect(
+        showsInOut({ pathname: '/transactions', query: { account } }),
+      ).toBe(false);
+    });
+
+    it('is false when there is no router information at all', () => {
+      expect(showsInOut({})).toBe(false);
+    });
+  });
+});

--- a/src/components/TransactionsList/__tests__/useTransactionHeaders.test.tsx
+++ b/src/components/TransactionsList/__tests__/useTransactionHeaders.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const routerQuery: Record<string, string | string[] | undefined> = {};
+
+let routerPathname = '/transactions';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    pathname: routerPathname,
+    query: routerQuery,
+  }),
+}));
+
+// The installed testing-library still calls the removed ReactDOM.render; every
+// component suite in this repo carries the same createRoot shim.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { useTransactionHeaders } from '../useTransactionHeaders';
+
+/** Renders the headings the hook returns, one per element. */
+const Probe: React.FC = () => (
+  <ul>
+    {useTransactionHeaders().map(header => (
+      <li key={header} data-testid="header">
+        {header}
+      </li>
+    ))}
+  </ul>
+);
+
+const headersFor = (
+  query: Record<string, string | string[] | undefined>,
+  pathname = '/transactions',
+) => {
+  routerPathname = pathname;
+  Object.keys(routerQuery).forEach(key => delete routerQuery[key]);
+  Object.assign(routerQuery, query);
+
+  render(<Probe />);
+
+  return screen.getAllByTestId('header').map(node => node.textContent);
+};
+
+describe('useTransactionHeaders', () => {
+  it('gives the five base headings when the list is not scoped', () => {
+    expect(headersFor({})).toEqual([
+      'Transaction Hash',
+      'Block/Fees',
+      'From/To',
+      'Type',
+      'Misc',
+    ]);
+  });
+
+  it('adds In/Out after From/To when the URL names an account', () => {
+    // This suite only renders the headings hook. That the cells line up with
+    // them is enforced end to end, not here.
+    expect(headersFor({ account: 'klv1abc' })).toEqual([
+      'Transaction Hash',
+      'Block/Fees',
+      'From/To',
+      'In/Out',
+      'Type',
+      'Misc',
+    ]);
+  });
+
+  it('ignores a repeated account parameter, which names no single account', () => {
+    expect(headersFor({ account: ['klv1abc', 'klv1def'] })).toHaveLength(5);
+  });
+
+  it('leaves the column out on a route the account never filters', () => {
+    // The asset page forwards `account` to the API, which ignores it, so the
+    // list still holds everyone. A direction there would read "In" for
+    // essentially every row.
+    expect(headersFor({ account: 'klv1abc' }, '/asset/[asset]')).toHaveLength(
+      5,
+    );
+  });
+
+  it('ignores an empty account parameter', () => {
+    expect(headersFor({ account: '' })).toHaveLength(5);
+  });
+});

--- a/src/components/TransactionsList/columns.ts
+++ b/src/components/TransactionsList/columns.ts
@@ -1,0 +1,113 @@
+import { ParsedUrlQuery } from 'querystring';
+
+/**
+ * The column layout of the shared transactions table, in one place.
+ *
+ * It used to be in two: `transactionTableHeaders` gave the headings, and
+ * `transactionRowSections` built the cells and spliced an extra one in at
+ * index 3 when the list was scoped to an account. Only one of the four call
+ * sites widened its heading list to match, so `/transactions?account=…`,
+ * `/asset/<id>?account=…` and `/asset/<id>/<nonce>?account=…` rendered five
+ * headings above six cells and every column from the fourth onwards sat under
+ * the wrong one.
+ *
+ * Both now come from `getTransactionColumns`, so they cannot disagree: a
+ * column is one entry, carrying its key and its heading together.
+ */
+
+export type TransactionColumnKey =
+  | 'hash'
+  | 'blockFees'
+  | 'fromTo'
+  | 'inOut'
+  | 'type'
+  | 'misc';
+
+export interface ITransactionColumn {
+  key: TransactionColumnKey;
+  /** Heading text. Not translated here: see the note below. */
+  header: string;
+}
+
+/**
+ * Headings are still the English literals they have always been. They are
+ * safe to translate, unlike the filter values, because no route passes
+ * `sortableColumns` for this table and so no heading doubles as a sort key
+ * (issue #678 blocks the holders table for exactly that reason). Doing it
+ * belongs with the work that moves the cells themselves, not here, where the
+ * point is that the two lists stop drifting apart.
+ *
+ * A cell's `span` is not repeated here. It lives on the `IRowSection` the row
+ * builder returns, which is the only place `Table` reads it from; a copy here
+ * would be a second source of truth that nothing checks.
+ */
+const BASE_COLUMNS: ITransactionColumn[] = [
+  { key: 'hash', header: 'Transaction Hash' },
+  { key: 'blockFees', header: 'Block/Fees' },
+  { key: 'fromTo', header: 'From/To' },
+  { key: 'type', header: 'Type' },
+  { key: 'misc', header: 'Misc' },
+];
+
+const IN_OUT_COLUMN: ITransactionColumn = {
+  key: 'inOut',
+  header: 'In/Out',
+};
+
+/** Position of the In/Out column, directly after From/To. */
+const IN_OUT_INDEX = 3;
+
+/**
+ * The routes whose request layer actually narrows the list to one account.
+ * Only `requestTransactionsDefault` renames `account` to `address`, and
+ * `address` is the parameter the API honours: measured against the live API,
+ * `?account=<addr>` leaves the total record count untouched while
+ * `?address=<addr>` cuts it from 58.5M to about 12k.
+ *
+ * That distinction is the whole reason this is not simply "is there an account
+ * in the URL". On `/asset/<id>?account=<addr>` the account rides along, is
+ * ignored by the API, and the list still holds everyone's transactions. A
+ * direction column there would compare each row's sender against an account
+ * the list was never filtered by, and read "In" for essentially every row.
+ */
+const ACCOUNT_SCOPED_PATHNAMES = new Set([
+  '/transactions',
+  '/account/[account]',
+]);
+
+export interface ITransactionColumnsContext {
+  /**
+   * True when the list is narrowed to one account, which is the only case
+   * where a transaction has a direction worth showing.
+   */
+  showInOut: boolean;
+}
+
+export const getTransactionColumns = ({
+  showInOut,
+}: ITransactionColumnsContext): ITransactionColumn[] => {
+  const columns = [...BASE_COLUMNS];
+  if (showInOut) columns.splice(IN_OUT_INDEX, 0, IN_OUT_COLUMN);
+  return columns;
+};
+
+export const getTransactionHeaders = (
+  context: ITransactionColumnsContext,
+): string[] => getTransactionColumns(context).map(column => column.header);
+
+/**
+ * Whether this list carries a direction. Both the headings and the cells ask
+ * this, so they agree about the column's existence by construction.
+ */
+export const showsInOut = (router: {
+  pathname?: string;
+  query?: ParsedUrlQuery;
+}): boolean => {
+  if (!ACCOUNT_SCOPED_PATHNAMES.has(router?.pathname ?? '')) return false;
+
+  const account = router?.query?.account;
+  // Next hands back an array when a parameter repeats. The direction is
+  // decided by comparing a sender against one account, which an array can
+  // never equal, so the column would read "In" for every row.
+  return typeof account === 'string' && account !== '';
+};

--- a/src/components/TransactionsList/useTransactionHeaders.ts
+++ b/src/components/TransactionsList/useTransactionHeaders.ts
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router';
+import { getTransactionHeaders, showsInOut } from './columns';
+
+/**
+ * Column headings for the shared transactions table.
+ *
+ * A hook rather than a constant because whether the In/Out column exists
+ * depends on the URL, and it has to be decided from the same place
+ * `transactionRowSections` decides it. Four call sites each answered that
+ * question themselves, three of them by not asking it at all.
+ */
+export const useTransactionHeaders = (): string[] => {
+  const router = useRouter();
+
+  return getTransactionHeaders({ showInOut: showsInOut(router) });
+};

--- a/src/pages/account/[account].tsx
+++ b/src/pages/account/[account].tsx
@@ -772,7 +772,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   const props = await serverSideTranslations(
     locale,
-    ['common', 'accounts'],
+    ['common', 'accounts', 'transactions'],
     nextI18nextConfig,
     ['en'],
   );

--- a/src/pages/asset/[asset].tsx
+++ b/src/pages/asset/[asset].tsx
@@ -2,6 +2,7 @@ import { AssetSummary } from '@/components/Asset/AssetSummary';
 import { AssetTabs } from '@/components/Asset/AssetTabs';
 import Tabs, { ITabs } from '@/components/NewTabs';
 import Table, { ITable } from '@/components/Table';
+import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import Holders from '@/components/Tabs/Holders';
 import TransactionsFilters from '@/components/TransactionsFilters';
 import api from '@/services/api';
@@ -9,7 +10,6 @@ import { assetCall, assetPoolCall, ITOCall } from '@/services/requests/asset';
 import { AssetTypeString } from '@/types/assets';
 import { IAssetPage } from '@/types/index';
 import { setQueryAndRouter } from '@/utils';
-import { transactionTableHeaders } from '@/utils/contracts';
 import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
 import { AssetPageContainer } from '@/views/assets';
 import { GetServerSideProps } from 'next';
@@ -30,6 +30,7 @@ import { transactionRowSections } from '../transactions';
 const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
   const router = useRouter();
   const { t } = useTranslation(['common', 'assets']);
+  const transactionHeaders = useTransactionHeaders();
 
   // Unlike the two lookups below, assetCall answers undefined only when the
   // request failed, so it keeps React Query's retry rather than reporting a
@@ -107,7 +108,7 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
 
   const tableProps: ITable = {
     type: 'transactions',
-    header: transactionTableHeaders,
+    header: transactionHeaders,
     rowSections: transactionRowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
@@ -166,7 +167,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   const props = await serverSideTranslations(
     locale,
-    ['common', 'assets', 'table'],
+    ['common', 'assets', 'table', 'transactions'],
     nextI18nextConfig,
     ['en'],
   );

--- a/src/pages/asset/[asset]/[nonce].tsx
+++ b/src/pages/asset/[asset]/[nonce].tsx
@@ -3,12 +3,12 @@ import { NonFungibleView } from '@/components/Asset/NonFungibleView';
 import { SemiFungibleView } from '@/components/Asset/SemiFungibleView';
 import Title from '@/components/Layout/Title';
 import { ITable } from '@/components/Table';
+import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import TransactionsFilters from '@/components/TransactionsFilters';
 import { transactionRowSections } from '@/pages/transactions';
 import api from '@/services/api';
 import { requestNonceDetails } from '@/services/requests/asset/nonce';
 import { Container, Header, SpacedContainer } from '@/styles/common';
-import { transactionTableHeaders } from '@/utils/contracts';
 import { getParsedTransactionPrecision } from '@/utils/precisionFunctions';
 import { GetServerSideProps } from 'next';
 import { useTranslation } from 'next-i18next';
@@ -21,6 +21,7 @@ import { AssetTitle } from '@/components/Asset/AssetSummary/AssetTitle';
 
 const AssetNonce: React.FC<PropsWithChildren> = () => {
   const { t } = useTranslation(['common', 'assets']);
+  const transactionHeaders = useTransactionHeaders();
   const router = useRouter();
   const assetId = router.query.asset as string;
   const nonceValue = router.query.nonce as string;
@@ -59,7 +60,7 @@ const AssetNonce: React.FC<PropsWithChildren> = () => {
 
   const tableProps: ITable = {
     type: 'transactions',
-    header: transactionTableHeaders,
+    header: transactionHeaders,
     rowSections: transactionRowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
@@ -94,7 +95,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 }) => {
   const props = await serverSideTranslations(
     locale,
-    ['common', 'assets'],
+    ['common', 'assets', 'table', 'transactions'],
     nextI18nextConfig,
     ['en'],
   );

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -95,6 +95,10 @@ const AssetsFilters: React.FC<PropsWithChildren> = () => {
   const filters: IFilter[] = [
     {
       title: `${t('common:Titles.Assets')}`,
+      // Stated rather than inferred from the title. Filter used to match on
+      // `title === 'Asset'`, which this never was, so this box has been showing
+      // the generic prompt.
+      placeholder: 'Type the token ID',
       data: filterAssets.map(asset => asset.assetId),
       onClick: value => handleSelected(value, 'asset'),
       onChange: async value => {

--- a/src/pages/block/[block].tsx
+++ b/src/pages/block/[block].tsx
@@ -28,6 +28,8 @@ import {
   TooltipContainer,
 } from '@/views/blocks/detail';
 import { GetStaticPaths, GetStaticProps } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import nextI18nextConfig from '../../../next-i18next.config';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
@@ -347,6 +349,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps<IBlockPage> = async ({
   params,
+  locale = 'en',
 }) => {
   const props: IBlockPage = {
     block: {} as IBlock,
@@ -372,8 +375,18 @@ export const getStaticProps: GetStaticProps<IBlockPage> = async ({
 
   props.block = block.data.block;
 
+  // The page loaded no translation namespace at all, so every `t()` reachable
+  // from it, including the ones inside the shared transactions table and its
+  // filter bar, returned its own key.
+  const translations = await serverSideTranslations(
+    locale,
+    ['common', 'transactions'],
+    nextI18nextConfig,
+    ['en'],
+  );
+
   return {
-    props,
+    props: { ...props, ...translations },
   };
 };
 

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -4,6 +4,12 @@ import Title from '@/components/Layout/Title';
 import LinkWithDropdown from '@/components/LinkWithDropdown';
 import { MultiContractToolTip } from '@/components/MultiContractToolTip';
 import Table, { ITable } from '@/components/Table';
+import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
+import {
+  getTransactionColumns,
+  showsInOut,
+  TransactionColumnKey,
+} from '@/components/TransactionsList/columns';
 import {
   CustomFieldWrapper,
   InOutSpan,
@@ -39,7 +45,6 @@ import {
   contractTypes,
   filteredSections,
   getLabelForTableField,
-  transactionTableHeaders,
 } from '@/utils/contracts';
 import { capitalizeString } from '@/utils/convertString';
 import { findReceipt } from '@/utils/findKey';
@@ -48,9 +53,13 @@ import { KLV_PRECISION } from '@/utils/globalVariables';
 import { parseAddress } from '@/utils/parseValues';
 import { getPrecision } from '@/utils/precisionFunctions';
 import { TXType } from '@klever/connect';
+import { GetServerSideProps } from 'next';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from 'next/link';
 import { NextRouter, useRouter } from 'next/router';
 import React, { PropsWithChildren } from 'react';
+import nextI18nextConfig from '../../../next-i18next.config';
 
 interface IRequestTxQuery {
   asset?: string;
@@ -264,8 +273,8 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
 
   const customFields = getCustomFields(contract, receipts, precision, data);
 
-  const sections: IRowSection[] = [
-    {
+  const sectionByColumn: Record<TransactionColumnKey, IRowSection> = {
+    hash: {
       element: props => (
         <DoubleRow {...props} key={hash}>
           <ExplorerLink
@@ -288,7 +297,7 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
       ),
       span: 2,
     },
-    {
+    blockFees: {
       element: props => (
         <DoubleRow {...props} key={blockNum}>
           <ExplorerLink type="block" value={String(blockNum || 0)} compact />
@@ -299,7 +308,7 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
       ),
       span: 1,
     },
-    {
+    fromTo: {
       element: props => (
         <DoubleRow {...props} key={sender}>
           {mobileAddressSectionElement(sender)}
@@ -308,8 +317,23 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
       ),
       span: 1,
     },
-
-    {
+    inOut: {
+      element: props => (
+        <DoubleRow {...props} key={inOrOut}>
+          <CenteredRow>
+            {contractType === 'TransferContractType' ? (
+              <InOutSpan status={inOrOut === 'In' ? 'success' : 'pending'}>
+                {inOrOut}
+              </InOutSpan>
+            ) : (
+              <InOutSpan status={'icon'}>- -</InOutSpan>
+            )}
+          </CenteredRow>
+        </DoubleRow>
+      ),
+      span: 1,
+    },
+    type: {
       element: props =>
         contractType === 'Multi contract' ? (
           <DoubleRow {...props}>
@@ -344,7 +368,7 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
         ),
       span: 1,
     },
-    {
+    misc: {
       element: props =>
         contractType ? (
           <DoubleRow {...props}>
@@ -374,39 +398,23 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
         ),
       span: 1,
     },
-  ];
-
-  const inOutRow: IRowSection = {
-    element: props => (
-      <DoubleRow {...props} key={inOrOut}>
-        <CenteredRow>
-          {contractType === 'TransferContractType' ? (
-            <InOutSpan status={inOrOut === 'In' ? 'success' : 'pending'}>
-              {inOrOut}
-            </InOutSpan>
-          ) : (
-            <InOutSpan status={'icon'}>- -</InOutSpan>
-          )}
-        </CenteredRow>
-      </DoubleRow>
-    ),
-    span: 1,
   };
 
-  if (router?.query?.account) {
-    sections.splice(3, 0, inOutRow);
-    return sections;
-  }
-
-  return sections;
+  // Ordered by the column list rather than assembled here, so the cells and
+  // the headings above them come from the same decision.
+  return getTransactionColumns({ showInOut: showsInOut(router) }).map(
+    column => sectionByColumn[column.key],
+  );
 };
 
 const Transactions: React.FC<PropsWithChildren> = () => {
   const router = useRouter();
+  const { t } = useTranslation(['common', 'transactions']);
+  const header = useTransactionHeaders();
 
   const tableProps: ITable = {
     type: 'transactions',
-    header: transactionTableHeaders,
+    header,
     rowSections: transactionRowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactionsDefault(page, limit, router),
@@ -416,12 +424,34 @@ const Transactions: React.FC<PropsWithChildren> = () => {
   return (
     <Container>
       <Header>
-        <Title title="Transactions" Icon={Icon} />
+        <Title title={t('common:Titles.Transactions')} Icon={Icon} />
       </Header>
 
       <Table {...tableProps} />
     </Container>
   );
+};
+
+/**
+ * The page carried no data method at all, so it loaded no translation
+ * namespace and `t()` here would have returned its own key. Server-rendered
+ * rather than static: `_app` defines getInitialProps, which already disables
+ * static optimisation app-wide, so this changes what the page receives and not
+ * how it renders. getStaticProps would have changed how it renders, by turning
+ * `router.isReady` false on the first render of any URL carrying a query
+ * string, which is every filtered link into this page.
+ */
+export const getServerSideProps: GetServerSideProps = async ({
+  locale = 'en',
+}) => {
+  const props = await serverSideTranslations(
+    locale,
+    ['common', 'transactions'],
+    nextI18nextConfig,
+    ['en'],
+  );
+
+  return { props };
 };
 
 export default Transactions;

--- a/src/pages/validators/index.tsx
+++ b/src/pages/validators/index.tsx
@@ -362,6 +362,7 @@ const Validators: React.FC<PropsWithChildren> = () => {
     return [
       {
         title: 'Name',
+        placeholder: 'Search name…',
         data: filterValidators
           .map(validator => validator.name)
           .filter(validator => !!validator) as string[],
@@ -385,6 +386,7 @@ const Validators: React.FC<PropsWithChildren> = () => {
       },
       {
         title: 'Version',
+        placeholder: 'Search version…',
         data: versionStats.map(stat => stat.version),
         onClick: async value => {
           if (value === 'All') {

--- a/src/utils/contracts/index.ts
+++ b/src/utils/contracts/index.ts
@@ -444,14 +444,6 @@ export const initialsTableHeaders = [
   'Contract',
 ];
 
-export const transactionTableHeaders = [
-  'Transaction Hash',
-  'Block/Fees',
-  'From/To',
-  'Type',
-  'Misc',
-];
-
 export const smartContractsTableHeaders = [
   'Contract',
   'Total Transactions',

--- a/src/utils/formatFunctions/__tests__/toLocaleFixed.test.ts
+++ b/src/utils/formatFunctions/__tests__/toLocaleFixed.test.ts
@@ -1,0 +1,44 @@
+import { toLocaleFixed } from '../index';
+
+describe('toLocaleFixed', () => {
+  // Number.prototype is global, so a spy left behind by a failing assertion
+  // would follow every later test in the run. restoreMocks is not enabled in
+  // this repo's jest config, so the restore has to be unconditional.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('asks for en-US rather than for whatever locale the runtime defaults to', () => {
+    // Asserted on the argument, not on the output, because the output alone
+    // proves nothing: on an en-US machine a runtime-default implementation
+    // produces exactly the same string, so a value-only test would pass in CI
+    // while the bug it guards was still there.
+    //
+    // What it guards: the server renders with its own locale and the browser
+    // with the reader's. When those disagree on the decimal separator, React
+    // discards the server-rendered tree and rebuilds it. That was visible on
+    // every block page from a browser set to a comma-decimal locale.
+    const spy = jest.spyOn(Number.prototype, 'toLocaleString');
+
+    toLocaleFixed(1, 6);
+
+    expect(spy).toHaveBeenCalledWith('en-US', { minimumFractionDigits: 6 });
+  });
+
+  it('returns a string even when handed nothing, so template literals stay clean', () => {
+    // The signature promises a string. Before this it could return undefined,
+    // which a template literal renders as the word "undefined" beside the
+    // ticker; several call sites interpolate this.
+    expect(toLocaleFixed(undefined as unknown as number, 2)).toBe('');
+    expect(`${toLocaleFixed(undefined as unknown as number, 2)} KLV`).toBe(
+      ' KLV',
+    );
+  });
+
+  it('pads to the requested precision and groups thousands', () => {
+    expect(toLocaleFixed(1, 6)).toBe('1.000000');
+    expect(toLocaleFixed(0, 6)).toBe('0.000000');
+    expect(toLocaleFixed(1234.5, 2)).toBe('1,234.50');
+    expect(toLocaleFixed(8.14, 6)).toBe('8.140000');
+  });
+});

--- a/src/utils/formatFunctions/index.ts
+++ b/src/utils/formatFunctions/index.ts
@@ -150,16 +150,32 @@ export const filterDate = (selectedDays: ISelectedDays): IFilterDater => {
 };
 
 /**
- * Shorthand version of toLocaleString for passing precision and always using user locale. It receives a number that will be formatted having a minimal precision according to the precision arg passed.
- * @param value
- * @param precision
- * @returns string
+ * A number with at least `precision` decimals.
+ *
+ * Formatted in en-US rather than in the reader's own locale, and that is
+ * deliberate. `toLocaleString(undefined, …)` asks the runtime for its default,
+ * which is the server's locale during SSR and the browser's afterwards. On a
+ * machine whose locale uses a comma decimal separator the two disagree
+ * ("1.000000" from the server, "1,000000" in the browser), and React discards
+ * the whole server-rendered tree and rebuilds it on the client. It is visible
+ * on every block page today for most of continental Europe.
+ *
+ * en-US is the honest choice here rather than an arbitrary one: `en` is the
+ * only locale this app ships (next-i18next.config.js), all of its copy is
+ * English, and the assets section already pins `toLocaleString('en-US')` in
+ * five places. This makes the rest of the app agree with that.
+ *
+ * The optional call is kept because a caller can still hand this an undefined
+ * at runtime past the type, but it now returns a string in that case rather
+ * than undefined. The signature said `string` while the body could return
+ * undefined, and the difference showed: in a template literal an undefined
+ * renders the word "undefined" next to the ticker, where an empty string
+ * renders nothing.
  */
-export const toLocaleFixed = (value: number, precision: number): string => {
-  return value?.toLocaleString(undefined, {
+export const toLocaleFixed = (value: number, precision: number): string =>
+  value?.toLocaleString('en-US', {
     minimumFractionDigits: precision,
-  });
-};
+  }) ?? '';
 
 export const isHex = (str: string): boolean => {
   const hexRegex = /^[0-9a-fA-F]+$/;

--- a/src/utils/hooks/__tests__/useFetchPartial.test.tsx
+++ b/src/utils/hooks/__tests__/useFetchPartial.test.tsx
@@ -1,0 +1,160 @@
+import { act, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Factory mock, never loading the real module: precisionFunctions reaches
+// @/pages/transactions and from there an ESM chain Jest cannot transform.
+jest.mock('@/utils/precisionFunctions', () => ({
+  getPrecision: jest.fn(),
+}));
+
+jest.mock('@/components/Skeleton', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+// Same shim every component suite in this repo carries: this
+// testing-library version drives the removed ReactDOM.render API.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+const mockGet = jest.fn();
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => mockGet(...args) },
+}));
+
+import { useFetchPartial } from '../index';
+
+interface IRow {
+  assetId?: string;
+}
+
+/**
+ * Drives the hook the way TransactionsFilters does: awaits the search and
+ * only then clears its own loading flag. That mirror matters, because the
+ * defect being pinned was a promise that never settled, which no assertion
+ * on the hook's return value alone would catch.
+ */
+const Harness: React.FC = () => {
+  const [, fetchPartial, loading] = useFetchPartial<IRow>(
+    'assets',
+    'assets/list',
+    'assetId',
+  );
+  const [settled, setSettled] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={async () => {
+          await fetchPartial('KLV');
+          setSettled(true);
+        }}
+      >
+        search
+      </button>
+      <span data-testid="state">
+        {settled ? 'settled' : loading ? 'loading' : 'idle'}
+      </span>
+    </div>
+  );
+};
+
+describe('useFetchPartial', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockGet.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const search = async () => {
+    await act(async () => {
+      screen.getByText('search').click();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(600);
+    });
+    // let the awaited promise chain flush
+    await act(async () => Promise.resolve());
+  };
+
+  it('settles even when a loaded row is missing the search field', async () => {
+    // The initial load returns a row without assetId, the shape the optional
+    // chain at the call sites says to expect. Matching used to call
+    // toUpperCase on it inside the timer, where nothing rejects, so the
+    // caller's await hung and its spinner stayed on forever.
+    mockGet.mockResolvedValueOnce({
+      data: { assets: [{}, { assetId: 'KFI' }] },
+    });
+    mockGet.mockResolvedValueOnce({
+      data: { assets: [{ assetId: 'KLV' }] },
+    });
+    render(<Harness />);
+    await act(async () => Promise.resolve());
+
+    await search();
+
+    expect(screen.getByTestId('state')).toHaveTextContent('settled');
+  });
+
+  it('settles when the request itself rejects', async () => {
+    mockGet.mockResolvedValueOnce({ data: { assets: [] } });
+    mockGet.mockRejectedValueOnce(new Error('network down'));
+    render(<Harness />);
+    await act(async () => Promise.resolve());
+
+    await search();
+
+    expect(screen.getByTestId('state')).toHaveTextContent('settled');
+  });
+
+  it('settles on the silent failure shape, HTTP 200 with data null', async () => {
+    mockGet.mockResolvedValueOnce({ data: { assets: [] } });
+    mockGet.mockResolvedValueOnce({ data: null, error: '' });
+    render(<Harness />);
+    await act(async () => Promise.resolve());
+
+    await search();
+
+    expect(screen.getByTestId('state')).toHaveTextContent('settled');
+  });
+});

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -100,51 +100,63 @@ export const useFetchPartial = <T,>(
   useEffect(() => {
     initialState();
   }, []);
+  // Skips rows whose field is not a string: the API can return rows with the
+  // field missing, and calling toUpperCase on one used to throw inside the
+  // timer below, where nothing rejects. The whole body is wrapped so the
+  // promise settles and the spinner resets no matter what fails; before, a
+  // throw in here left the caller's `await` hanging and its loading state on
+  // forever.
+  const matchesValue = (asset: T, value: string): boolean => {
+    const field = (asset as { [key: string]: unknown })[dataType];
+    return (
+      typeof field === 'string' &&
+      field.toUpperCase().includes(value.toUpperCase())
+    );
+  };
+
   return [
     items,
     value => {
       clearTimeout(fetchPartialTimeout);
       return new Promise(res => {
         fetchPartialTimeout = setTimeout(async () => {
-          let response: PartialResponse;
-          if (
-            value &&
-            !items.find(asset =>
-              (asset as { [key: string]: string })[dataType]
-                .toUpperCase()
-                .includes(value.toUpperCase()),
-            )
-          ) {
-            setLoading(true);
-            if (type !== 'assets') {
-              query = { ...query };
-              query[dataType] = value;
-              response = await api.get({
-                route: `${route}`,
-                query: {
-                  dataType: value,
-                  ...query,
-                },
-              });
+          try {
+            let response: PartialResponse;
+            if (value && !items.some(asset => matchesValue(asset, value))) {
+              setLoading(true);
+              if (type !== 'assets') {
+                query = { ...query };
+                query[dataType] = value;
+                response = await api.get({
+                  route: `${route}`,
+                  query: {
+                    dataType: value,
+                    ...query,
+                  },
+                });
+              } else {
+                response = await api.get({
+                  route: `${route}`,
+                  query: {
+                    asset: value,
+                    ...query,
+                  },
+                });
+              }
+              // The API's failure mode is HTTP 200 with data: null, so the
+              // read has to survive that as well as an empty list.
+              const found = response?.data?.[type] ?? [];
+              if (found.length) {
+                setItems([...items, ...found]);
+              }
+              res(found.length ? found : items);
             } else {
-              response = await api.get({
-                route: `${route}`,
-                query: {
-                  asset: value,
-                  ...query,
-                },
-              });
+              res(items);
             }
-            if (!response.data[type].length) {
-              setItems([...items]);
-            } else {
-              res(response.data[type]);
-              setItems([...items, ...response.data[type]]);
-            }
-            res(response.data[type]);
-            setLoading(false);
-          } else {
+          } catch (error) {
+            console.error(error);
             res(items);
+          } finally {
             setLoading(false);
           }
         }, 500);


### PR DESCRIPTION
Groundwork for restyling the shared transactions table, plus the defects that surfaced while doing it. No visual redesign yet: apart from the fixes named below, this is meant to render identically to `develop`.

The table is one construction on five routes (`/transactions`, the asset page, the asset nonce page, the block page and the account page), and the link hover menu it uses sits behind every hash and address in the app. Both needed to stop being decided by displayed text before either can be translated or restyled.

## Bugs fixed

**Column headings and cells could disagree, and did.** The heading list and the cell list were built by two separate code paths. `transactionRowSections` spliced an In/Out cell in at index 3 whenever the URL named an account, and of the four places that supplied the headings, only the `Tabs/Transactions` wrapper widened its list to match. On `/transactions?account=…`, `/asset/<id>?account=…` and `/asset/<id>/<nonce>?account=…` that rendered five headings above six cells: Type sat under From/To, Misc sat under Type, and the real Misc column had no heading at all. Reproduced against live data before the change and confirmed gone after, on all seven combinations of the five routes with and without an account.

A column is now one entry carrying its key and its heading together, and both lists are derived from it, so there is no longer a second list to disagree with.

**In/Out was shown on routes where it means nothing, and no longer is.** This is a deliberate behaviour change worth reviewing on its own. The column used to appear whenever an account was in the URL, but only `requestTransactionsDefault` renames `account` to `address`, and `address` is the parameter the API filters on: measured against the live API, `?account=` leaves the record count at 58.5M while `?address=` cuts it to about 12k. So on `/asset/<id>?account=…` the column compared each row's sender against an account the list was never narrowed by, and read "In" for essentially every row. It is now limited to the two routes that actually scope. Before this branch those routes rendered the cell with no heading, so the visible change there is one meaningless column disappearing.

**Three separate causes of a broken hydration on `/block/<n>`.** The page was discarding its entire server-rendered tree and rebuilding it on the client.

Two were pre-existing. `toLocaleFixed` asked the runtime for its default locale, so the server wrote `1.000000` while a browser set to a comma-decimal locale wrote `1,000000`; that is most of continental Europe, on every block page. It is now pinned to en-US, which is the only locale this app ships and what the assets section already does in five places. Separately, `DateFilter` returned `null` until `router.isReady`, and Next answers that differently on each side for a statically generated page.

The third was introduced here and caught in review: building the filter list during render made the same `router.isReady` difference decide what the first render emits. None of the three now occur; measured with zero console output from a browser set to Dutch.

**The hover menu described every link as an address.** Hovering a transaction hash offered "Copy Address", a QR code of a value that is not an address, and a Transfer form prefilled with that hash as its receiver, which cannot be submitted correctly. Same for block numbers. The menu now knows what its link points at: the copy action is named after the thing it copies, and QR plus Transfer appear only for wallet-format addresses. `ExplorerLink` reads the same table, so the toast can no longer say "Wallet Address copied" on one path and "account copied" on the other for the same value.

**A menu label that wrapped rendered on top of itself.** Menu items inherit `line-height: 0` from the copy icon's button wrapper. "Copy Address" fit on one line and hid it; the longer labels did not.

## Behaviour that is now translatable

`Filter` used its displayed text as three things at once: the label a reader sees, the key the code looks up, and the value that travels to the URL and on to the API. That is fine while the product is English-only and becomes a defect the moment anything is translated. Two examples that had already misfired: the Status control got a button input by comparing its title against the literal "Status", which `Tabs/Proposals` passes through `t()` (pt-BR already renders "Estado"), and the search placeholders were picked the same way, so the assets and pools filters have been showing the generic prompt instead of "Type the token ID".

`Filter` now takes `renderLabel` and `placeholder`, and call sites state the input type they want. Selecting an option still reports the value, so URLs and API calls are unchanged.

The transactions filter bar is translated on top of that. The namespaces are wired first, because a `t()` call added without them does not fall back to English, it renders its own key: `/transactions` carried no data method at all and `/block/<n>` returned only its block. Every English value is byte-identical to the literal it replaces, including `MarketBuy` and `ITOBuy`; a test pins that, because only `en` is active and any drift would be a copy change smuggled in under a translation.

`/transactions` gets `getServerSideProps` rather than `getStaticProps`. `_app` defines `getInitialProps`, which already disables static optimisation app-wide, so server-rendering changes what the page receives and not how it renders. `getStaticProps` would have changed how it renders, by turning `router.isReady` false on the first render of any URL carrying a query string, which is every filtered link into this page.

## Performance

The hover menu was built for every link and then hidden with CSS, QR code included. Measured on the transactions list at 1440px: 46 QR codes rendered into a page that shows none of them, and 2026 elements inside the table. After: 0 and 474, with hovering one link producing exactly one QR code and the full menu. This is not transactions-only, the same wrapper sits behind every compact `ExplorerLink`.

The cost side, so it is recorded rather than found later: `/transactions` now fetches its route data on a client-side navigation into the page, which it did not before, because it has a data method where it had none. In-page filtering and pagination are unaffected, since those push with `shallow: true`.

## Tests

The e2e suite reached the filters by their position among their siblings (`:nth-child(2)`, `:nth-child(3)`), which is 26 generated tests hanging on an ordering nothing enforces. Each filter now carries its own identifier. The suite also only ever ran at Cypress's default 1000px, where this app renders cards, so the column table was never exercised in CI at all; both viewports are now stated explicitly and the desktop layout has its own coverage.

Seven tests written during this work could not fail for the thing their names claimed, and were rewritten once review found them. Worth listing, because the pattern is the point:

- the e2e guarding the heading/cell split visited the one URL where both counts were five before and after, so it passed against `develop`. It now visits the scoped URL, and with the defect reproduced it fails with "Found '5', expected '6'".
- the column test reversed the copying branch and asserted on the shared one.
- the accented-character test passed with the old input sanitiser in place, because the truncated needle still matched.
- the placeholder test asserted the exact string the removed title-matching branch produced.
- the identity test covered only the contract names, so renaming `MarketBuy` to `Market Buy` would have passed the suite it was written to prevent.
- the menu test kept its entity list by hand, in a directory tsconfig excludes, while claiming completeness.
- one assertion compared a function against its own definition.

Two behaviours had no test at all and now do: the lazy mount, and the entity split that decides whether a QR code and a prefilled Transfer form appear. The Buy Type filter, the only conditional control in the bar, is constructed in a test for the first time.

Unit tests go from 474 to 527 across 45 suites; e2e from 94 to 99.

## What review caught in this branch's own work

Recorded because these are defects this branch introduced and then repaired, not defects of `develop`, and squashing hides that.

The label/value split dropped a `String()` guard on the search matcher, so one null-ish entry in a filter's list plus one keystroke threw from render. The Coin filter maps `asset?.assetId`, whose optional chain says exactly that is expected, and there is no error boundary anywhere in the app.

The longer menu labels plus `white-space: nowrap` in a fixed 12rem panel squeezed out the only shrinkable box in the row. Measured at 375px: the copy icon dropped to 11.28px next to "Copy Block Number" and to 0px next to "Copy Contract Address", which also spilled past the panel edge. The panel now has a floor rather than a fixed width, the icon does not shrink, and all three menus measure a full icon with no overflow.

Smaller ones from the same round: option keys moved to the list value, which the validators filter cannot guarantee is unique; the Coin filter was the only one whose "All" stayed untranslated; validator links said "Copy Address" without saying which address, while the app already says "Validator Address" elsewhere; and three routes loaded a namespace they reach no key of.

A second review round found more. `next-i18next.config.js` built `localePath` with `path.resolve`, and next-i18next ships its whole config to the browser inside `__NEXT_DATA__`, so that sent the build machine's directory layout to every visitor and baked it into the prerendered block pages. It is a relative path now; resolving it was never needed, since next-i18next resolves against the working directory itself. That round also found seven tests that could not fail, three of them written to guard this very change, and two behaviours with no test at all: the lazy mount and the entity split. Both have one now, and the Buy Type filter is constructed in a test for the first time. The assets and pools search boxes finally get the prompt this PR's own description said they had been missing.

## Deliberately not here

The restyle itself. Row height, the sticky tinted header and a dedicated mobile card are a separate change, because going from 83px to 60px means deciding per column what stays, what moves to a tooltip and what goes, and that is a product decision rather than a CSS one.

The request layer. A shared module with an allowlist for `transaction/list` belongs with this work, but it touches every module under `services/requests/`, which is what the open escaping PR also does. It waits for that one to land.

## Verification

`tsc --noEmit` clean. 514 unit tests and 99 e2e green, the latter against a production build. Computed styles of the table compared against `develop` side by side and identical. Query parameters leaving all five routes unchanged, including a filtered URL arriving intact, which is what shows `router.isReady` did not move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized transaction filters, statuses, buy types, and contract action labels.
  * Added entity-specific link menus with clearer copy, QR, and transfer actions.
  * Improved transaction table columns across account, asset, tablet, and desktop views.
* **Bug Fixes**
  * Filters and date controls now render reliably during loading and localization changes.
  * Improved dropdown layouts, number formatting, asset filter prompts, and partial-data handling.
* **Tests**
  * Expanded coverage for filters, transaction tables, responsive layouts, link menus, and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->