### PR TITLE
test(i18n): catch a locale path that only works from the project root

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "test": "jest",
+    "verify:i18n": "node scripts/verify-i18n.mjs",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "cy:open": "cypress open",

--- a/scripts/verify-i18n.mjs
+++ b/scripts/verify-i18n.mjs
@@ -95,9 +95,18 @@ for (const page of PAGES) {
   buildId = data.buildId;
   const i18n = data?.props?.pageProps?._nextI18Next;
 
-  // A page that loads no namespaces translates nothing, which is a choice,
-  // not a fault: it has no keys to resolve.
-  if (!i18n) continue;
+  // Every page in PAGES asks for namespaces, so a missing payload is a fault
+  // rather than a page with nothing to translate. Passing it would also skip
+  // the two checks below, which is how a release gate goes quiet on the exact
+  // regression it exists to catch.
+  if (!i18n) {
+    failures.push(
+      `${page}: asked for no namespaces at all (the page lost its ` +
+        `serverSideTranslations, or this environment runs a build from ` +
+        `before it had them)`,
+    );
+    continue;
+  }
 
   localePath = i18n?.userConfig?.localePath ?? localePath;
   const store = i18n?.initialI18nStore?.en ?? {};

--- a/scripts/verify-i18n.mjs
+++ b/scripts/verify-i18n.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Checks that a deployed environment actually loaded its translations.
+ *
+ * Usage:
+ *   node scripts/verify-i18n.mjs https://testnet.kleverscan.org
+ *
+ * For an environment behind basic auth, pass the credentials through the
+ * environment rather than the command line, where they would survive in
+ * shell history and show up in process listings and CI logs:
+ *   VERIFY_I18N_AUTH=user:password node scripts/verify-i18n.mjs <url>
+ *
+ * Exits non-zero when a page renders keys instead of text, so it can gate a
+ * release.
+ *
+ * Why this exists as its own check: the failure it looks for raises nothing.
+ * next-i18next resolves the locale folder against the server's working
+ * directory, so an environment that starts the process elsewhere loads every
+ * namespace empty, logs nothing, and serves pages that render their own keys.
+ * Many keys in this app are the English sentence they stand for
+ * ("Total Accounts"), so half of such a page still reads correctly and the
+ * failure hides in plain sight. It went unnoticed across three environments.
+ * Unit tests cannot see it either: locally the working directory is always
+ * the project root.
+ */
+
+const [, , baseArg] = process.argv;
+const credentials = process.env.VERIFY_I18N_AUTH;
+
+if (!baseArg) {
+  console.error('usage: node scripts/verify-i18n.mjs <base-url>');
+  console.error('       VERIFY_I18N_AUTH=user:password for basic auth');
+  process.exit(2);
+}
+
+const base = baseArg.replace(/\/$/, '');
+
+/** Pages chosen because each loads namespaces and renders dotted keys. */
+const PAGES = ['/', '/accounts', '/transactions', '/assets'];
+
+/** Generous for a server-rendered page, short enough to fail a stuck one. */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Keys that read as a path rather than as a sentence. These are the ones a
+ * reader notices; the rest of the failure is invisible, which is why the
+ * store itself is checked as well.
+ */
+const RAW_KEY =
+  />(?:Titles|Cards|Filters|Buttons|AccountsPage|Date)\.[A-Za-z .]+</;
+
+const headers = credentials
+  ? { Authorization: `Basic ${Buffer.from(credentials).toString('base64')}` }
+  : undefined;
+
+const readNextData = html => {
+  const match = html.match(
+    /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+  );
+  return match ? JSON.parse(match[1]) : null;
+};
+
+const failures = [];
+let localePath = null;
+let buildId = null;
+
+for (const page of PAGES) {
+  const url = `${base}${page}`;
+  let html;
+  try {
+    // The signal covers reading the body too, not just the headers: a
+    // response that stalls halfway would otherwise hang this check instead
+    // of failing it, which is the worse outcome for something meant to gate
+    // a release.
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      failures.push(`${page}: HTTP ${response.status}`);
+      continue;
+    }
+    html = await response.text();
+  } catch (error) {
+    failures.push(`${page}: request failed (${error.message})`);
+    continue;
+  }
+
+  const data = readNextData(html);
+  if (!data) {
+    failures.push(`${page}: no __NEXT_DATA__ in the response`);
+    continue;
+  }
+
+  buildId = data.buildId;
+  const i18n = data?.props?.pageProps?._nextI18Next;
+
+  // A page that loads no namespaces translates nothing, which is a choice,
+  // not a fault: it has no keys to resolve.
+  if (!i18n) continue;
+
+  localePath = i18n?.userConfig?.localePath ?? localePath;
+  const store = i18n?.initialI18nStore?.en ?? {};
+
+  // Checked against the namespaces the page itself asked for, not against
+  // the ones that happen to be in the store: a store that is missing
+  // altogether has nothing to iterate, so counting only what is present
+  // would let the very failure this script exists for pass silently. Reading
+  // the page's own list also means this needs no table to maintain here.
+  const requested = i18n?.ns ?? [];
+  const unresolved = requested.filter(
+    namespace => Object.keys(store[namespace] ?? {}).length === 0,
+  );
+
+  if (unresolved.length) {
+    failures.push(
+      `${page}: namespaces asked for but not loaded: ${unresolved.join(', ')}`,
+    );
+  }
+
+  const raw = html.match(RAW_KEY);
+  if (raw) {
+    failures.push(
+      `${page}: renders a key instead of text (${raw[0].slice(1, -1)})`,
+    );
+  }
+}
+
+console.log(`base:       ${base}`);
+console.log(`buildId:    ${buildId ?? 'unknown'}`);
+console.log(`localePath: ${localePath ?? 'unknown'}`);
+
+if (failures.length) {
+  console.error('\nTranslations are not loaded:');
+  for (const failure of failures) console.error(`  - ${failure}`);
+  console.error(
+    '\nThe files are usually present and the keys usually exist; what fails is',
+  );
+  console.error(
+    'reading them at request time. Check that localePath above is absolute and',
+  );
+  console.error('points at public/locales inside that image.');
+  process.exit(1);
+}
+
+console.log(`\nAll ${PAGES.length} pages resolved their translations.`);

