### PR TITLE
fix: build-time path resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,6 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
-# Where next-i18next reads the translations. Stated absolutely because it
-# otherwise resolves them against the server's working directory per request:
-# started from anywhere but /app, every namespace loads empty and the site
-# renders raw keys ("Titles.Accounts") instead of text.
-ENV LOCALES_PATH=/app/public/locales
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,24 +1,22 @@
-/**
- * Where the translation files live.
- *
- * next-i18next resolves a relative path with path.resolve(process.cwd(), …)
- * on every request, so a relative value only finds the files while the
- * server's working directory happens to be the project root. Started from
- * anywhere else, every namespace loads empty and each t() renders its own
- * key ("Titles.Accounts" instead of "Accounts") across the whole site, which
- * is what testnet showed. Reproduced by serving one build from two working
- * directories.
- *
- * The deployment therefore states the absolute location itself, and the
- * relative value stays the default for local runs, where the working
- * directory is the project root anyway.
- */
-const localePath = process.env.LOCALES_PATH || './public/locales';
+const path = require('path');
 
+/**
+ * Where the translation files live, resolved once, here.
+ *
+ * next-i18next resolves a relative localePath with path.resolve(process.cwd(),
+ * …) on every request instead. In the Lambdas that serve this site the working
+ * directory at request time is not the application root, so a relative value
+ * loads every namespace empty and each t() renders its own key
+ * ("Titles.Accounts" instead of "Accounts") across the whole site. Resolving at
+ * module load captures the application root while the process still reports it.
+ *
+ * The cost is that next-i18next hands this config to the browser inside
+ * __NEXT_DATA__, so the absolute location is visible to visitors.
+ */
 module.exports = {
   i18n: {
     locales: ['en'],
     defaultLocale: 'en',
   },
-  localePath,
+  localePath: path.resolve('./public/locales'),
 };

--- a/src/__tests__/nextI18nextConfig.test.ts
+++ b/src/__tests__/nextI18nextConfig.test.ts
@@ -6,7 +6,7 @@ import path from 'path';
  * a relative path against the server's working directory on every request.
  * A deployment whose working directory is not the project root then loads
  * every namespace empty and renders raw keys ("Titles.Accounts") site-wide,
- * which is why the location is stated explicitly there.
+ * which is why this config resolves the location before handing it over.
  */
 describe('next-i18next config', () => {
   const configPath = path.join(process.cwd(), 'next-i18next.config.js');
@@ -17,20 +17,11 @@ describe('next-i18next config', () => {
     return require(configPath);
   };
 
-  afterEach(() => {
-    delete process.env.LOCALES_PATH;
-  });
+  it('states an already-resolved path, not a relative one', () => {
+    const { localePath } = loadConfig();
 
-  it('takes the locale path from the environment when it is set', () => {
-    process.env.LOCALES_PATH = '/srv/app/public/locales';
-
-    expect(loadConfig().localePath).toBe('/srv/app/public/locales');
-  });
-
-  it('falls back to the project-relative path for local runs', () => {
-    delete process.env.LOCALES_PATH;
-
-    expect(loadConfig().localePath).toBe('./public/locales');
+    expect(path.isAbsolute(localePath)).toBe(true);
+    expect(localePath).toBe(path.resolve('./public/locales'));
   });
 
   it('points at a folder that holds the namespaces it declares', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization reliability in production and serverless environments by using a consistent absolute path for translation files.
  * Removed reliance on environment-specific locale path overrides.

* **Tests**
  * Updated localization configuration coverage to verify the resolved absolute translation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->