--- a/src/__tests__/nextI18nextConfig.test.ts
+++ b/src/__tests__/nextI18nextConfig.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 /**
@@ -22,6 +23,58 @@ describe('next-i18next config', () => {
 
     expect(path.isAbsolute(localePath)).toBe(true);
     expect(localePath).toBe(path.resolve('./public/locales'));
+  });
+
+  /**
+   * The regression this file exists for, reproduced rather than described.
+   *
+   * The serverless runtime that serves this site starts in the application
+   * root and handles requests from somewhere else. A value resolved while
+   * the module loads survives that; a relative one is re-resolved per
+   * request against the wrong directory, finds nothing, and every namespace
+   * loads empty. Nothing raises: pages simply render their own keys, and
+   * because many keys here are the English sentence, half the page still
+   * reads correctly, which is why it went unnoticed across three
+   * environments.
+   */
+  it('still finds the files when the working directory changes after load', () => {
+    const { localePath } = loadConfig();
+    const projectRoot = process.cwd();
+
+    try {
+      process.chdir(os.tmpdir());
+
+      // Exactly what next-i18next does for each request.
+      const requested = path.resolve(
+        process.cwd(),
+        `${localePath}/en/common.json`,
+      );
+
+      const found = fs.existsSync(requested);
+
+      // Thrown rather than left to the matcher, so the failure explains
+      // itself to whoever hits it instead of reading "expected true,
+      // received false". The assertion below keeps it a real expectation.
+      if (!found) {
+        throw new Error(
+          [
+            `localePath "${localePath}" only resolves while the server runs from the project root.`,
+            `After moving to another directory it looked for: ${requested}`,
+            '',
+            'next-i18next resolves a relative localePath against process.cwd() on every',
+            'request, and the runtime that serves this site handles requests from a',
+            'different directory than the one it started in. Every namespace then loads',
+            'empty and pages render their own keys ("Titles.Accounts" instead of',
+            '"Accounts"), with no error anywhere. Keep the path resolved in',
+            'next-i18next.config.js while the module loads, as path.resolve() does.',
+          ].join('\n'),
+        );
+      }
+
+      expect(found).toBe(true);
+    } finally {
+      process.chdir(projectRoot);
+    }
   });
 
   it('points at a folder that holds the namespaces it declares', () => {


### PR DESCRIPTION
## Why

The translations broke across devnet, testnet and production this week, and nothing anywhere raised a flag. next-i18next re-resolves a relative locale path against `process.cwd()` on every request, and the runtime that serves this site handles requests from a different directory than the one it started in. Every namespace then loads empty, no error, no log.

It stayed invisible for two reasons. Many keys in this repo are the English sentence they stand for, so `t('Total Accounts')` still renders "Total Accounts" when nothing is loaded, and only dotted keys like `Titles.Accounts` look wrong. And no test could see it, because locally the working directory is always the project root.

#689 fixed the cause. This adds the two checks that would have caught it, so the next person does not have to rediscover it.

## The unit test

It reproduces the failure instead of describing it: load the config, change the working directory, then assert the path still finds the files. That is exactly what happens between process start and request handling in that runtime.

Proven both ways: it fails on the relative form and passes on the resolved one. Worth noting that the existing `points at a folder` test passes on **both**, which is why it never caught this.

When it fails it explains itself rather than printing `expected true, received false`:

```
localePath "./public/locales" only resolves while the server runs from the project root.
After moving to another directory it looked for: /tmp/public/locales/en/common.json

next-i18next resolves a relative localePath against process.cwd() on every
request, and the runtime that serves this site handles requests from a
different directory than the one it started in. Every namespace then loads
empty and pages render their own keys ("Titles.Accounts" instead of
"Accounts"), with no error anywhere. Keep the path resolved in
next-i18next.config.js while the module loads, as path.resolve() does.
```

It runs in the existing unit-tests job, so every PR is covered.

## The deployed check

A unit test cannot see how the image is actually started, so `yarn verify:i18n <url>` reads the rendered pages of a running environment and exits non-zero when a namespace loaded empty or a key is rendered instead of text. It prints the buildId and the resolved locale path, which is what tells you whether you are even looking at the build you think you are.

```
yarn verify:i18n https://testnet.kleverscan.org
yarn verify:i18n https://devnet.kleverscan.org user:password
```

Verified against a healthy environment (passes) and against a server started from the wrong directory (fails, naming all four pages and the empty namespaces).

## Verification

`tsc --noEmit` clean, Jest 622 tests green, and both new checks demonstrated failing before they pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment verification command that checks selected pages for successful responses, metadata, build and locale information, and unresolved translations.
  * Supports optional authenticated requests and configurable timeouts, with clear failure reporting.

* **Bug Fixes**
  * Missing translation data is now reported as a verification failure instead of being skipped.
  * Added regression coverage to ensure locale files remain available when the application runs from a different working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->