### PR TITLE
feat(transactions): rebuild the list, fix dark-mode surfaces, cut list load time

### DIFF
--- a/__mocks__/next-i18next.js
+++ b/__mocks__/next-i18next.js
@@ -1,3 +1,8 @@
 module.exports = {
-  useTranslation: () => ({ t: key => key }),
+  useTranslation: () => ({
+    // Mirrors the real t() for the path tests exercise: no resources are
+    // loaded here, so every lookup misses and falls back to
+    // options.defaultValue when the caller provides one, else to the key.
+    t: (key, options) => options?.defaultValue ?? key,
+  }),
 };

--- a/cypress/e2e/pages/transactions.cy.ts
+++ b/cypress/e2e/pages/transactions.cy.ts
@@ -9,7 +9,7 @@
  */
 
 import { contracts } from '../../../src/configs/transactions';
-import { ContractsIndex } from '../../../src/types/contracts';
+import { Contract, ContractsIndex } from '../../../src/types/contracts';
 
 const PAGE_TITLE_SELECTOR = 'h1';
 /**
@@ -44,8 +44,44 @@ const hashForType = (typeIndex: number): string => {
   return `${prefix}${'ab'.repeat(31)}`.slice(0, 64);
 };
 
+/**
+ * Parameters real enough to reach the section builders, for the types whose
+ * Amount column is asserted below.
+ *
+ * Every other type keeps the neutral placeholder in `txForType`: a real
+ * typeString routes an empty parameter into the real builders, and not all of
+ * those survive `{}`. The fields here are the ones their builder reads, in
+ * the order it draws them, so the cells before the amount are filled and a
+ * column that picked the wrong one would show a word instead of a figure.
+ */
+const REAL_CONTRACTS: Record<
+  number,
+  { typeString: string; parameter: Record<string, unknown> }
+> = {
+  [ContractsIndex.Transfer]: {
+    typeString: Contract.Transfer,
+    parameter: { amount: 1_000_000, assetId: 'KLV', toAddress: ADDRESS },
+  },
+  [ContractsIndex.Withdraw]: {
+    typeString: Contract.Withdraw,
+    // Its builder draws the withdraw type first and the amount second, so a
+    // withdrawType other than 1 puts the word "Staking" in front of it.
+    parameter: { withdrawType: 0, amount: 5_000_000, assetId: 'KLV' },
+  },
+  [ContractsIndex.Deposit]: {
+    typeString: Contract.Deposit,
+    // Two cells before the amount here: the deposit type, then the id.
+    parameter: {
+      depositTypeString: 'FPRDeposit',
+      id: 'KLV',
+      amount: 7_000_000,
+      currencyID: 'KLV',
+    },
+  },
+};
+
 const txForType = (typeIndex: number) => {
-  const isTransfer = typeIndex === 0;
+  const real = REAL_CONTRACTS[typeIndex];
   return {
     hash: hashForType(typeIndex),
     blockNum: 1000 + typeIndex,
@@ -64,14 +100,13 @@ const txForType = (typeIndex: number) => {
     contract: [
       {
         type: typeIndex,
-        typeString: 'Contract',
-        parameter: isTransfer
-          ? {
-              amount: 1_000_000,
-              assetId: 'KLV',
-              toAddress: ADDRESS,
-            }
-          : {},
+        // Only the types in REAL_CONTRACTS carry their real typeString:
+        // contractTypes derives the row's type from it, and a real typeString
+        // routes the parameter into the real section builders. The rest keep
+        // a neutral placeholder, whose empty parameter those builders would
+        // not all survive.
+        typeString: real?.typeString ?? 'Contract',
+        parameter: real?.parameter ?? {},
       },
     ],
   };
@@ -104,6 +139,68 @@ const stubPrecisions = (): void => {
   }).as('precisions');
 };
 
+/**
+ * The summary card above the list. Its three requests all start with the
+ * list route's path, so these must be registered AFTER the list stub:
+ * Cypress matches the most recently registered interceptor, and while the
+ * generic list stub answered them their responses landed in `@txList`, where
+ * `cy.wait('@txList')` then read the summary's request instead of the
+ * filtered one (its missing `type` param read as 0).
+ */
+const stubSummaryApis = (): void => {
+  // The only list request carrying `minify`, which is what separates the
+  // card's total from the table's own paged request.
+  cy.intercept(
+    {
+      method: 'GET',
+      url: '**/v1.0/transaction/list*',
+      query: { minify: 'true' },
+    },
+    {
+      statusCode: 200,
+      body: {
+        data: { transactions: [] },
+        pagination: { totalRecords: 58_500_000 },
+        error: '',
+        code: 'successful',
+      },
+    },
+  ).as('txTotal');
+
+  // The card asks this route once for the window totals and once per
+  // contract type for the composition bar.
+  const countPerType: Record<string, number> = {
+    '0': 5747, // Transfer
+    '63': 1865, // Smart Contract
+    '9': 592, // Claim
+    '4': 228, // Freeze
+  };
+
+  cy.intercept('GET', '**/v1.0/transaction/list/count/*', req => {
+    const type = new URL(req.url).searchParams.get('type');
+    const buckets =
+      type === null
+        ? [
+            { doc_count: 8447, key: 1787664055000 },
+            { doc_count: 7124, key: 1787577655000 },
+          ]
+        : [{ doc_count: countPerType[type] ?? 0, key: 1787664055000 }];
+    req.reply({
+      statusCode: 200,
+      body: { data: { number_by_day: buckets }, error: '', code: 'successful' },
+    });
+  }).as('txCount');
+
+  cy.intercept('GET', '**/v1.0/transaction/statistics*', {
+    statusCode: 200,
+    body: {
+      data: { most_transacted: [{ key: 'KLV', doc_count: 43_564_012 }] },
+      error: '',
+      code: 'successful',
+    },
+  }).as('txStatistics');
+};
+
 const stubTransactionListApis = (): void => {
   stubPrecisions();
 
@@ -118,6 +215,9 @@ const stubTransactionListApis = (): void => {
       body: listResponse(safeIndex),
     });
   }).as('txList');
+
+  // Last, so these win for their own URLs (see stubSummaryApis).
+  stubSummaryApis();
 };
 
 /**
@@ -224,17 +324,23 @@ describe('Transactions Page', () => {
     });
   });
 
-  it('labels every cell with its column, and shows no header row', () => {
-    // Below the tablet breakpoint the table renders as cards: there is no
-    // column header row, and each cell carries its own label instead.
+  it('renders each row as one card: no header row, hash link, labeled facts', () => {
+    // Below the tablet breakpoint the table renders as cards. Since the
+    // restyle a row is ONE card element (not one testid per cell): the hash
+    // links out on top and the other columns become labeled lines.
     cy.get(TABLE_ROW_SELECTOR, { timeout: 15000 }).should(
       'have.length.at.least',
       1,
     );
     cy.get('[data-testid="table-header"]').should('not.exist');
-    cy.get('[data-testid="table-row-0"]')
-      .first()
-      .should('contain.text', 'Transaction Hash');
+    cy.get('[data-testid="table-row-0"]').within(() => {
+      cy.get('[data-testid="transaction-link"]')
+        .should('have.attr', 'href')
+        .and('include', '/transaction/');
+      ['Type', 'From', 'To', 'Block'].forEach(label => {
+        cy.contains(label).should('be.visible');
+      });
+    });
   });
 });
 
@@ -244,6 +350,46 @@ describe('Transactions Page (desktop)', () => {
     stubTransactionListApis();
     cy.visit('/transactions');
     cy.wait('@txList', { timeout: 15000 });
+  });
+
+  /**
+   * The summary card is what the page adds above the table, and it must not
+   * be able to take the table down with it: the figures and the contract
+   * type breakdown are asserted together with the rows still being there.
+   */
+  it('shows the 24 hour figures and the contract type breakdown', () => {
+    cy.wait('@txCount', { timeout: 15000 });
+
+    cy.contains('Transactions (24h)').should('be.visible');
+    // 8447 formatted (formatAmount truncates rather than rounds), and the
+    // change against the previous window (7124).
+    cy.contains('8.44 K').should('be.visible');
+    cy.contains('+18.6%').should('be.visible');
+    cy.contains('Total transactions').should('be.visible');
+    cy.contains('Most transacted').should('be.visible');
+
+    // The named types, their counts, and the remainder that closes the bar
+    // (8447 minus 5747, 1865, 592 and 228). The bar itself carries the
+    // description as its accessible name, like the assets registry strip.
+    //
+    // Scoped to the card, because the page around it is full of numbers and
+    // type names: unscoped, "Transfer" also matches the badge on a row and
+    // "15" matches a block number, an age or part of a longer figure, so the
+    // assertions could pass with the legend missing entirely.
+    cy.get('[aria-label="Transaction statistics"]').within(() => {
+      cy.get('[aria-label="Contract types in the last 24 hours"]').should(
+        'exist',
+      );
+      cy.contains('Transfer').should('be.visible');
+      cy.contains('5.74 K').should('be.visible');
+      cy.contains('Smart Contract').should('be.visible');
+      cy.contains('Other').should('be.visible');
+      // Anchored: the remainder is its own element, and a bare 15 would match
+      // any figure that merely contains those two digits.
+      cy.contains(/^15$/).should('be.visible');
+    });
+
+    cy.get(TABLE_ROW_SELECTOR).should('have.length.at.least', 1);
   });
 
   it('renders the column header row', () => {
@@ -284,18 +430,23 @@ describe('Transactions Page (desktop)', () => {
     cy.get('[data-testid="table-header"]', { timeout: 15000 })
       .children()
       .then(headings => {
-        expect(headings).to.have.length(6);
+        expect(headings).to.have.length(10);
         expect(
           [...headings].map(cell => cell.textContent?.trim()),
         ).to.deep.equal([
           'Transaction Hash',
-          'Block/Fees',
-          'From/To',
-          'In/Out',
           'Type',
-          'Misc',
+          'Block',
+          'Age',
+          'From',
+          // The circled status arrow's column is deliberately unheaded.
+          '',
+          'To',
+          'In/Out',
+          'Amount',
+          'Fee',
         ]);
-        cy.get('[data-testid="table-row-0"]').should('have.length', 6);
+        cy.get('[data-testid="table-row-0"]').should('have.length', 10);
       });
   });
 
@@ -324,6 +475,90 @@ describe('Transactions Page (desktop)', () => {
       timeout: 15000,
     }).should('be.visible');
   });
+
+  /**
+   * The single-line density contract: a row is exactly 60px tall and the
+   * row's key facts stay visible inside it: the hash link, the type badge
+   * and the circled status arrow. Height alone would pass with clipped
+   * content, and visible content alone would pass at any height, so the
+   * assertions only hold together.
+   */
+  it('keeps the hash, type badge and status arrow inside the 60px row', () => {
+    // The container, not a cell. That testid sits on all nine cells of the
+    // row, and they only happen to be 60px because the grid stretches them;
+    // a cell that stopped stretching would keep its own height and let a
+    // taller row through the assertion that names the row.
+    cy.get('[data-testid="table-row-0"]', { timeout: 15000 })
+      .first()
+      .parent()
+      .should($row => {
+        expect(Math.round($row.outerHeight() ?? 0), 'row height').to.eq(60);
+      });
+    const expectedHash = hashForType(0);
+    cy.get(`a[href*="/transaction/${expectedHash}"]`).should('be.visible');
+    // Scoped to the row. Unscoped, "Transfer" also names a segment of the
+    // summary legend above the table, and cypress resolves matches in
+    // document order, so the assertion was satisfied by the card while the
+    // badge it is meant to guard could be clipped or missing.
+    cy.get('[data-testid="table-row-0"]')
+      .parent()
+      .within(() => {
+        cy.contains('Transfer').should('be.visible');
+        // One status arrow per row; its status word sits in the tooltip and
+        // in visually hidden text, so presence, not visibility.
+        cy.contains('Success').should('exist');
+      });
+  });
+});
+
+/**
+ * The Amount column resolves a position in `contractLabels` and uses it to
+ * index the elements `filteredSections` built. The two live in different
+ * files with nothing tying them together, so reordering either one puts a
+ * neighbouring field in this column and nothing says so.
+ *
+ * Neither module can be reached by a unit test: both pull in the ESM
+ * dependency the Jest transform does not cover. This is the only level the
+ * coupling can be held at, and Transfer alone will not do it, because its
+ * amount sits at index 0 where almost anything lands.
+ */
+describe('Transactions Page (desktop, amount column)', () => {
+  /** Its place among the base columns: hash, type, block, age, from, arrow, to, amount, fee. */
+  const AMOUNT_COLUMN_INDEX = 7;
+
+  const CASES = [
+    {
+      label: 'a withdrawal, whose amount sits behind its type',
+      typeIndex: ContractsIndex.Withdraw,
+      // What the cell in front of the amount holds, and so what this column
+      // would show if the position were off by one.
+      neighbour: 'Staking',
+    },
+    {
+      label: 'a deposit, whose amount sits behind its type and its id',
+      typeIndex: ContractsIndex.Deposit,
+      neighbour: 'FPR',
+    },
+  ];
+
+  CASES.forEach(({ label, typeIndex, neighbour }) => {
+    it(`shows a figure and not the field beside it for ${label}`, () => {
+      cy.viewport(...DESKTOP_VIEWPORT);
+      stubTransactionListApis();
+      cy.visit(`/transactions?type=${typeIndex}`);
+      cy.wait('@txList', { timeout: 15000 });
+
+      cy.get(TABLE_ROW_SELECTOR, { timeout: 15000 })
+        .eq(AMOUNT_COLUMN_INDEX)
+        .should($cell => {
+          const text = $cell.text();
+          // A digit, so the empty cell an out-of-range position renders
+          // ("- -") fails too, not only a neighbour landing here.
+          expect(text, 'amount cell').to.match(/\d/);
+          expect(text, 'amount cell').to.not.contain(neighbour);
+        });
+    });
+  });
 });
 
 describe('Block Page i18n', () => {
@@ -335,25 +570,40 @@ describe('Block Page i18n', () => {
     Cypress.env('DEFAULT_API_HOST') || 'https://api.testnet.klever.org';
   const API_VERSION = Cypress.env('DEFAULT_API_VERSION') || 'v1.0';
 
-  /** Same bounded 429 backoff as the detail suite: the shared testnet API
-   * rate-limits, and cy.request fails outright on a non-2xx without
-   * failOnStatusCode. */
+  /**
+   * Bounded backoff against a shared, rate-limited API.
+   *
+   * This runs late in the last-but-one spec, by which point the suite has
+   * spent its allowance: the spec passes on its own and fails inside a full
+   * run, on an endpoint that answers every direct call. So the window is wide
+   * rather than tight, and it retries on any answer without a usable number
+   * rather than on 429 alone. The assertion still demands a real number.
+   */
   const requestLatestBlockNum = (
-    retriesLeft = 5,
+    retriesLeft = 8,
   ): Cypress.Chainable<number> => {
     return cy
       .request({
         url: `${API_BASE}/${API_VERSION}/transaction/list`,
-        qs: { limit: 1, page: 1 },
+        // Filtered the way the detail suite below filters, on purpose. The
+        // unfiltered list answered CI with an empty payload for a minute at a
+        // time while the filtered one in the same run kept working, so this
+        // asks the shape the environment can actually serve. Any real block
+        // carrying a successful transfer satisfies what this test needs.
+        qs: { type: 0, status: 'Success', limit: 1, page: 1 },
         failOnStatusCode: false,
         timeout: 20000,
       })
       .then(res => {
-        if (res.status === 429 && retriesLeft > 0) {
-          cy.wait(2500);
+        const blockNum = res.body?.data?.transactions?.[0]?.blockNum;
+        // Retry on anything that did not yield a usable number, not only on
+        // 429: the list also answers 200 with an empty payload under load.
+        // The assertion below still demands a real number; only the number of
+        // attempts is relaxed.
+        if (typeof blockNum !== 'number' && retriesLeft > 0) {
+          cy.wait(5000);
           return requestLatestBlockNum(retriesLeft - 1);
         }
-        const blockNum = res.body?.data?.transactions?.[0]?.blockNum;
         expect(blockNum, 'blockNum from the live list').to.be.a('number');
         return cy.wrap(blockNum as number);
       });

--- a/public/locales/en/transactions.json
+++ b/public/locales/en/transactions.json
@@ -48,5 +48,33 @@
     "Deposit": "Deposit",
     "ITO Trigger": "ITO Trigger",
     "Smart Contract": "Smart Contract"
+  },
+  "Table": {
+    "TransactionHash": "Transaction Hash",
+    "BlockFees": "Block/Fees",
+    "InOut": "In/Out",
+    "Type": "Type",
+    "Block": "Block",
+    "CopyHash": "Copy transaction hash",
+    "HashCopied": "Transaction hash copied to clipboard",
+    "OpenTransaction": "Open transaction in a new tab",
+    "OpenInNewTab": "Open in a new tab",
+    "ActionType": "Action type",
+    "NotApplicable": "Not applicable",
+    "Age": "Age",
+    "Amount": "Amount",
+    "Fee": "Fee"
+  },
+  "Summary": {
+    "Breakdown": "Contract types in the last 24 hours",
+    "Down": "down {{percent}} compared with the previous 24 hours",
+    "FungibleBasis": "Leading fungible asset",
+    "Growth": "grew {{percent}} in the last 24 hours",
+    "Label": "Transaction statistics",
+    "Last24h": "Transactions (24h)",
+    "MostTransacted": "Most transacted",
+    "OtherTypes": "Other",
+    "Total": "Total transactions",
+    "Up": "up {{percent}} compared with the previous 24 hours"
   }
 }

--- a/src/components/Asset/NonFungibleView.tsx
+++ b/src/components/Asset/NonFungibleView.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { NonceDetails } from '@/components/Asset/NFTDetails';
 import Table, { ITable } from '@/components/Table';
+import { TransactionsTableWrapper } from '@/components/TransactionsList/styles';
 import {
   CardContent,
   CardHeader,
@@ -52,7 +53,9 @@ export const NonFungibleView: React.FC<
       <CardContainer>
         <SingleNFTTableContainer>
           <h3>Asset Transactions</h3>
-          <Table {...tableProps} />
+          <TransactionsTableWrapper>
+            <Table {...tableProps} />
+          </TransactionsTableWrapper>
         </SingleNFTTableContainer>
       </CardContainer>
     </>

--- a/src/components/Asset/SemiFungibleView.tsx
+++ b/src/components/Asset/SemiFungibleView.tsx
@@ -1,6 +1,7 @@
 import { SftMetadata } from '@/components/Asset/SFTMetadata';
 import { SftOverviewTab } from '@/components/Asset/SftOverviewTab';
 import Table, { ITable } from '@/components/Table';
+import { TransactionsTableWrapper } from '@/components/TransactionsList/styles';
 import { requestSftDetails } from '@/services/requests/asset/nonce';
 import {
   CardContent,
@@ -53,7 +54,9 @@ export const SemiFungibleView: React.FC<
 
       <CardContainer>
         <h3>Asset Transactions</h3>
-        <Table {...tableProps} />
+        <TransactionsTableWrapper>
+          <Table {...tableProps} />
+        </TransactionsTableWrapper>
       </CardContainer>
     </>
   );

--- a/src/components/DataList/SummaryLoading.tsx
+++ b/src/components/DataList/SummaryLoading.tsx
@@ -8,6 +8,9 @@ interface ISummaryLoadingProps {
   tiles: number;
   /** Strips that end in a distribution bar reserve its height too. */
   bar?: boolean;
+  /** Lets a page add its own spacing without the loaded card and this one
+   * drifting apart, which would jump the page once the figures arrive. */
+  className?: string;
 }
 
 /**
@@ -19,8 +22,9 @@ const SummaryLoading: React.FC<ISummaryLoadingProps> = ({
   label,
   tiles,
   bar,
+  className,
 }) => (
-  <SummaryCard aria-label={label}>
+  <SummaryCard aria-label={label} className={className}>
     <SummarySkeletonRow>
       {Array.from({ length: tiles }, (_, index) => (
         <Skeleton key={index} width={150} height={56} />

--- a/src/components/DataList/styles.ts
+++ b/src/components/DataList/styles.ts
@@ -35,7 +35,7 @@ export const DATA_LIST_ROW_HEIGHT = '60px';
  * spots (violet on dark cards is 3.3:1, red at badge size 3.4:1), so each
  * mode gets a hand-picked equivalent.
  */
-const accentText = ({ theme }: { theme: DefaultTheme }): string =>
+export const accentText = ({ theme }: { theme: DefaultTheme }): string =>
   theme.dark ? '#C95ED4' : theme.violet;
 
 const voidText = ({ theme }: { theme: DefaultTheme }): string =>
@@ -77,7 +77,7 @@ export const inCard = (display: string, fontWeight?: number) => css`
   }
 `;
 
-const focusRing = css`
+export const focusRing = css`
   &:focus-visible {
     outline: 2px solid ${props => props.theme.violet};
     outline-offset: 2px;
@@ -99,9 +99,16 @@ export const VisuallyHidden = styled.span`
 
 /* --------------------------------- badges -------------------------------- */
 
-type BadgeVariant = 'void' | 'contract' | 'neutral' | 'warning' | 'accent';
+export type BadgeVariant =
+  | 'void'
+  | 'contract'
+  | 'neutral'
+  | 'warning'
+  | 'accent'
+  | 'success'
+  | 'danger';
 
-const badgeColor = (
+export const badgeColor = (
   props: { theme: DefaultTheme },
   variant: BadgeVariant,
 ): string => {
@@ -118,10 +125,23 @@ const badgeColor = (
       return theme.dark ? '#EB9C27' : '#8F5A00';
     case 'accent':
       return accentText(props);
+    case 'success':
+      // successColor is derived for icon size, where 3:1 suffices. Badge
+      // text at 0.625rem needs 4.5:1, which the light value misses (3.33:1
+      // on the tint), so this spot darkens it further: 4.98:1 on the tint,
+      // 4.70:1 on a hovered row.
+      return theme.dark ? successColor(props) : '#217A50';
+    case 'danger':
+      // Red kin of the void badge; a separate name because a failed
+      // transaction and the burn address are unrelated concepts, and a
+      // slightly darker light value than voidText because the badge must
+      // hold 4.5:1 on a hovered row's violet tint (4.78:1; voidText dips
+      // to 4.39:1 there).
+      return theme.dark ? voidText(props) : '#BE3448';
   }
 };
 
-const badgeTint = (
+export const badgeTint = (
   props: { theme: DefaultTheme },
   variant: BadgeVariant,
 ): string => {
@@ -139,6 +159,12 @@ const badgeTint = (
       break;
     case 'accent':
       base = theme.violet;
+      break;
+    case 'success':
+      base = theme.green;
+      break;
+    case 'danger':
+      base = theme.red;
       break;
     default:
       base = theme.blueGray500;
@@ -531,7 +557,7 @@ export const MobileListCard = styled.div`
   border-radius: 8px;
   border: solid 1px
     ${props => (props.theme.dark ? props.theme.darkGray : props.theme.black10)};
-  background-color: ${props => props.theme.table.background};
+  background-color: ${props => props.theme.white};
 `;
 
 export const MobileTopRow = styled.div`
@@ -643,9 +669,13 @@ export const dataListTableSkin = css`
          (z-index 2) and the site navigation (6). */
       z-index: 1;
       padding: 12px;
+      /* Tinted against the card it sits on, not against the page. Mixing into
+         the page colour left the band darker than its own surface once the
+         card stopped borrowing that colour: 1.02 against the card, and the
+         wrong way round. Light mixes into the same surface and reads 1.07. */
       background-color: ${props =>
         props.theme.dark
-          ? mix(0.05, '#FFFFFF', props.theme.background)
+          ? mix(0.05, '#FFFFFF', props.theme.white)
           : mix(0.03, props.theme.black, props.theme.white)};
       border-bottom: 1px solid ${props => props.theme.black10};
       /* Typography inherits like every other table header on the site

--- a/src/components/ExplorerLink/__tests__/index.test.tsx
+++ b/src/components/ExplorerLink/__tests__/index.test.tsx
@@ -105,4 +105,44 @@ describe('ExplorerLink compact mode', () => {
     expect(screen.getByText('QR Code')).toBeInTheDocument();
     expect(screen.getByText('Transfer')).toBeInTheDocument();
   });
+
+  describe('the monospace an address type gets', () => {
+    /** The link's own text node, whichever wrapper it ended up in. */
+    const renderedInside = (text: string): string =>
+      screen.getByText(text).tagName;
+
+    it('wraps a hash-shaped type in its own element', () => {
+      render(
+        <ThemeProvider theme={theme}>
+          <ExplorerLink type="smart-contract" value="klv1abc" compact />
+        </ThemeProvider>,
+      );
+
+      // The address goes through Mono, which renders a span of its own inside
+      // the anchor rather than putting the text straight in the link.
+      const anchor = screen.getByText('klv1abc').closest('a') as HTMLElement;
+      expect(anchor.firstElementChild).not.toBeNull();
+      expect(renderedInside('klv1abc')).toBe('SPAN');
+    });
+
+    it('gives way when the label brings its own typography', () => {
+      // A resolved contract name is words, not a hash, so the caller turns the
+      // monospace off and the label renders exactly as it was handed over.
+      render(
+        <ThemeProvider theme={theme}>
+          <ExplorerLink
+            type="smart-contract"
+            value="klv1abc"
+            label={<b>Bitcoin.me</b>}
+            mono={false}
+            compact
+          />
+        </ThemeProvider>,
+      );
+
+      expect(renderedInside('Bitcoin.me')).toBe('B');
+      const anchor = screen.getByText('Bitcoin.me').closest('a') as HTMLElement;
+      expect(anchor.firstElementChild?.tagName).toBe('B');
+    });
+  });
 });

--- a/src/components/ExplorerLink/index.tsx
+++ b/src/components/ExplorerLink/index.tsx
@@ -28,9 +28,18 @@ const routes: Record<ExplorerLinkType, string> = {
 interface ExplorerLinkProps {
   type: ExplorerLinkType;
   value?: string;
-  label?: string;
+  /** Plain text, or a node for a label that decides its own typography. */
+  label?: React.ReactNode;
   /** Use in table row sections — hides icons inside a hover dropdown */
   compact?: boolean;
+  /** Testid for the link itself, e.g. the smoke suite's transaction-link. */
+  dataTestId?: string;
+  /**
+   * Overrides the monospace an address type gets by default. A label that
+   * renders a name rather than a hash sets this, because a name belongs in
+   * the page font.
+   */
+  mono?: boolean;
 }
 
 const monoTypes: ExplorerLinkType[] = [
@@ -45,6 +54,8 @@ const ExplorerLink: React.FC<ExplorerLinkProps> = ({
   value,
   label,
   compact,
+  dataTestId,
+  mono,
 }) => {
   if (!value) {
     return <span>{label || '--'}</span>;
@@ -52,22 +63,27 @@ const ExplorerLink: React.FC<ExplorerLinkProps> = ({
 
   const href = `${routes[type]}/${value}`;
   const displayText = label || value;
-  const text = monoTypes.includes(type) ? (
-    <Mono>{displayText}</Mono>
-  ) : (
-    displayText
-  );
+  const text =
+    (mono ?? monoTypes.includes(type)) ? (
+      <Mono>{displayText}</Mono>
+    ) : (
+      displayText
+    );
 
   if (compact) {
     return (
       <LinkWithDropdown link={href} address={value || ''} entity={type}>
-        <Link href={href}>{text}</Link>
+        <Link href={href} data-testid={dataTestId}>
+          {text}
+        </Link>
       </LinkWithDropdown>
     );
   }
   return (
     <CenteredRow>
-      <Link href={href}>{text}</Link>
+      <Link href={href} data-testid={dataTestId}>
+        {text}
+      </Link>
       <a
         href={href}
         target="_blank"

--- a/src/components/Filter/styles.ts
+++ b/src/components/Filter/styles.ts
@@ -122,8 +122,11 @@ export const SelectorContainer = styled.div<{ open: boolean }>`
 
   gap: 0.25rem;
 
-  background-color: ${props =>
-    props.theme.dark ? props.theme.background : props.theme.white};
+  /* The raised surface, as everywhere else. This one matters most: the panel
+     floats over the page, and reading the background token gave it the page's
+     own colour, so an overlay had nothing separating it from what it covered.
+     Reads #fff in the light theme and #151515 in the dark one. */
+  background-color: ${props => props.theme.white};
 
   border: 1px solid ${props => props.theme.black10};
   border-radius: 16px;

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -17,10 +17,14 @@ export const Container = styled.div`
   right: 0;
   z-index: 6;
   transition: top 0.1s linear;
-  background-color: ${props =>
-    props.theme.dark ? props.theme.background : props.theme.true.white};
+  /* The raised surface, the same one the cards and tables sit on: #fff in the
+     light theme, #151515 in the dark one. Reading the background token for
+     dark gave the bar the page's own colour, so it had no edge of its own and
+     only its hairline told a reader where the chrome ended. Identical in
+     light, where both tokens are #fff. */
+  background-color: ${props => props.theme.white};
   border-bottom: 1px solid
-    ${props => (props.theme.dark ? props.theme.blue : props.theme.black10)};
+    ${props => (props.theme.dark ? props.theme.black20 : props.theme.black10)};
   @media (min-width: ${props => props.theme.breakpoints.mobile}) {
     width: 100%;
     justify-content: space-between;
@@ -478,7 +482,7 @@ export const ConnectionWrapper = styled.div`
   z-index: 3;
   padding: 0.75rem 1.5rem;
   border-bottom: 1px solid
-    ${props => (props.theme.dark ? props.theme.blue : props.theme.black10)};
+    ${props => (props.theme.dark ? props.theme.black20 : props.theme.black10)};
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/Home/CoinDataFetcher/CoinCard/styles.ts
+++ b/src/components/Home/CoinDataFetcher/CoinCard/styles.ts
@@ -3,7 +3,7 @@ import { TableGradientBorder } from '@/components/Table/styles';
 import { DefaultCardStyles } from '@/styles/common';
 import { DataCardDefaultStyles } from '@/views/home';
 import Image from 'next/legacy/image';
-import styled, { css, keyframes } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 interface IVariation {
   positive: boolean;
 }
@@ -106,16 +106,16 @@ export const CardContentError = styled(CardContent)`
   justify-content: center;
 `;
 
+/**
+ * The loading shape sits inside the coin card, so it takes the same surface
+ * the card does in both themes. It used to hardcode the near-black the card
+ * itself once borrowed from the page; now that the card has a surface of its
+ * own, that value would draw a darker rectangle where the seam should be
+ * invisible.
+ */
 export const CardContainerSkeleton = styled(CardContainer)`
   padding: 1.5rem 1.5rem 1.5rem 1.5rem;
-  ${props =>
-    props.theme.dark
-      ? css`
-          background-color: ${props.theme.true.newBlack} !important;
-        `
-      : css`
-          ${DefaultCardStyles}
-        `};
+  ${DefaultCardStyles}
 `;
 
 export const HeaderContainer = styled.div`

--- a/src/components/Logo/styles.ts
+++ b/src/components/Logo/styles.ts
@@ -38,12 +38,25 @@ export const LetterLogo = styled.div<{ invertColors?: boolean }>`
   float: left;
 `;
 
-export const Verified = styled(Certified)`
+/**
+ * The corner mark on a verified asset, sized against the logo rather than
+ * left at the icon's own 24px, which covered three quarters of a 32px list
+ * logo.
+ *
+ * The viewBox is restored here because the SVG pipeline strips it from
+ * Certified.svg. Without one, a width does not scale the drawing: it crops
+ * it, so the mark rendered as a cut-off wedge instead of a check, which is
+ * invisible at icon size and unmistakable when magnified.
+ */
+export const Verified = styled(Certified).attrs({ viewBox: '0 0 24 24' })`
   position: absolute;
   right: 0;
-  top: -1rem;
+  top: 0;
 
-  transform: translate(50%, 50%);
+  width: 45%;
+  height: 45%;
+
+  transform: translate(15%, -15%);
 `;
 
 export const NextImageWrapperLogo = styled.div`

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -190,6 +190,21 @@ const Table = <TCard,>({
     // them for placeholders and back made paging flicker.
     placeholderData: keepPreviousData,
 
+    // A step out and back is a common move, and every list here costs a
+    // round trip the API answers in about a second. Inside this window the
+    // rows a reader just looked at are shown again without asking for them a
+    // second time. A page load, a filter change and the refresh control all
+    // bypass it, so nothing here can pin a stale list on screen.
+    //
+    // Only a list that actually has rows. `tableRequest` turns every failure
+    // into an empty result and react-query files that as a success, so
+    // without this an API that was briefly down would keep answering "no data
+    // here" from cache for ten seconds instead of retrying on the next mount.
+    staleTime: query =>
+      (query.state.data as { items?: unknown[] } | undefined)?.items?.length
+        ? 10_000
+        : 0,
+
     ...onErrorHandler(),
   });
 

--- a/src/components/Table/styles.ts
+++ b/src/components/Table/styles.ts
@@ -17,13 +17,22 @@ export const ContainerView = styled.div`
   width: 100%;
 `;
 
+/**
+ * The card's own surface, plus the gradient hairline around it.
+ *
+ * The fill is `white` in both themes on purpose. That token is the raised
+ * surface, not the colour white: #fff in the light theme and #151515 in the
+ * dark one. Filling the dark card with `background` instead, as this did,
+ * gave it exactly the page's own colour, so a table and a summary card had no
+ * surface at all and the hairline was left holding them together on its own.
+ * Measured: interior against page was 1.00 in dark and 1.10 in light; reading
+ * `white` in both makes it 1.11, the same step the light theme has.
+ */
 export const TableGradientBorder = css`
   border: 1px solid transparent;
   background-image: linear-gradient(
-      ${props =>
-        props.theme.dark ? props.theme.background : props.theme.white},
-      ${props =>
-        props.theme.dark ? props.theme.background : props.theme.white}
+      ${props => props.theme.white},
+      ${props => props.theme.white}
     ),
     linear-gradient(
       to bottom,
@@ -166,7 +175,7 @@ export const TableRow = styled.div<TableRowProps>`
       ${props =>
         props.theme.dark ? props.theme.darkGray : props.theme.black10};
 
-    background-color: ${props => props.theme.table.background};
+    background-color: ${props => props.theme.white};
   }
 
   @media screen and (min-width: ${props => props.theme.breakpoints.tablet}) {
@@ -353,10 +362,6 @@ export const Status = styled.span<IStatus>`
   @media screen and (max-width: ${props => props.theme.breakpoints.tablet}) {
     width: fit-content;
   }
-`;
-
-export const InOutSpan = styled(Status)`
-  min-width: 50px !important;
 `;
 
 export const EmptyRow = styled.div`

--- a/src/components/Tabs/Transactions/index.tsx
+++ b/src/components/Tabs/Transactions/index.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren } from 'react';
 import Table, { ITable } from '@/components/Table';
 import TransactionsFilters from '@/components/TransactionsFilters';
+import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
+import { TransactionsTableWrapper } from '@/components/TransactionsList/styles';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import { transactionRowSections } from '@/pages/transactions';
 import { IInnerTableProps } from '@/types/index';
@@ -24,9 +26,15 @@ const Transactions: React.FC<PropsWithChildren<ITransactionsProps>> = props => {
     header,
     type: 'transactions',
     Filters: TransactionsFilters,
+    MobileCard: TransactionsMobileCard,
+    singleLineSkeleton: true,
   };
 
-  return <Table {...tableProps} />;
+  return (
+    <TransactionsTableWrapper>
+      <Table {...tableProps} />
+    </TransactionsTableWrapper>
+  );
 };
 
 export default Transactions;

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -10,6 +10,13 @@ interface ITooltipProps {
   customStyles?: ICustomStyles;
   minMsgLength?: number;
   maxVw?: number;
+  /**
+   * Opt-in: the trigger joins the tab order and the tooltip opens on focus,
+   * for tooltips whose message is not readable anywhere else on the page.
+   * Off by default so existing hover-hint tooltips do not become extra tab
+   * stops.
+   */
+  focusable?: boolean;
 }
 
 const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
@@ -18,6 +25,7 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
   customStyles,
   minMsgLength = 0,
   maxVw,
+  focusable = false,
 }) => {
   const [displayMessage, setDisplayMessage] = useState(false);
   const parsedMsgs = msg.split('\n');
@@ -26,6 +34,11 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
       className="button-tooltip"
       onMouseOver={() => setDisplayMessage(true)}
       onMouseLeave={() => setDisplayMessage(false)}
+      {...(focusable && {
+        tabIndex: 0,
+        onFocus: () => setDisplayMessage(true),
+        onBlur: () => setDisplayMessage(false),
+      })}
       maxVw={maxVw}
     >
       {Component ? (

--- a/src/components/TransactionsList/ContractTargetLabel.tsx
+++ b/src/components/TransactionsList/ContractTargetLabel.tsx
@@ -1,0 +1,108 @@
+import { Mono } from '@/styles/common';
+import { parseAddress } from '@/utils/parseValues';
+import React from 'react';
+import { ContractName } from './styles';
+import { useContractName } from './useContractName';
+
+export interface IContractTargetLabelProps {
+  address: string;
+  isContract?: boolean;
+  /** How many characters of the address to keep when no name is known. */
+  truncateTo: number;
+}
+
+/**
+ * The longest name this cell will draw. A name is set by whoever owns the
+ * account, through SetAccountName, so it is untrusted text of any length: a
+ * 200 character one was measured to widen the page from 800px to 1838px and
+ * put the whole table behind a horizontal scrollbar. Real names on mainnet
+ * reach 32 characters ("Hardlock5 Certification Registry"), which is where
+ * this sits.
+ */
+const NAME_LIMIT = 32;
+
+/**
+ * Characters that let a name lie about itself rather than merely be ugly:
+ * the bidi overrides and isolates, which paint text right to left so a
+ * reversed string reads as a well known domain, plus the zero-width marks
+ * and the control blocks. \s does not cover any of them.
+ *
+ * Enumerated rather than taken by Unicode category: \p{Cf} would say this in
+ * one term, but it needs the u flag and this project compiles to es5. The
+ * three Hangul fillers are not formatting characters at all, they draw as a
+ * blank glyph, which is the same lie by another route. The trailing
+ * alternation is the tag block, which lives outside the BMP and so arrives
+ * here as a surrogate pair.
+ */
+const DECEPTIVE =
+  /[\u0000-\u001F\u007F-\u009F\u061C\u115F\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\u3164\uE000-\uF8FF\uFE00-\uFE0F\uFEFF\uFFA0\uFFF9-\uFFFB]|\uDB40[\uDC00-\uDC7F]/g;
+
+/**
+ * A name shaped like a wallet address, which no honest name needs to be.
+ *
+ * Matched as a prefix rather than as the whole string. A reader sees the
+ * first 32 characters, so a name that is an address with one disqualifying
+ * character past that point passed a whole-string test and was then drawn as
+ * a plain address once the tail was cut away.
+ */
+const LOOKS_LIKE_AN_ADDRESS = /^klv1[0-9a-z]{6,}/i;
+
+/**
+ * What of a name is safe to draw. Returns an empty string for a name that
+ * survives none of this, and the row keeps its address.
+ *
+ * The name stands where the counterparty address used to, so it is the only
+ * identifier a reader sees. That makes impersonation the risk worth spending
+ * code on: a name that reads as an address, or one that reverses itself into
+ * somebody else's brand, would be a lie in the one field the reader trusts.
+ *
+ * Cut first, then judge. Judging the whole name and drawing a shortened one
+ * asks the question about a string the reader never sees.
+ */
+const displayName = (name: string): string => {
+  const cleaned = name.replace(DECEPTIVE, '').replace(/\s+/g, ' ').trim();
+  const shown =
+    cleaned.length > NAME_LIMIT
+      ? `${cleaned.slice(0, NAME_LIMIT)}\u2026`
+      : cleaned;
+
+  if (!shown || LOOKS_LIKE_AN_ADDRESS.test(shown)) return '';
+
+  return shown;
+};
+
+/**
+ * What a row shows for the address it points at: the contract's own name when
+ * the chain has one, and the shortened address otherwise.
+ *
+ * The name arrives on its own request, so a row paints its address first and
+ * takes the name when it lands. That keeps a decoration off the path the
+ * table has to walk before it can show anything at all.
+ *
+ * A name is words and gets the page font; an address is a hash and keeps the
+ * monospace that makes its middle ellipsis line up down the column.
+ */
+const ContractTargetLabel: React.FC<IContractTargetLabelProps> = ({
+  address,
+  isContract,
+  truncateTo,
+}) => {
+  const name = useContractName(address, Boolean(isContract));
+  const shown = name ? displayName(name) : '';
+
+  // Both readings share one fixed box. The name lands about a second after
+  // the row is readable, and a cell that resizes on arrival drags every
+  // column beside it; identical width either way means nothing moves.
+  //
+  // A name that survives none of the cleaning is not a name; the address is.
+  // The title carries the cleaned text plus the address, so the cell is never
+  // the only place the counterparty is named, and the characters kept out of
+  // the cell cannot reappear in the browser's own tooltip.
+  return (
+    <ContractName title={shown ? `${shown} · ${address}` : address}>
+      {shown || <Mono>{parseAddress(address, truncateTo)}</Mono>}
+    </ContractName>
+  );
+};
+
+export default ContractTargetLabel;

--- a/src/components/TransactionsList/MobileCard.tsx
+++ b/src/components/TransactionsList/MobileCard.tsx
@@ -1,0 +1,228 @@
+import CopyAction from '@/components/DataList/CopyAction';
+import ExplorerLink from '@/components/DataList/ExplorerLink';
+import {
+  MobileListCard,
+  MobileMetaItem,
+  MobileTopRow,
+  RowActions,
+  VisuallyHidden,
+} from '@/components/DataList/styles';
+import { Mono } from '@/styles/common';
+import { ITransaction } from '@/types';
+import { ContractsName } from '@/types/contracts';
+import {
+  contractTypes,
+  filteredSections,
+  getLabelForTableField,
+} from '@/utils/contracts';
+import { formatAmount, formatDate } from '@/utils/formatFunctions';
+import { KLV_PRECISION } from '@/utils/globalVariables';
+import { parseAddress } from '@/utils/parseValues';
+import { useTranslation } from 'next-i18next';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React from 'react';
+import {
+  InOutBadge,
+  MultiContractBadge,
+  TransactionStatusBadge,
+} from './badges';
+import { showsInOut } from './columns';
+import ContractTargetLabel from './ContractTargetLabel';
+import { getTransactionRowDetails, valueDirection } from './rowDetails';
+import { CardHashLink, CardLabel, CardRow, CardValue } from './styles';
+
+export interface ITransactionsMobileCardProps {
+  item: ITransaction;
+  index: number;
+}
+
+/**
+ * Card layout for mobile and tablet: the hash with its status on top, then
+ * the same facts the desktop columns carry, one labeled line each. Replaces
+ * the generic heading-per-cell card the shared Table falls back to.
+ */
+const TransactionsMobileCard: React.FC<ITransactionsMobileCardProps> = ({
+  item,
+  index,
+}) => {
+  const { t } = useTranslation(['transactions']);
+  const router = useRouter();
+  const {
+    hash,
+    blockNum,
+    timestamp,
+    sender,
+    receipts,
+    contract,
+    kAppFee,
+    bandwidthFee,
+    status,
+    precision,
+    data,
+  } = item;
+
+  const contractType = contractTypes(contract);
+  // Same source as the desktop To column, so the card and the table cannot
+  // disagree about a row's counterparty (contract address for invokes, the
+  // claimer for claims and withdrawals).
+  const { target } = getTransactionRowDetails({
+    contract,
+    contractType,
+    data,
+    sender,
+    receipts,
+  });
+  const direction = valueDirection({
+    account:
+      typeof router?.query?.account === 'string'
+        ? router.query.account
+        : undefined,
+    sender,
+    contractType,
+    receipts,
+  });
+  // Undefined is an answer: a delegation aimed at this validator moves nothing
+  // into it, and a badge either way would be a claim the transaction does not
+  // make.
+  const showDirection = showsInOut(router) && direction !== undefined;
+
+  const typeLabel =
+    contractType === 'Multi contract'
+      ? contractType
+      : // Same fallback as the desktop badge: a future contract type shows
+        // its raw name instead of an empty value.
+        (ContractsName[contractType as keyof typeof ContractsName] ??
+        contractType);
+
+  const customFields = filteredSections(
+    contract,
+    contractType,
+    receipts,
+    precision,
+    data,
+  );
+  const customLabels = getLabelForTableField(contractType) ?? [];
+
+  return (
+    <MobileListCard data-testid={`table-row-${index}`}>
+      <MobileTopRow>
+        <CardHashLink
+          href={`/transaction/${hash}`}
+          data-testid="transaction-link"
+        >
+          <Mono>{parseAddress(hash, 16)}</Mono>
+        </CardHashLink>
+        <TransactionStatusBadge status={status} />
+        {showDirection && <InOutBadge direction={direction} />}
+        <RowActions>
+          <CopyAction
+            value={hash}
+            label={t('transactions:Table.CopyHash', {
+              defaultValue: 'Copy transaction hash',
+            })}
+            announcement={t('transactions:Table.HashCopied', {
+              defaultValue: 'Transaction hash copied to clipboard',
+            })}
+            large
+          />
+          <ExplorerLink
+            href={`/transaction/${hash}`}
+            label={t('transactions:Table.OpenTransaction', {
+              defaultValue: 'Open transaction in a new tab',
+            })}
+            title={t('transactions:Table.OpenInNewTab', {
+              defaultValue: 'Open in a new tab',
+            })}
+            large
+          />
+        </RowActions>
+      </MobileTopRow>
+      <CardRow>
+        <CardLabel>
+          {t('transactions:Table.Type', { defaultValue: 'Type' })}
+        </CardLabel>
+        <CardValue>
+          {contractType === 'Multi contract' ? (
+            <MultiContractBadge contract={contract} />
+          ) : (
+            typeLabel
+          )}
+        </CardValue>
+      </CardRow>
+      <CardRow>
+        <CardLabel>
+          {t('transactions:From', { defaultValue: 'From' })}
+        </CardLabel>
+        <CardValue>
+          <Link href={`/account/${sender}`}>
+            <Mono>{parseAddress(sender, 16)}</Mono>
+          </Link>
+        </CardValue>
+      </CardRow>
+      <CardRow>
+        <CardLabel>{t('transactions:To', { defaultValue: 'To' })}</CardLabel>
+        <CardValue>
+          {target ? (
+            <Link
+              href={`${target.isContract ? '/smart-contract' : '/account'}/${
+                target.address
+              }`}
+            >
+              <ContractTargetLabel
+                address={target.address}
+                isContract={target.isContract}
+                truncateTo={16}
+              />
+            </Link>
+          ) : (
+            <>
+              <Mono aria-hidden="true">--</Mono>
+              <VisuallyHidden>
+                {t('transactions:Table.NotApplicable', {
+                  defaultValue: 'Not applicable',
+                })}
+              </VisuallyHidden>
+            </>
+          )}
+        </CardValue>
+      </CardRow>
+      <CardRow>
+        <CardLabel>
+          {t('transactions:Table.BlockFees', { defaultValue: 'Block/Fees' })}
+        </CardLabel>
+        <CardValue>
+          <Link href={`/block/${blockNum || 0}`}>{blockNum || 0}</Link>
+          <MobileMetaItem>
+            {formatAmount((kAppFee + bandwidthFee) / 10 ** KLV_PRECISION)} KLV
+          </MobileMetaItem>
+        </CardValue>
+      </CardRow>
+      {customLabels.map((label, fieldIndex) =>
+        customFields[fieldIndex] ? (
+          <CardRow key={label}>
+            <CardLabel>
+              {label === 'Type'
+                ? // Several label sets (Smart Contract, ITO Trigger) name
+                  // their first field "Type" too; on desktop the column
+                  // headings disambiguate, on one card the same label twice
+                  // with different values reads as a contradiction.
+                  t('transactions:Table.ActionType', {
+                    defaultValue: 'Action type',
+                  })
+                : label}
+            </CardLabel>
+            <CardValue>{customFields[fieldIndex]}</CardValue>
+          </CardRow>
+        ) : null,
+      )}
+      <CardRow>
+        <MobileMetaItem>
+          {formatDate(timestamp || Date.now(), { showElapsedTime: true })}
+        </MobileMetaItem>
+      </CardRow>
+    </MobileListCard>
+  );
+};
+
+export default TransactionsMobileCard;

--- a/src/components/TransactionsList/Summary.tsx
+++ b/src/components/TransactionsList/Summary.tsx
@@ -1,0 +1,254 @@
+import {
+  DistBar,
+  DistSegment,
+  LegendDot,
+  LegendItem,
+  LegendRow,
+  Tile,
+  TileLabel,
+  TileSub,
+  TileValue,
+  TileValueRow,
+  TilesGrid,
+  VisuallyHidden,
+} from '@/components/DataList/styles';
+// The same percent policy the holders and assets legends use, so the two
+// visually identical legends cannot format the same quantity differently.
+import { formatShare } from '@/components/DataList/format';
+import {
+  ITransactionTypeShare,
+  summaryVariation,
+  totalGrowth,
+  transactionsSummaryCall,
+} from '@/services/requests/transactions/summary';
+import { formatAmount } from '@/utils/formatFunctions';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+import { useTheme } from 'styled-components';
+import {
+  PageSummaryCard,
+  PageSummaryLoading,
+  SummaryAssetLink,
+  TrendValue,
+} from './styles';
+
+/**
+ * Percentage with its sign, e.g. "+18.6%". A rate, not a share, so it has no
+ * ceiling: a figure that more than doubled reads "+140%" rather than being
+ * clamped. The precision is a parameter because the day-on-day change lands
+ * in whole percents while the chain's own growth is a fraction of one.
+ */
+const formatVariation = (variation: number, precision = 1): string =>
+  `${variation > 0 ? '+' : ''}${(variation * 100).toFixed(precision)}%`;
+
+/**
+ * The figures above the transactions list: the last rolling 24 hours with
+ * its change against the window before it, the chain's total, and the
+ * leading fungible asset. Only the unscoped list shows it; the same table
+ * inside an account, asset or block is narrowed to that subject, where
+ * chain-wide figures would say nothing about what the reader came for.
+ */
+const TransactionsSummary: React.FC = () => {
+  const { t } = useTranslation(['transactions']);
+  const theme = useTheme();
+  const label = t('transactions:Summary.Label', {
+    defaultValue: 'Transaction statistics',
+  });
+  const { data: summary, isLoading } = useQuery({
+    queryKey: ['transactionsSummary'],
+    queryFn: transactionsSummaryCall,
+    // The figures move by the second; refetching on every mount would make
+    // the card flicker without telling the reader anything new.
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return <PageSummaryLoading label={label} tiles={3} bar />;
+  }
+
+  /** One color per named type, with the computed remainder muted. */
+  const segmentColor = (share: ITransactionTypeShare, index: number): string =>
+    share.name === 'Other'
+      ? theme.blueGray500
+      : [theme.violet, theme.purple, theme.lightPurple, theme.green][index % 4];
+
+  const variation = summary ? summaryVariation(summary) : undefined;
+  const growth = summary ? totalGrowth(summary) : undefined;
+  // Each figure is shown only when its own request answered; a failed part
+  // leaves its tile out instead of printing a zero the chain never had.
+  const hasFigures =
+    summary &&
+    (summary.last24h !== undefined ||
+      summary.totalTransactions !== undefined ||
+      summary.mostTransactedAsset !== undefined);
+
+  if (!summary || !hasFigures) return null;
+
+  // The shares sum to the window's own total; using that sum rather than
+  // last24h keeps the bar full even if the parts answered moments apart.
+  const breakdownTotal = summary.breakdown.reduce(
+    (sum, share) => sum + share.count,
+    0,
+  );
+
+  return (
+    <PageSummaryCard aria-label={label}>
+      <TilesGrid>
+        {summary.last24h !== undefined && (
+          <Tile>
+            <TileLabel>
+              {t('transactions:Summary.Last24h', {
+                defaultValue: 'Transactions (24h)',
+              })}
+            </TileLabel>
+            <TileValueRow>
+              <TileValue>{formatAmount(summary.last24h)}</TileValue>
+            </TileValueRow>
+            {variation !== undefined && (
+              <TileSub>
+                {/* The same threshold the wording below uses. Splitting them
+                    at zero painted an unchanged day in the falling colour
+                    while the words beside it read "up 0.0%". */}
+                <TrendValue $positive={variation >= 0}>
+                  <span aria-hidden="true">{formatVariation(variation)}</span>
+                  {/* The direction in words: a leading "+" is commonly not
+                      announced, which would leave a rise and a fall sounding
+                      identical. */}
+                  <VisuallyHidden>
+                    {t(
+                      variation < 0
+                        ? 'transactions:Summary.Down'
+                        : 'transactions:Summary.Up',
+                      {
+                        defaultValue:
+                          variation < 0
+                            ? 'down {{percent}} compared with the previous 24 hours'
+                            : 'up {{percent}} compared with the previous 24 hours',
+                        // Without the sign: the word already carries the
+                        // direction, and "up +23.5%" reads as a stutter.
+                        percent: `${(Math.abs(variation) * 100).toFixed(1)}%`,
+                      },
+                    )}
+                  </VisuallyHidden>
+                </TrendValue>
+              </TileSub>
+            )}
+          </Tile>
+        )}
+
+        {summary.totalTransactions !== undefined && (
+          <Tile>
+            <TileLabel>
+              {t('transactions:Summary.Total', {
+                defaultValue: 'Total transactions',
+              })}
+            </TileLabel>
+            <TileValueRow>
+              {/* Written out, not compacted: this is the figure a reader may
+                  want to quote, and "58.55 M" throws five digits away.
+                  Rendered the way the home page renders the same number, in
+                  the reader's own locale, rather than through the pinned
+                  toLocaleFixed. That helper exists to stop a server and a
+                  browser disagreeing mid-hydration, which cannot happen here:
+                  the query above is unresolved during SSR, so the server
+                  renders the skeleton and never this number. */}
+              <TileValue>
+                {summary.totalTransactions.toLocaleString()}
+              </TileValue>
+            </TileValueRow>
+            {growth !== undefined && (
+              <TileSub>
+                {/* formatVariation, not formatShare: a share formatter clamps
+                    at 100% and carries a ">99.9%" branch, so a young chain
+                    that more than doubled in a day would read "+100%". This
+                    is a rate, and it has no ceiling. */}
+                <TrendValue $positive={growth >= 0}>
+                  <span aria-hidden="true">{formatVariation(growth, 2)}</span>
+                  <VisuallyHidden>
+                    {t('transactions:Summary.Growth', {
+                      defaultValue: 'grew {{percent}} in the last 24 hours',
+                      percent: `${(growth * 100).toFixed(2)}%`,
+                    })}
+                  </VisuallyHidden>
+                </TrendValue>
+              </TileSub>
+            )}
+          </Tile>
+        )}
+
+        {summary.mostTransactedAsset && (
+          <Tile>
+            <TileLabel>
+              {t('transactions:Summary.MostTransacted', {
+                defaultValue: 'Most transacted',
+              })}
+            </TileLabel>
+            <TileValueRow>
+              <TileValue>
+                <SummaryAssetLink
+                  href={`/asset/${summary.mostTransactedAsset.assetId}`}
+                >
+                  {summary.mostTransactedAsset.assetId}
+                </SummaryAssetLink>
+              </TileValue>
+            </TileValueRow>
+            <TileSub>
+              {/* The ranking's basis, not its raw count. The count is on a
+                  different footing than the total beside it: measured live,
+                  the unfiltered figure for the same asset (71.1M) exceeds
+                  this card's own chain total (58.6M), so an asset occurrence
+                  is not a transaction. Its window is undocumented too. */}
+              {t('transactions:Summary.FungibleBasis', {
+                defaultValue: 'Leading fungible asset',
+              })}
+            </TileSub>
+          </Tile>
+        )}
+      </TilesGrid>
+
+      {/* Same shape as the assets registry strip, deliberately: tiles, then
+          the bar, then its legend, with no heading in between, so both
+          summary cards stand the same height on their pages. */}
+      {summary.breakdown.length > 1 && breakdownTotal > 0 && (
+        <>
+          <DistBar
+            role="img"
+            aria-label={t('transactions:Summary.Breakdown', {
+              defaultValue: 'Contract types in the last 24 hours',
+            })}
+          >
+            {summary.breakdown.map((share, index) => (
+              <DistSegment
+                key={share.name}
+                $color={segmentColor(share, index)}
+                $delay={index * 60}
+                style={{
+                  width: `${(share.count / breakdownTotal) * 100}%`,
+                }}
+                title={`${share.name}: ${formatAmount(share.count)}`}
+                aria-hidden="true"
+              />
+            ))}
+          </DistBar>
+          <LegendRow>
+            {summary.breakdown.map((share, index) => (
+              <LegendItem key={share.name}>
+                <LegendDot $color={segmentColor(share, index)} />
+                {share.name === 'Other'
+                  ? t('transactions:Summary.OtherTypes', {
+                      defaultValue: 'Other',
+                    })
+                  : share.name}{' '}
+                <strong>{formatAmount(share.count)}</strong>{' '}
+                {formatShare(share.count, breakdownTotal)}
+              </LegendItem>
+            ))}
+          </LegendRow>
+        </>
+      )}
+    </PageSummaryCard>
+  );
+};
+
+export default TransactionsSummary;

--- a/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
+++ b/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
@@ -1,0 +1,263 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The installed testing-library still calls the removed ReactDOM.render; every
+// component suite in this repo carries the same createRoot shim.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+// Its real implementation reaches @/utils/precisionFunctions and from there
+// an ESM chain Jest cannot transform, the same wall every other suite here
+// works around. Shortening is not what this suite is about.
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => `${value.slice(0, 6)}...`,
+}));
+
+const nameCall = jest.fn();
+
+jest.mock('@/services/requests/smartContracts/names', () => ({
+  CONTRACT_NAME_STALE_TIME: 1000,
+  contractNameQueryKey: (address: string) => ['smartContractName', address],
+  smartContractNameCall: (address: string) => nameCall(address),
+}));
+
+import ContractTargetLabel from '../ContractTargetLabel';
+
+const ADDRESS =
+  'klv1qqqqqqqqqqqqqpgqu34l5t0w5qjajuk5w7j9jy4rxxhj974rx04sdw565h';
+
+const renderLabel = (
+  props: Partial<{ address: string; isContract: boolean }>,
+) =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({
+          defaultOptions: { queries: { retry: false, gcTime: 0 } },
+        })
+      }
+    >
+      <ContractTargetLabel
+        address={props.address ?? ADDRESS}
+        isContract={props.isContract ?? true}
+        truncateTo={12}
+      />
+    </QueryClientProvider>,
+  );
+
+/**
+ * Renders and lets the name request answer before the caller asserts.
+ *
+ * A row shows its address until the name lands, so "the address is still
+ * there" is true for an instant whatever the name was. Asserting that without
+ * waiting made the refusal tests pass with the refusal deleted.
+ */
+const renderSettled = async (
+  props: Partial<{ address: string; isContract: boolean }>,
+): Promise<void> => {
+  renderLabel(props);
+  // A macrotask, not a microtask: react-query hands the answer on through its
+  // own scheduler, so draining the microtask queue lands before the row has
+  // seen the name and the assertion is vacuous again.
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+};
+
+beforeEach(() => {
+  nameCall.mockReset();
+});
+
+describe('ContractTargetLabel', () => {
+  it('shows the contract name once the chain answers with one', async () => {
+    nameCall.mockResolvedValue('Bitcoin.me');
+
+    renderLabel({});
+
+    expect(await screen.findByText('Bitcoin.me')).toBeTruthy();
+  });
+
+  it('keeps the shortened address for a contract that has no name', async () => {
+    // The ordinary case: most contracts on chain are unnamed.
+    nameCall.mockResolvedValue(null);
+
+    renderLabel({});
+
+    expect(await screen.findByText(/klv1qq/)).toBeTruthy();
+    expect(nameCall).toHaveBeenCalled();
+    expect(screen.queryByText('Bitcoin.me')).toBeNull();
+  });
+
+  it('asks for no name at all when the target is a plain account', () => {
+    renderLabel({ isContract: false });
+
+    expect(nameCall).not.toHaveBeenCalled();
+    expect(screen.getByText(/klv1qq/)).toBeTruthy();
+  });
+
+  it('survives an empty address without asking for a name', () => {
+    // Guards the fallback the query key uses: an address the row could not
+    // resolve must not become a request for the name of nothing.
+    renderLabel({ address: '' });
+
+    expect(nameCall).not.toHaveBeenCalled();
+  });
+
+  it('caps a name long enough to widen the whole page', async () => {
+    // Whoever deploys a contract picks its name. A 200 character one was
+    // measured to push the page from 800px to 1838px, because the cell clips
+    // instead of ellipsising and nothing bounds the text.
+    nameCall.mockResolvedValue('A'.repeat(200));
+
+    renderLabel({});
+
+    const shown = await screen.findByText(/^A+…$/);
+    expect(shown.textContent?.length).toBeLessThanOrEqual(33);
+    // The address rides in the tooltip, so the cell never becomes the only
+    // place the counterparty is named.
+    expect(shown.getAttribute('title')).toContain(ADDRESS);
+  });
+
+  it('collapses whitespace so a name cannot set the row height', async () => {
+    nameCall.mockResolvedValue('Klever\n\n   Bridge');
+
+    renderLabel({});
+
+    expect(await screen.findByText('Klever Bridge')).toBeTruthy();
+  });
+
+  it('falls back to the address for a name that is only whitespace', async () => {
+    nameCall.mockResolvedValue('   ');
+
+    renderLabel({});
+
+    expect(await screen.findByText(/klv1qq/)).toBeTruthy();
+  });
+
+  it('strips the bidi override that paints a name backwards', async () => {
+    // U+202E reverses what follows, so this paints as "klever.com" in the one
+    // field a reader uses to identify the counterparty. \s does not match it.
+    nameCall.mockResolvedValue('‮moc.revelk');
+
+    renderLabel({});
+
+    expect(await screen.findByText('moc.revelk')).toBeTruthy();
+  });
+
+  it('refuses a name shaped like a wallet address', async () => {
+    // Names are set through SetAccountName by anyone, and mainnet already
+    // carries full bech32 strings as names. One standing where the real
+    // counterparty address stands would be a lie the reader cannot see.
+    nameCall.mockResolvedValue(
+      'klv1fqeupef8haxequ0nvsxlmt2gl07mqjhrr38p2l4r8daguxjjvk7q7zhups',
+    );
+
+    await renderSettled({});
+
+    expect(screen.getByText(/klv1qq/)).toBeTruthy();
+    expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+  });
+
+  it('refuses a name that is an address with one odd character past the cap', async () => {
+    // The cap runs before the address check now. Judging the whole name and
+    // drawing a shortened one asked the question about a string the reader
+    // never sees: an address with a trailing underscore failed the address
+    // test and was then drawn as 32 characters of plain bech32.
+    nameCall.mockResolvedValue(
+      'klv1fqeupef8haxequ0nvsxlmt2gl07mqjhrr38p2l4r8daguxjjvk7q7zhups_',
+    );
+
+    await renderSettled({});
+
+    expect(screen.getByText(/klv1qq/)).toBeTruthy();
+    expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+  });
+
+  it('refuses one that hides its odd character in a homoglyph', async () => {
+    // Same bypass with a Cyrillic a as the disqualifying character, which no
+    // ASCII-shaped test catches.
+    nameCall.mockResolvedValue(
+      'klv1fqeupef8haxequ0nvsxlmt2gl07mqjhrr38p2l4r8daguxjjvk7q7zhup\u0430',
+    );
+
+    await renderSettled({});
+
+    expect(screen.getByText(/klv1qq/)).toBeTruthy();
+    expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+  });
+
+  it('strips a Hangul filler, which draws as a blank and is not a space', async () => {
+    // U+3164 is a letter, not a formatting character, so neither \s nor the
+    // control blocks reach it. Left in, it breaks up an address just enough
+    // to pass the address check while still reading as one.
+    nameCall.mockResolvedValue('Klever\u3164Bridge');
+
+    renderLabel({});
+
+    expect(await screen.findByText('KleverBridge')).toBeTruthy();
+  });
+
+  it('strips the word joiner and the Arabic letter mark', async () => {
+    // Both are formatting characters the enumerated ranges missed: U+2060
+    // joins glyphs across a boundary, U+061C reorders the neutrals around it
+    // exactly as the right-to-left mark does.
+    nameCall.mockResolvedValue('Klever\u2060Bri\u061Cdge');
+
+    renderLabel({});
+
+    expect(await screen.findByText('KleverBridge')).toBeTruthy();
+  });
+
+  it('keeps the address out of reach of a zero-width character', async () => {
+    nameCall.mockResolvedValue('Klever​Bridge');
+
+    renderLabel({});
+
+    expect(await screen.findByText('KleverBridge')).toBeTruthy();
+  });
+
+  it('renders the address before the name has arrived', () => {
+    // The name must never be something the row waits for.
+    nameCall.mockReturnValue(new Promise(() => undefined));
+
+    renderLabel({});
+
+    expect(screen.getByText(/klv1qq/)).toBeTruthy();
+  });
+});

--- a/src/components/TransactionsList/__tests__/MobileCard.test.tsx
+++ b/src/components/TransactionsList/__tests__/MobileCard.test.tsx
@@ -1,0 +1,249 @@
+import theme from '@/styles/theme';
+import { ITransaction } from '@/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const routerQuery: Record<string, string | string[] | undefined> = {};
+let routerPathname = '/transactions';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    pathname: routerPathname,
+    query: routerQuery,
+  }),
+}));
+
+// The card only formats what these give back; their real implementations pull
+// @/utils/precisionFunctions and from there an ESM chain Jest cannot
+// transform, so they are replaced wholesale like every other suite does.
+// Classification mirrors the real dispatch (contract count, then contract
+// type), NOT the payload shape: an earlier version keyed on the presence of
+// toAddress, which made "Transfer without toAddress", the crash shape the
+// card guards against, unrepresentable in this suite.
+const customLabels = { current: ['Amount'] as string[] };
+
+jest.mock('@/utils/contracts', () => ({
+  contractTypes: (contracts: { type?: number }[]) => {
+    if (contracts?.length > 1) return 'Multi contract';
+    return contracts?.[0]?.type === 0
+      ? 'TransferContractType'
+      : 'FreezeContractType';
+  },
+  filteredSections: () => [<span key="amount">1 KLV</span>],
+  getLabelForTableField: () => customLabels.current,
+}));
+
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => `${value.slice(0, 6)}...`,
+}));
+
+// Resolved against the real English locale file rather than stubbed, so a key
+// the card asks for that nobody ever added fails the suite here instead of
+// rendering "transactions:Table.Type" at a reader.
+jest.mock('next-i18next', () => {
+  const bundle = jest.requireActual(
+    '../../../../public/locales/en/transactions.json',
+  );
+
+  const translate = (key: string): string => {
+    const path = key.includes(':') ? key.split(':')[1] : key;
+    const value = path
+      .split('.')
+      .reduce<unknown>(
+        (node, part) =>
+          node && typeof node === 'object'
+            ? (node as Record<string, unknown>)[part]
+            : undefined,
+        bundle,
+      );
+    if (typeof value === 'string') return value;
+    throw new Error(`missing transactions locale key: ${key}`);
+  };
+
+  return { useTranslation: () => ({ t: translate }) };
+});
+
+// The installed testing-library still calls the removed ReactDOM.render; every
+// component suite in this repo carries the same createRoot shim.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import TransactionsMobileCard from '../MobileCard';
+
+const SENDER = 'klv1sendersendersendersender';
+const RECEIVER = 'klv1receiverreceiverreceiver';
+
+const transfer = (overrides: Partial<ITransaction> = {}): ITransaction =>
+  ({
+    hash: 'abc123def456',
+    blockNum: 4242,
+    timestamp: 1700000000000,
+    sender: SENDER,
+    receipts: [],
+    contract: [
+      {
+        type: 0,
+        parameter: { amount: 1_000_000, assetId: 'KLV', toAddress: RECEIVER },
+      },
+    ],
+    kAppFee: 1_000_000,
+    bandwidthFee: 500_000,
+    status: 'success',
+    precision: 6,
+    ...overrides,
+  }) as unknown as ITransaction;
+
+const renderCard = (
+  item: ITransaction,
+  {
+    pathname = '/transactions',
+    query = {},
+  }: {
+    pathname?: string;
+    query?: Record<string, string | string[] | undefined>;
+  } = {},
+) => {
+  routerPathname = pathname;
+  Object.keys(routerQuery).forEach(key => delete routerQuery[key]);
+  Object.assign(routerQuery, query);
+
+  // The card looks a contract name up through react-query. Retries and the
+  // console noise they produce are off: this suite is about what the card
+  // renders, and the name is decoration it does without.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <TransactionsMobileCard item={item} index={3} />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+};
+
+beforeEach(() => {
+  customLabels.current = ['Amount'];
+});
+
+describe('TransactionsMobileCard', () => {
+  it('is the row for the shared table: one card carrying the row testid', () => {
+    renderCard(transfer());
+    const card = screen.getByTestId('table-row-3');
+
+    const hashLink = within(card).getByTestId('transaction-link');
+    expect(hashLink.getAttribute('href')).toBe('/transaction/abc123def456');
+
+    expect(within(card).getByText('Type')).toBeTruthy();
+    expect(within(card).getByText('Transfer')).toBeTruthy();
+    expect(within(card).getByText('From')).toBeTruthy();
+    expect(within(card).getByText('To')).toBeTruthy();
+    expect(within(card).getByText('Block/Fees')).toBeTruthy();
+    expect(within(card).getByText('4242').getAttribute('href')).toBe(
+      '/block/4242',
+    );
+    expect(within(card).getByText('Success')).toBeTruthy();
+    expect(within(card).getByText('Amount')).toBeTruthy();
+  });
+
+  it('shows -- for the receiver when the contract has none', () => {
+    renderCard(
+      transfer({
+        contract: [{ type: 4, parameter: {} }],
+      } as Partial<ITransaction>),
+    );
+    const card = screen.getByTestId('table-row-3');
+
+    expect(within(card).getByText('--')).toBeTruthy();
+    expect(within(card).queryByText('Transfer')).toBeNull();
+  });
+
+  it('survives a Transfer whose parameter is missing, without a broken link', () => {
+    renderCard(
+      transfer({
+        contract: [{ type: 0, parameter: undefined }],
+      } as unknown as Partial<ITransaction>),
+    );
+    const card = screen.getByTestId('table-row-3');
+
+    expect(within(card).getByText('--')).toBeTruthy();
+    expect(card.querySelector('a[href="/account/undefined"]')).toBeNull();
+  });
+
+  it('renders a colliding custom "Type" label as "Action type"', () => {
+    customLabels.current = ['Type'];
+    renderCard(transfer());
+    const card = screen.getByTestId('table-row-3');
+
+    expect(within(card).getAllByText('Type')).toHaveLength(1);
+    expect(within(card).getByText('Action type')).toBeTruthy();
+  });
+
+  it('renders a multi-contract row as one badge carrying the count', () => {
+    renderCard(
+      transfer({
+        contract: [
+          { type: 0, parameter: {} },
+          { type: 4, parameter: {} },
+        ],
+      } as unknown as Partial<ITransaction>),
+    );
+
+    expect(screen.getByText(/Multi contract/)).toBeTruthy();
+    // The count is the emphasized element inside the badge.
+    expect(screen.getByText('2').tagName).toBe('B');
+  });
+
+  it('adds the direction badge only when the list is scoped to the sender', () => {
+    renderCard(transfer(), { query: { account: SENDER } });
+    expect(screen.getByText('Out')).toBeTruthy();
+  });
+
+  it('leaves the direction off when the route does not filter by account', () => {
+    renderCard(transfer(), {
+      pathname: '/asset/[asset]',
+      query: { account: SENDER },
+    });
+    expect(screen.queryByText('Out')).toBeNull();
+    expect(screen.queryByText('In')).toBeNull();
+  });
+});

--- a/src/components/TransactionsList/__tests__/Summary.test.tsx
+++ b/src/components/TransactionsList/__tests__/Summary.test.tsx
@@ -1,0 +1,200 @@
+import theme from '@/styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Resolved from the shipped bundle rather than echoed back, so a key the card
+// asks for that nobody ever added fails the suite here instead of rendering
+// "transactions:Summary.Growth" at a reader.
+jest.mock('next-i18next', () => {
+  const bundle = jest.requireActual(
+    '../../../../public/locales/en/transactions.json',
+  );
+
+  const translate = (
+    key: string,
+    options?: Record<string, unknown>,
+  ): string => {
+    const path = key.includes(':') ? key.split(':')[1] : key;
+    const value = path
+      .split('.')
+      .reduce<unknown>(
+        (node, part) =>
+          node && typeof node === 'object'
+            ? (node as Record<string, unknown>)[part]
+            : undefined,
+        bundle,
+      );
+    if (typeof value !== 'string') {
+      throw new Error(`missing transactions locale key: ${key}`);
+    }
+    return value.replace(/\{\{(\w+)\}\}/g, (whole, name) =>
+      options && name in options ? String(options[name]) : whole,
+    );
+  };
+
+  return { useTranslation: () => ({ t: translate }) };
+});
+
+// The installed testing-library still calls the removed ReactDOM.render; every
+// component suite in this repo carries the same createRoot shim.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+const summaryCall = jest.fn();
+
+// Only the request is replaced. The arithmetic beside it stays real, so a
+// change to what "grew by" means is caught here as well as in its own spec.
+jest.mock('@/services/requests/transactions/summary', () => ({
+  ...jest.requireActual('@/services/requests/transactions/summary'),
+  transactionsSummaryCall: () => summaryCall(),
+}));
+
+import TransactionsSummary from '../Summary';
+
+const FULL = {
+  last24h: 8247,
+  previous24h: 8000,
+  totalTransactions: 58558891,
+  mostTransactedAsset: { assetId: 'KLV', count: 4000 },
+  breakdown: [
+    { name: 'Transfer', count: 5000 },
+    { name: 'Smart Contract', count: 2000 },
+    { name: 'Other', count: 1247 },
+  ],
+};
+
+const renderSummary = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({
+          defaultOptions: { queries: { retry: false, gcTime: 0 } },
+        })
+      }
+    >
+      <ThemeProvider theme={theme}>
+        <TransactionsSummary />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+
+/** The card, whether it is still a skeleton or holds the figures. */
+const card = (): HTMLElement =>
+  screen.getByLabelText('Transaction statistics') as HTMLElement;
+
+const digitsOf = (text: string): string => text.replace(/\D/g, '');
+
+beforeEach(() => {
+  summaryCall.mockReset();
+});
+
+describe('TransactionsSummary', () => {
+  it('reserves the card while the figures are still on their way', () => {
+    summaryCall.mockReturnValue(new Promise(() => undefined));
+
+    renderSummary();
+
+    // Named for assistive tech before its content is known, and holding no
+    // figure yet, so the page below it does not jump when they arrive.
+    expect(digitsOf(card().textContent ?? '')).toBe('');
+  });
+
+  it('writes the chain total out in full and compacts the day figure', async () => {
+    summaryCall.mockResolvedValue(FULL);
+
+    renderSummary();
+
+    // Every digit present, against the locale's own separators: this figure is
+    // the one a reader may want to quote, and "58.55 M" throws five away.
+    const total = await screen.findByText(/58.558.891|58,558,891/);
+    expect(digitsOf(total.textContent ?? '')).toBe('58558891');
+
+    // The day figure keeps the compact form the rest of the list uses, which
+    // truncates its second decimal rather than rounding it.
+    expect(screen.getByText('8.24 K')).toBeTruthy();
+  });
+
+  it('puts a signed change under each of the two counts', async () => {
+    summaryCall.mockResolvedValue(FULL);
+
+    renderSummary();
+
+    // Against the 24 hours before it: 8247 from 8000.
+    expect(await screen.findByText('+3.1%')).toBeTruthy();
+    // Against the chain's total a day ago: 8247 on top of 58550644.
+    expect(screen.getByText('+0.01%')).toBeTruthy();
+  });
+
+  it('says the direction in words, which a bare plus sign does not carry', async () => {
+    summaryCall.mockResolvedValue({ ...FULL, last24h: 7000 });
+
+    renderSummary();
+
+    expect(
+      await screen.findByText('down 12.5% compared with the previous 24 hours'),
+    ).toBeTruthy();
+  });
+
+  it('leaves out a tile whose own request answered nothing', async () => {
+    summaryCall.mockResolvedValue({
+      ...FULL,
+      last24h: undefined,
+      previous24h: undefined,
+    });
+
+    renderSummary();
+
+    expect(await screen.findByText('Total transactions')).toBeTruthy();
+    // No zero the chain never had, and no percentage computed from one.
+    expect(screen.queryByText('Transactions (24h)')).toBeNull();
+  });
+
+  it('draws no card at all when every figure is missing', async () => {
+    summaryCall.mockResolvedValue({ breakdown: [] });
+
+    renderSummary();
+
+    // Waited out rather than asserted straight away: the skeleton also carries
+    // this label, so an immediate check would pass on the loading state.
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Transaction statistics')).toBeNull(),
+    );
+  });
+});

--- a/src/components/TransactionsList/__tests__/badges.test.tsx
+++ b/src/components/TransactionsList/__tests__/badges.test.tsx
@@ -1,0 +1,86 @@
+import theme from '@/styles/theme';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The installed testing-library still calls the removed ReactDOM.render; every
+// component suite in this repo carries the same createRoot shim.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { InOutBadge, TransactionStatusBadge } from '../badges';
+
+/**
+ * The variant is not readable from the DOM as an attribute, but
+ * styled-components derives the class from the resolved css, so two badges
+ * carry the same className exactly when they resolved to the same variant.
+ * That makes the mapping observable: In must look like success, Out like
+ * pending, and fail must not look like success.
+ */
+const classOf = (text: string): string =>
+  (screen.getByText(text) as HTMLElement).className;
+
+describe('transaction badges', () => {
+  beforeEach(() => {
+    render(
+      <ThemeProvider theme={theme}>
+        <TransactionStatusBadge status="success" />
+        <TransactionStatusBadge status="pending" />
+        <TransactionStatusBadge status="fail" />
+        <InOutBadge direction="In" />
+        <InOutBadge direction="Out" />
+      </ThemeProvider>,
+    );
+  });
+
+  it('capitalizes the raw chain status for display', () => {
+    expect(screen.getByText('Success')).toBeTruthy();
+    expect(screen.getByText('Pending')).toBeTruthy();
+    expect(screen.getByText('Fail')).toBeTruthy();
+  });
+
+  it('maps success and In to the same look, pending and Out likewise', () => {
+    expect(classOf('In')).toBe(classOf('Success'));
+    expect(classOf('Out')).toBe(classOf('Pending'));
+  });
+
+  it('gives fail its own look, distinct from success and pending', () => {
+    expect(classOf('Fail')).not.toBe(classOf('Success'));
+    expect(classOf('Fail')).not.toBe(classOf('Pending'));
+  });
+});

--- a/src/components/TransactionsList/__tests__/columns.test.ts
+++ b/src/components/TransactionsList/__tests__/columns.test.ts
@@ -1,40 +1,56 @@
-import {
-  getTransactionColumns,
-  getTransactionHeaders,
-  showsInOut,
-} from '../columns';
+import { getTransactionColumns, listsWholeChain, showsInOut } from '../columns';
 
-const BASE_KEYS = ['hash', 'blockFees', 'fromTo', 'type', 'misc'];
+const BASE_KEYS = [
+  'hash',
+  'type',
+  'block',
+  'age',
+  'from',
+  'direction',
+  'to',
+  'amount',
+  'fee',
+];
 
 describe('transaction table columns', () => {
-  it('lists the five base columns in order', () => {
+  it('lists the nine single-line base columns in order', () => {
     expect(getTransactionColumns({ showInOut: false }).map(c => c.key)).toEqual(
       BASE_KEYS,
     );
   });
 
-  it('puts In/Out directly after From/To when the list is scoped to an account', () => {
+  it('puts In/Out directly after To when the list is scoped to an account', () => {
     expect(getTransactionColumns({ showInOut: true }).map(c => c.key)).toEqual([
       'hash',
-      'blockFees',
-      'fromTo',
-      'inOut',
       'type',
-      'misc',
+      'block',
+      'age',
+      'from',
+      'direction',
+      'to',
+      'inOut',
+      'amount',
+      'fee',
     ]);
   });
 
-  it('gives every column a non-empty heading, in both shapes', () => {
-    // Only that much. `getTransactionHeaders` is defined as this map, so
-    // asserting the two match would restate the implementation. What the
-    // headings and the cells actually agreeing is worth is enforced end to
-    // end, in cypress/e2e/pages/transactions.cy.ts, since Jest cannot import
-    // the module the cells live in.
+  it('gives every column a non-empty heading, except the unheaded arrow', () => {
+    // Only that much. What the headings and the cells actually agreeing is
+    // worth is enforced end to end, in cypress/e2e/pages/transactions.cy.ts,
+    // since Jest cannot import the module the cells live in.
     for (const showInOut of [false, true]) {
-      const headers = getTransactionHeaders({ showInOut });
+      const columns = getTransactionColumns({ showInOut });
+      const headers = columns.map(column => column.header);
 
-      expect(headers).toHaveLength(getTransactionColumns({ showInOut }).length);
-      expect(headers.every(header => header.length > 0)).toBe(true);
+      columns.forEach((column, index) => {
+        if (column.key === 'direction') {
+          // The circled status arrow is deliberately unheaded, like the
+          // reference explorers.
+          expect(headers[index]).toBe('');
+        } else {
+          expect(headers[index].length).toBeGreaterThan(0);
+        }
+      });
     }
   });
 
@@ -91,6 +107,27 @@ describe('transaction table columns', () => {
 
     it('is false when there is no router information at all', () => {
       expect(showsInOut({})).toBe(false);
+    });
+  });
+
+  describe('listsWholeChain', () => {
+    it('is true for a bare list and while paging through it', () => {
+      expect(listsWholeChain({ query: {} })).toBe(true);
+      expect(listsWholeChain({ query: { page: '3', limit: '50' } })).toBe(true);
+      expect(listsWholeChain({})).toBe(true);
+    });
+
+    it.each([
+      ['an account', { account: 'klv1abc' }],
+      ['a contract type', { type: '63' }],
+      ['a status', { status: 'Success' }],
+      ['an asset', { asset: 'KLV' }],
+      ['a date range', { startdate: '1787491255', enddate: '1787577655' }],
+      ['a filter alongside paging', { page: '2', type: '63' }],
+    ])('is false once the list is narrowed by %s', (_label, query) => {
+      // The summary above the list is chain-wide, so any narrowing at all
+      // makes it describe something other than the rows underneath it.
+      expect(listsWholeChain({ query })).toBe(false);
     });
   });
 });

--- a/src/components/TransactionsList/__tests__/rowDetails.test.ts
+++ b/src/components/TransactionsList/__tests__/rowDetails.test.ts
@@ -1,0 +1,256 @@
+import { IReceipt } from '@/types';
+import { IContract } from '@/types/contracts';
+import { getTransactionRowDetails, valueDirection } from '../rowDetails';
+
+const one = (type: string, parameter: unknown): IContract[] =>
+  [{ typeString: type, parameter }] as unknown as IContract[];
+
+const SENDER = 'klv1sender';
+
+describe('getTransactionRowDetails', () => {
+  it('gives a Transfer its receiver as the target', () => {
+    const details = getTransactionRowDetails({
+      contract: one('TransferContractType', { toAddress: 'klv1to' }),
+      contractType: 'TransferContractType',
+    });
+    expect(details.target).toEqual({ address: 'klv1to' });
+    expect(details.typeDetail).toBeUndefined();
+  });
+
+  it('marks a smart contract invoke with its address and function tooltip', () => {
+    // "swap" in hex; the function name rides in the transaction data.
+    const details = getTransactionRowDetails({
+      contract: one('SmartContractType', {
+        type: 'SCInvoke',
+        address: 'klv1contract',
+      }),
+      contractType: 'SmartContractType',
+      data: ['73776170'],
+    });
+    expect(details.target).toEqual({
+      address: 'klv1contract',
+      isContract: true,
+    });
+    expect(details.contractTooltip).toBe('Contract\nFunction: swap');
+  });
+
+  it('still renders a contract row when the node sends a type that is not a string', () => {
+    const details = getTransactionRowDetails({
+      contract: one('SmartContractType', {
+        type: 0,
+        address: 'klv1contract',
+      }),
+      contractType: 'SmartContractType',
+    });
+    expect(details.target).toEqual({
+      address: 'klv1contract',
+      isContract: true,
+    });
+    expect(details.typeDetail).toBeUndefined();
+  });
+
+  it('pays a claim out to the transfer receipt address, with the claim type as detail', () => {
+    const details = getTransactionRowDetails({
+      contract: one('ClaimContractType', { claimType: 'StakingClaim' }),
+      contractType: 'ClaimContractType',
+      sender: SENDER,
+      receipts: [{ type: 0, to: 'klv1paid' }],
+    });
+    expect(details.target).toEqual({ address: 'klv1paid' });
+    // Spaced out for the badge: STAKINGCLAIM reads as one shouted word.
+    expect(details.typeDetail).toBe('Staking Claim');
+  });
+
+  it('falls back to the sender when a claim carries no transfer receipt', () => {
+    const details = getTransactionRowDetails({
+      contract: one('ClaimContractType', { claimType: 1 }),
+      contractType: 'ClaimContractType',
+      sender: SENDER,
+      receipts: [],
+    });
+    expect(details.target).toEqual({ address: SENDER });
+    // Numeric enum value resolves back to its name, spaced out.
+    expect(details.typeDetail).toBe('Allowance Claim');
+  });
+
+  it('resolves a numeric market type on a sell order', () => {
+    const details = getTransactionRowDetails({
+      contract: one('SellContractType', { marketType: 0 }),
+      contractType: 'SellContractType',
+    });
+    expect(details.typeDetail).toBe('Buy It Now Market');
+  });
+
+  it('gives a delegation its validator as the target', () => {
+    const details = getTransactionRowDetails({
+      contract: one('DelegateContractType', { toAddress: 'klv1validator' }),
+      contractType: 'DelegateContractType',
+    });
+    expect(details.target).toEqual({ address: 'klv1validator' });
+  });
+
+  it('stays empty for a multi-contract transaction', () => {
+    const contracts = [
+      ...one('TransferContractType', { toAddress: 'klv1to' }),
+      ...one('FreezeContractType', {}),
+    ];
+    expect(
+      getTransactionRowDetails({
+        contract: contracts,
+        contractType: 'Multi contract',
+      }),
+    ).toEqual({});
+  });
+
+  it('stays empty when the parameter is missing entirely', () => {
+    expect(
+      getTransactionRowDetails({
+        contract: [{ typeString: 'TransferContractType' }] as IContract[],
+        contractType: 'TransferContractType',
+      }),
+    ).toEqual({});
+  });
+});
+
+describe('valueDirection', () => {
+  const ACCOUNT = 'klv1account';
+  const OTHER = 'klv1other';
+  const CONTRACT = 'klv1contract';
+
+  const transferReceipt = (from: string, to: string) =>
+    ({ type: 0, from, to }) as unknown as IReceipt;
+
+  describe('a transaction the account submitted', () => {
+    it('is outgoing for a transfer it sent', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: ACCOUNT,
+          contractType: 'TransferContractType',
+          receipts: [transferReceipt(ACCOUNT, OTHER)],
+        }),
+      ).toBe('Out');
+    });
+
+    it('is outgoing for a freeze, whatever rewards ride along', () => {
+      // The staking contracts pay out accrued rewards in the same
+      // transaction, so a freeze carries a transfer receipt paying its own
+      // sender. Reading the receipts first called this incoming: measured
+      // against mainnet, on 30 of 40 freezes, 16 of 40 unfreezes and 10 of 40
+      // delegations.
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: ACCOUNT,
+          contractType: 'FreezeContractType',
+          receipts: [transferReceipt('klv1staking', ACCOUNT)],
+        }),
+      ).toBe('Out');
+    });
+
+    it('is outgoing for a contract call that swaps both ways', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: ACCOUNT,
+          contractType: 'SmartContractType',
+          receipts: [
+            transferReceipt(ACCOUNT, CONTRACT),
+            transferReceipt(CONTRACT, ACCOUNT),
+          ],
+        }),
+      ).toBe('Out');
+    });
+
+    it('is incoming for a claim, which exists to pay its sender', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: ACCOUNT,
+          contractType: 'ClaimContractType',
+          receipts: [transferReceipt('klv1staking', ACCOUNT)],
+        }),
+      ).toBe('In');
+    });
+
+    it('is incoming for a withdrawal, on the same reasoning', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: ACCOUNT,
+          contractType: 'WithdrawContractType',
+          receipts: [],
+        }),
+      ).toBe('In');
+    });
+  });
+
+  describe('a transaction somebody else submitted', () => {
+    it('is incoming when a transfer receipt pays this account', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: OTHER,
+          contractType: 'TransferContractType',
+          receipts: [transferReceipt(OTHER, ACCOUNT)],
+        }),
+      ).toBe('In');
+    });
+
+    it('is outgoing when a transfer receipt takes from this account', () => {
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: OTHER,
+          contractType: 'SmartContractType',
+          receipts: [transferReceipt(ACCOUNT, OTHER)],
+        }),
+      ).toBe('Out');
+    });
+
+    it('answers nothing when no transfer receipt names this account', () => {
+      // A validator's own page lists the delegations aimed at it, and none of
+      // them moves value into it. Saying "In" there would be an invention.
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: OTHER,
+          contractType: 'DelegateContractType',
+          receipts: [{ type: 7, from: OTHER } as unknown as IReceipt],
+        }),
+      ).toBeUndefined();
+    });
+
+    it('answers nothing for a send that failed and moved nothing', () => {
+      // A failed transfer carries no transfer receipt. A green In beside an
+      // amount that never arrived is the shape of a fake deposit.
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: OTHER,
+          contractType: 'TransferContractType',
+          receipts: [{ type: 19 } as unknown as IReceipt],
+        }),
+      ).toBeUndefined();
+    });
+
+    it('reads only the transfer receipt, not any receipt with a from', () => {
+      // Kills a mutant that drops the receipt-type guard: type 4 is a freeze
+      // bucket record, not value leaving the account.
+      expect(
+        valueDirection({
+          account: ACCOUNT,
+          sender: OTHER,
+          contractType: 'FreezeContractType',
+          receipts: [{ type: 4, from: ACCOUNT } as unknown as IReceipt],
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  it('answers nothing without an account to answer about', () => {
+    expect(
+      valueDirection({ sender: ACCOUNT, contractType: 'TransferContractType' }),
+    ).toBeUndefined();
+  });
+});

--- a/src/components/TransactionsList/__tests__/useTransactionHeaders.test.tsx
+++ b/src/components/TransactionsList/__tests__/useTransactionHeaders.test.tsx
@@ -80,31 +80,41 @@ const headersFor = (
 };
 
 describe('useTransactionHeaders', () => {
-  it('gives the five base headings when the list is not scoped', () => {
+  it('gives the nine single-line headings when the list is not scoped', () => {
+    // The empty string is the deliberately unheaded column of the circled
+    // status arrow between From and To.
     expect(headersFor({})).toEqual([
       'Transaction Hash',
-      'Block/Fees',
-      'From/To',
       'Type',
-      'Misc',
+      'Block',
+      'Age',
+      'From',
+      '',
+      'To',
+      'Amount',
+      'Fee',
     ]);
   });
 
-  it('adds In/Out after From/To when the URL names an account', () => {
+  it('adds In/Out after To when the URL names an account', () => {
     // This suite only renders the headings hook. That the cells line up with
     // them is enforced end to end, not here.
     expect(headersFor({ account: 'klv1abc' })).toEqual([
       'Transaction Hash',
-      'Block/Fees',
-      'From/To',
-      'In/Out',
       'Type',
-      'Misc',
+      'Block',
+      'Age',
+      'From',
+      '',
+      'To',
+      'In/Out',
+      'Amount',
+      'Fee',
     ]);
   });
 
   it('ignores a repeated account parameter, which names no single account', () => {
-    expect(headersFor({ account: ['klv1abc', 'klv1def'] })).toHaveLength(5);
+    expect(headersFor({ account: ['klv1abc', 'klv1def'] })).toHaveLength(9);
   });
 
   it('leaves the column out on a route the account never filters', () => {
@@ -112,11 +122,11 @@ describe('useTransactionHeaders', () => {
     // list still holds everyone. A direction there would read "In" for
     // essentially every row.
     expect(headersFor({ account: 'klv1abc' }, '/asset/[asset]')).toHaveLength(
-      5,
+      9,
     );
   });
 
   it('ignores an empty account parameter', () => {
-    expect(headersFor({ account: '' })).toHaveLength(5);
+    expect(headersFor({ account: '' })).toHaveLength(9);
   });
 });

--- a/src/components/TransactionsList/badges.tsx
+++ b/src/components/TransactionsList/badges.tsx
@@ -1,0 +1,125 @@
+import { BadgePill, VisuallyHidden } from '@/components/DataList/styles';
+import Tooltip from '@/components/Tooltip';
+import { ContractsIndex, IContract } from '@/types/contracts';
+import { capitalizeString } from '@/utils/convertString';
+import React from 'react';
+import { BadgeCount } from './styles';
+
+/**
+ * Badge dialect of the transactions table, shared by the desktop rows and
+ * the mobile card so the two cannot drift apart. The colors keep the meaning
+ * the old pill gave them: green for success and In, amber for pending and
+ * Out, red for fail.
+ */
+
+const STATUS_VARIANT: Record<string, 'success' | 'warning' | 'danger'> = {
+  success: 'success',
+  pending: 'warning',
+  fail: 'danger',
+};
+
+export const statusVariant = (
+  status?: string,
+): 'success' | 'warning' | 'danger' | 'neutral' =>
+  STATUS_VARIANT[status?.toLowerCase() ?? ''] ?? 'neutral';
+
+export const TransactionStatusBadge: React.FC<{ status?: string }> = ({
+  status,
+}) => (
+  <BadgePill $variant={statusVariant(status)}>
+    {capitalizeString(status ?? '')}
+  </BadgePill>
+);
+
+export const InOutBadge: React.FC<{ direction: 'In' | 'Out' }> = ({
+  direction,
+}) => (
+  <BadgePill $variant={direction === 'In' ? 'success' : 'warning'}>
+    {direction}
+  </BadgePill>
+);
+
+/**
+ * Hovering one type badge marks every badge of the same contract type in the
+ * list (the Basescan interaction), so a reader can spot "all the swaps" at a
+ * glance. Direct class toggling instead of React state: the match set is
+ * pure presentation, and re-rendering fifty rows per mouse move to paint an
+ * outline would be waste. The marker class is styled by
+ * TransactionsTableWrapper.
+ */
+const markSameType = (
+  event: React.MouseEvent<HTMLElement>,
+  on: boolean,
+): void => {
+  const badge = event.currentTarget;
+  const type = badge.dataset.contractType;
+  if (!type) return;
+  const scope = badge.closest('[data-testid="table-body"]') ?? document;
+  // Self-cleaning: a touch tap fires mouseenter but its mouseleave only
+  // arrives on the next tap elsewhere, so entering always sweeps first.
+  scope
+    .querySelectorAll('.type-hover-match')
+    .forEach(el => el.classList.remove('type-hover-match'));
+  if (!on) return;
+  scope
+    .querySelectorAll(`[data-contract-type="${CSS.escape(type)}"]`)
+    .forEach(el => el.classList.add('type-hover-match'));
+};
+
+export const TransactionTypeBadge: React.FC<{
+  label: string;
+  contractType: string;
+}> = ({ label, contractType }) => (
+  <BadgePill
+    $variant="contract"
+    data-contract-type={contractType}
+    onMouseEnter={event => markSameType(event, true)}
+    onMouseLeave={event => markSameType(event, false)}
+  >
+    {label}
+  </BadgePill>
+);
+
+/**
+ * The multi-contract case as the same pill dialect: count in the badge, the
+ * per-type breakdown behind the shared Tooltip, instead of the old
+ * bold-text-with-counter-chip that stood out of the row. The breakdown is
+ * computed before the tooltip body, so hovering repaints nothing (the churn
+ * the Age column had fixed).
+ */
+export const MultiContractBadge: React.FC<{ contract: IContract[] }> = ({
+  contract,
+}) => {
+  const counts: Record<string, number> = {};
+  contract.forEach(inner => {
+    // Numeric-enum reverse lookup: index by contract type number, get the
+    // display name back.
+    const name = String(
+      (ContractsIndex as unknown as Record<number, string>)[inner.type] ??
+        inner.type,
+    );
+    counts[name] = (counts[name] ?? 0) + 1;
+  });
+  const breakdown = Object.entries(counts)
+    .map(([name, count]) => `${name}: ${count}x`)
+    .join('\n');
+
+  return (
+    <Tooltip
+      msg={breakdown}
+      focusable
+      Component={() => (
+        <BadgePill
+          $variant="contract"
+          data-contract-type="Multi contract"
+          onMouseEnter={event => markSameType(event, true)}
+          onMouseLeave={event => markSameType(event, false)}
+        >
+          Multi contract (<BadgeCount>{contract.length}</BadgeCount>)
+          {/* The tooltip is hover-only; readers get the same breakdown. */}
+          <VisuallyHidden>{breakdown}</VisuallyHidden>
+        </BadgePill>
+      )}
+    />
+  );
+};

--- a/src/components/TransactionsList/columns.ts
+++ b/src/components/TransactionsList/columns.ts
@@ -13,15 +13,24 @@ import { ParsedUrlQuery } from 'querystring';
  *
  * Both now come from `getTransactionColumns`, so they cannot disagree: a
  * column is one entry, carrying its key and its heading together.
+ *
+ * Single-line variant: every datum that used to live on a cell's second line
+ * (timestamp, fee, receiver, first custom field) has its own column instead,
+ * the Basescan-style layout under comparison against the two-line benchmark
+ * (tag benchmark/two-line-rows).
  */
 
 export type TransactionColumnKey =
   | 'hash'
-  | 'blockFees'
-  | 'fromTo'
-  | 'inOut'
   | 'type'
-  | 'misc';
+  | 'block'
+  | 'age'
+  | 'from'
+  | 'direction'
+  | 'to'
+  | 'inOut'
+  | 'amount'
+  | 'fee';
 
 export interface ITransactionColumn {
   key: TransactionColumnKey;
@@ -30,12 +39,9 @@ export interface ITransactionColumn {
 }
 
 /**
- * Headings are still the English literals they have always been. They are
- * safe to translate, unlike the filter values, because no route passes
- * `sortableColumns` for this table and so no heading doubles as a sort key
- * (issue #678 blocks the holders table for exactly that reason). Doing it
- * belongs with the work that moves the cells themselves, not here, where the
- * point is that the two lists stop drifting apart.
+ * Headings here are the canonical English literals; display goes through
+ * `t()` in `useTransactionHeaders`, with these as the fallback, so this
+ * module stays free of i18n plumbing and usable outside React.
  *
  * A cell's `span` is not repeated here. It lives on the `IRowSection` the row
  * builder returns, which is the only place `Table` reads it from; a copy here
@@ -43,10 +49,16 @@ export interface ITransactionColumn {
  */
 const BASE_COLUMNS: ITransactionColumn[] = [
   { key: 'hash', header: 'Transaction Hash' },
-  { key: 'blockFees', header: 'Block/Fees' },
-  { key: 'fromTo', header: 'From/To' },
   { key: 'type', header: 'Type' },
-  { key: 'misc', header: 'Misc' },
+  { key: 'block', header: 'Block' },
+  { key: 'age', header: 'Age' },
+  { key: 'from', header: 'From' },
+  // The circled status arrow between the addresses; deliberately unheaded,
+  // like the reference explorers.
+  { key: 'direction', header: '' },
+  { key: 'to', header: 'To' },
+  { key: 'amount', header: 'Amount' },
+  { key: 'fee', header: 'Fee' },
 ];
 
 const IN_OUT_COLUMN: ITransactionColumn = {
@@ -54,8 +66,8 @@ const IN_OUT_COLUMN: ITransactionColumn = {
   header: 'In/Out',
 };
 
-/** Position of the In/Out column, directly after From/To. */
-const IN_OUT_INDEX = 3;
+/** Position of the In/Out column, directly after To. */
+const IN_OUT_INDEX = 7;
 
 /**
  * The routes whose request layer actually narrows the list to one account.
@@ -91,10 +103,6 @@ export const getTransactionColumns = ({
   return columns;
 };
 
-export const getTransactionHeaders = (
-  context: ITransactionColumnsContext,
-): string[] => getTransactionColumns(context).map(column => column.header);
-
 /**
  * Whether this list carries a direction. Both the headings and the cells ask
  * this, so they agree about the column's existence by construction.
@@ -111,3 +119,21 @@ export const showsInOut = (router: {
   // never equal, so the column would read "In" for every row.
   return typeof account === 'string' && account !== '';
 };
+
+/** Walking the list, not narrowing it. Neither changes which rows qualify. */
+const PAGINATION_KEYS = new Set(['page', 'limit']);
+
+/**
+ * Whether this list still holds the whole chain.
+ *
+ * Asked by the summary above it, whose figures are chain-wide. Every filter
+ * this page offers narrows the rows underneath while leaving those figures
+ * alone, and nothing in their labels says "network", so a card reading 8.19K
+ * transactions and a bar two thirds transfers would sit above a table of
+ * nothing but smart contract calls and read as its summary.
+ *
+ * Any parameter that is not paging counts as a filter, so a filter added
+ * later is covered without anyone remembering to list it here.
+ */
+export const listsWholeChain = (router: { query?: ParsedUrlQuery }): boolean =>
+  Object.keys(router?.query ?? {}).every(key => PAGINATION_KEYS.has(key));

--- a/src/components/TransactionsList/rowDetails.ts
+++ b/src/components/TransactionsList/rowDetails.ts
@@ -1,0 +1,251 @@
+import {
+  Contract,
+  EnumClaimType,
+  EnumMarketType,
+  IAssetTriggerContract,
+  IBuyContractPayload,
+  IClaimContract,
+  IContract,
+  IDelegateContract,
+  IDepositContract,
+  ISellContract,
+  ISmartContract,
+  ITransferContract,
+  IWithdrawContract,
+} from '@/types/contracts';
+import { IReceipt } from '@/types';
+import { ITransferReceipt } from '@/types/receipts';
+import { hexToString } from '@/utils/convertString';
+
+/**
+ * What the single-line row derives from the raw contract parameter: the
+ * counterparty for the To column, a short type refinement for a second
+ * badge, and the tooltip lines behind the contract mark. Read from the
+ * parameter itself rather than from `filteredSections`, whose output is
+ * React elements and therefore useless inside a string tooltip.
+ */
+
+export interface ITransactionTarget {
+  address: string;
+  /** Renders with the contract mark and routes to /smart-contract. */
+  isContract?: boolean;
+}
+
+export interface ITransactionRowDetails {
+  target?: ITransactionTarget;
+  typeDetail?: string;
+  contractTooltip?: string;
+}
+
+/**
+ * The receipt that records value changing hands between two accounts. Others
+ * carry value too (a kApp transfer is type 14), so this is the plain move,
+ * not "the only receipt with an amount".
+ */
+export const TRANSFER_RECEIPT_TYPE = 0;
+
+/**
+ * Narrows a receipt to the one shape that names both sides. The repo's
+ * `IReceipt` is a union whose other members have no `from`, so a caller
+ * cannot read one without asking which kind it is first.
+ */
+export const isTransferReceipt = (
+  receipt: IReceipt,
+): receipt is ITransferReceipt => receipt?.type === TRANSFER_RECEIPT_TYPE;
+
+export interface IRowDetailsInput {
+  contract: IContract[] | undefined;
+  contractType: string;
+  data?: string[];
+  sender?: string;
+  receipts?: IReceipt[];
+}
+
+interface IBuilderContext {
+  data?: string[];
+  /**
+   * Where a claim or withdrawal pays out: the transfer receipt names the
+   * receiving address, and on chain that is the claimer (verified live on
+   * an AllowanceClaim: receipt.to equals the sender).
+   */
+  paidTo?: string;
+}
+
+type DetailBuilder = (
+  parameter: NonNullable<IContract['parameter']>,
+  context: IBuilderContext,
+) => ITransactionRowDetails;
+
+/**
+ * Enum compounds read as one shouted word in a 0.625rem uppercase badge
+ * ("STAKINGCLAIM"); spacing the camel case out gives "STAKING CLAIM".
+ */
+const spaceOutCamelCase = (value: string): string =>
+  value.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+
+/** A badge-ready type refinement; API payloads carry names or numbers. */
+const detailText = (
+  value: string | number | undefined,
+  lookup?: Record<number, string>,
+): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  const name =
+    typeof value === 'number' ? (lookup?.[value] ?? String(value)) : value;
+  return spaceOutCamelCase(String(name));
+};
+
+const addressTarget = (address?: string): ITransactionRowDetails =>
+  address ? { target: { address } } : {};
+
+/**
+ * The invoked function comes out of the transaction's own data field, which
+ * the sender fills in and which does not have to name a real function. The
+ * tooltip renders one line per newline, so an unfiltered value could append
+ * lines of its own below the app's, in the app's own styling. Splitting on
+ * `@` bounds nothing when the payload simply omits it.
+ */
+const FUNCTION_NAME_LIMIT = 40;
+
+const readFunctionName = (data?: string[]): string =>
+  hexToString(data?.[0] || '')
+    .split('@')[0]
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
+    .slice(0, FUNCTION_NAME_LIMIT);
+
+const smartContractDetails: DetailBuilder = (parameter, { data }) => {
+  const par = parameter as unknown as ISmartContract;
+  if (!par.address) return {};
+  // The cast is a claim about the payload, not a check on it: the node fills
+  // this field, so a non-string type would take .slice down with the whole row.
+  const call = typeof par.type === 'string' ? par.type.slice(2) : '';
+  const calledFunction = call === 'Invoke' ? readFunctionName(data) : '';
+  return {
+    target: { address: par.address, isContract: true },
+    typeDetail: call && call !== 'Invoke' ? call : undefined,
+    contractTooltip: [
+      'Contract',
+      calledFunction && `Function: ${calledFunction}`,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+  };
+};
+
+const DETAIL_BUILDERS: Partial<Record<string, DetailBuilder>> = {
+  [Contract.Transfer]: parameter =>
+    addressTarget((parameter as ITransferContract).toAddress),
+  [Contract.SmartContract]: smartContractDetails,
+  [Contract.Delegate]: parameter =>
+    addressTarget((parameter as IDelegateContract).toAddress),
+  [Contract.Claim]: (parameter, { paidTo }) => ({
+    ...addressTarget(paidTo),
+    typeDetail: detailText(
+      (parameter as IClaimContract).claimType,
+      EnumClaimType as unknown as Record<number, string>,
+    ),
+  }),
+  [Contract.AssetTrigger]: parameter => {
+    const par = parameter as unknown as IAssetTriggerContract;
+    return {
+      ...addressTarget(par.toAddress),
+      typeDetail: detailText(par.triggerType),
+    };
+  },
+  [Contract.Withdraw]: (parameter, { paidTo }) => ({
+    ...addressTarget(paidTo),
+    typeDetail: detailText(
+      (parameter as unknown as IWithdrawContract).withdrawTypeString,
+    ),
+  }),
+  [Contract.Buy]: parameter => ({
+    typeDetail: detailText(
+      (parameter as unknown as IBuyContractPayload).buyType,
+    ),
+  }),
+  [Contract.Sell]: parameter => ({
+    typeDetail: detailText(
+      (parameter as unknown as ISellContract).marketType,
+      EnumMarketType as unknown as Record<number, string>,
+    ),
+  }),
+  [Contract.Deposit]: parameter => ({
+    typeDetail: detailText(
+      (parameter as unknown as IDepositContract).depositTypeString,
+    ),
+  }),
+  [Contract.ITOTrigger]: parameter => ({
+    typeDetail: detailText(
+      (parameter as unknown as { triggerType?: string | number }).triggerType,
+    ),
+  }),
+};
+
+export const getTransactionRowDetails = ({
+  contract,
+  contractType,
+  data,
+  sender,
+  receipts,
+}: IRowDetailsInput): ITransactionRowDetails => {
+  const parameter = contract?.[0]?.parameter;
+  if (!parameter || (contract?.length ?? 0) > 1) return {};
+
+  const paidTo = receipts?.find(isTransferReceipt)?.to ?? sender;
+
+  return DETAIL_BUILDERS[contractType]?.(parameter, { data, paidTo }) ?? {};
+};
+
+/**
+ * The two contract types that exist to pay their own submitter. Everything
+ * else an account submits is an outgoing act, whatever else rides along.
+ */
+const PAYS_ITS_SENDER = new Set<string>([Contract.Claim, Contract.Withdraw]);
+
+/**
+ * Which way value moved for one account, or undefined when the transaction
+ * says nothing about it.
+ *
+ * An account that submitted a transaction made an outgoing move, and the two
+ * payout types above are the exceptions. Reading the transfer receipts
+ * instead looks more precise and is a trap: the staking contracts pay out
+ * accrued rewards in the same transaction, so a freeze carries a receipt
+ * paying its own sender. Measured against mainnet, 30 of 40 freezes, 16 of 40
+ * unfreezes and 10 of 40 delegations would have been labelled incoming on the
+ * account that submitted them.
+ *
+ * For a transaction the account did not submit, only a transfer receipt
+ * naming it says anything, and where none does the honest answer is nothing:
+ * a validator's own page lists the delegations pointed at it, and none of
+ * them moves value into it.
+ */
+export const valueDirection = ({
+  account,
+  sender,
+  contractType,
+  receipts,
+}: {
+  account?: string;
+  sender?: string;
+  contractType?: string;
+  receipts?: IReceipt[];
+}): 'In' | 'Out' | undefined => {
+  if (!account) return undefined;
+
+  if (account === sender) {
+    return PAYS_ITS_SENDER.has(contractType ?? '') ? 'In' : 'Out';
+  }
+
+  let sent = false;
+  let received = false;
+
+  for (const receipt of receipts ?? []) {
+    if (!isTransferReceipt(receipt)) continue;
+    if (receipt.from === account) sent = true;
+    if (receipt.to === account) received = true;
+  }
+
+  if (received) return 'In';
+  if (sent) return 'Out';
+  return undefined;
+};

--- a/src/components/TransactionsList/styles.ts
+++ b/src/components/TransactionsList/styles.ts
@@ -1,0 +1,262 @@
+import {
+  accentText,
+  badgeColor,
+  badgeTint,
+  BadgePill,
+  BadgeVariant,
+  DATA_LIST_ROW_HEIGHT,
+  dataListTableSkin,
+  focusRing,
+  inCard,
+  SummaryCard,
+} from '@/components/DataList/styles';
+import SummaryLoading from '@/components/DataList/SummaryLoading';
+import { MobileCardItem } from '@/components/Table/styles';
+import Link from 'next/link';
+import styled, { css } from 'styled-components';
+
+/**
+ * The contract count inside the multi-contract badge. A `b`, not a span:
+ * the shared cell rules pin every span to the line height, and the count
+ * must only differ in weight.
+ */
+export const BadgeCount = styled.b`
+  font-weight: 800;
+`;
+
+/**
+ * The document mark behind a contract address in the To column, the
+ * Basescan affordance: its focusable tooltip carries "Contract" plus the
+ * invoked function, the data the dropped Misc column used to hold.
+ */
+export const ContractMark = styled.span`
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: ${props => props.theme.darkText};
+  cursor: help;
+`;
+
+/**
+ * The circled glyph between From and To: the row's status carrier. Green
+ * arrow for success, red exclamation for fail, amber clock for pending: the
+ * glyph varies with the color on purpose, so the state survives color
+ * blindness, and the word rides in the shared tooltip and in visually
+ * hidden text.
+ */
+export const DirectionStatusBadge = styled.span<{ $variant: BadgeVariant }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  color: ${props => badgeColor(props, props.$variant)};
+  border: 1px solid ${props => badgeColor(props, props.$variant)};
+  background-color: ${props => badgeTint(props, props.$variant)};
+
+  svg {
+    flex-shrink: 0;
+  }
+`;
+
+/**
+ * The shared data-list skin plus what the single-line transactions table
+ * needs on top of it: the 60px row with one 20px content line, the badge
+ * carve-outs, and the link affordances. No overflow container on purpose:
+ * a contained scroll was measured to clip the hover dropdowns on the bottom
+ * rows, hide columns without any affordance, and silence the sticky header,
+ * while wide data past its cap still pushed the page sideways. On desktop
+ * widths the table does not always fit below roughly 1170px; there the page
+ * scrolls horizontally like the app's other wide tables, and every popover,
+ * key control and the sticky header keep working.
+ */
+export const TransactionsTableWrapper = styled.div`
+  ${dataListTableSkin}
+
+  @media screen and (min-width: ${props => props.theme.breakpoints.tablet}) {
+    ${MobileCardItem} {
+      height: ${DATA_LIST_ROW_HEIGHT};
+      /* Inherited by the anonymous text of the amount sections, which the
+         shared a/span rule cannot reach; under width pressure that text
+         wrapped mid-amount ("20 K" over two lines). */
+      white-space: nowrap;
+    }
+
+    /* One 20px content line, centered by the cell's vertical-align inside
+       the 60px row; the shared rule would pin these to 24px. */
+    ${MobileCardItem} a,
+    ${MobileCardItem} span {
+      height: 20px;
+    }
+
+    /* More specific than the 20px line above, so badges keep the intrinsic
+       height they have everywhere else in the data-list system. A minimum
+       rather than a fixed height: at 200 percent browser text size the
+       0.625rem badge text outgrows 18px, and a fixed pill strikes through
+       its own label (WCAG 1.4.4); the 60px row has the vertical room. */
+    ${MobileCardItem} ${BadgePill},
+    ${MobileCardItem} ${DirectionStatusBadge} {
+      height: auto;
+      min-height: 18px;
+    }
+
+    /* The skin removes the permanent underline; without a hover or focus
+       replacement a link is indistinguishable from the static text next to
+       it (the block number sits directly above the fee in the same style). */
+    ${MobileCardItem} a:hover,
+    ${MobileCardItem} a:focus-visible {
+      text-decoration: underline;
+      text-underline-offset: 0.2rem;
+    }
+
+    /* Set by TransactionTypeBadge on every badge sharing the hovered
+       contract type. */
+    ${BadgePill}.type-hover-match {
+      outline: 1px dashed
+        ${props => (props.theme.dark ? '#C95ED4' : props.theme.violet)};
+      outline-offset: 1px;
+    }
+  }
+`;
+
+/* ------------------------------- summary --------------------------------- */
+
+/**
+ * Both directions read as small text (13px), so both need 4.5:1. The badge
+ * palette's success is the darker derived green; the raw successColor is
+ * calibrated for icons at 3:1 and measures 3.54:1 here.
+ */
+export const TrendValue = styled.span<{ $positive: boolean }>`
+  font-size: 0.8125rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: ${props => badgeColor(props, props.$positive ? 'success' : 'danger')};
+`;
+
+/**
+ * Here the summary is the first thing under the page title, where the shared
+ * card sits below a tab row on the pages it was built for and inherits its
+ * top spacing from there. 1.5rem is the shared CardContainer's rhythm, so it
+ * matches what the other list pages put under their title. The loading shape
+ * carries the same margin, or the page would drop 24px once the figures land.
+ */
+const pageSummarySpacing = css`
+  margin-top: 1.5rem;
+`;
+
+export const PageSummaryCard = styled(SummaryCard)`
+  ${pageSummarySpacing}
+`;
+
+export const PageSummaryLoading = styled(SummaryLoading)`
+  ${pageSummarySpacing}
+`;
+
+/**
+ * The box a contract name is allowed to occupy.
+ *
+ * Whoever deploys a contract chooses its name, and the To cell clips rather
+ * than ellipsises and grows to fit whatever it is given. Measured at a 1280px
+ * viewport: a 200 character name widened the page to 3017px, and even a name
+ * capped at 33 characters reached 1400px, so bounding the text alone does not
+ * hold the layout. The cap here matches the column's own 150px, which is what
+ * the truncated address it replaces was sized for.
+ */
+export const ContractName = styled.span`
+  ${inCard('inline-block')}
+
+  && {
+    /* Same floor as ceiling: the name lands about a second after the row is
+       readable, and a box that grows on arrival drags every column with it.
+       Measured before this was fixed: all nine columns changed width when the
+       names resolved, moving the row under the reader's pointer. */
+    min-width: 150px;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: bottom;
+  }
+`;
+
+/** The asset link, which the global reset would otherwise render as text. */
+export const SummaryAssetLink = styled(Link)`
+  color: ${accentText};
+  ${focusRing}
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+`;
+
+/* --------------------------- mobile card pieces -------------------------- */
+
+/* 10px rather than a tighter rhythm: From, To and Block are three adjacent
+   links, and sub-24px targets need 24px center-to-center spacing (WCAG
+   2.5.8) to keep a thumb off the neighbouring address. */
+export const CardRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 10px;
+
+  /* Only phones keep the label-left value-right spread; from tablet width
+     the card spans the page and space-between would put half a screen of
+     gutter between a label and its value. */
+  @media screen and (min-width: ${props => props.theme.breakpoints.mobile}) {
+    justify-content: flex-start;
+  }
+`;
+
+export const CardLabel = styled.span`
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: ${props => props.theme.darkText};
+`;
+
+export const CardValue = styled.span`
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+  font-size: 0.8125rem;
+  color: ${props => props.theme.black};
+
+  /* Truncation lives on the children: text-overflow only acts on inline
+     content of a block container, and this container's children are flex
+     items, so the trio on the container itself would clip without the
+     ellipsis. */
+  > * {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  a {
+    color: ${props => props.theme.black};
+    /* Persistent, not hover-only: a touch screen has no hover, and these
+       values sit next to non-link values in the same color. */
+    text-decoration: underline;
+    text-underline-offset: 0.2rem;
+  }
+`;
+
+export const CardHashLink = styled(Link)`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  color: ${props => props.theme.black};
+
+  &:focus-visible {
+    outline: 2px solid ${props => props.theme.violet};
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;

--- a/src/components/TransactionsList/useContractName.ts
+++ b/src/components/TransactionsList/useContractName.ts
@@ -1,0 +1,36 @@
+import {
+  CONTRACT_NAME_STALE_TIME,
+  contractNameQueryKey,
+  smartContractNameCall,
+} from '@/services/requests/smartContracts/names';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * The name of the contract a row points at, or undefined while it is unknown.
+ *
+ * Deliberately its own query rather than part of the row request: the table
+ * already waits on one round trip before it can paint, and a name is
+ * decoration on a link that reads fine without it. Rows render with the
+ * address and pick the name up when it lands.
+ *
+ * React Query deduplicates by address, so a page where forty rows call the
+ * same contract still asks once, and the hour-long staleTime means paging
+ * through a list asks not at all.
+ */
+export const useContractName = (
+  address: string,
+  enabled: boolean,
+): string | undefined => {
+  const { data } = useQuery({
+    queryKey: contractNameQueryKey(address),
+    queryFn: () => smartContractNameCall(address),
+    // An address the row could not resolve asks for nothing, so the query
+    // never runs and its key is never read.
+    enabled: Boolean(enabled && address),
+    staleTime: CONTRACT_NAME_STALE_TIME,
+    // A contract without a name is a settled answer, not a failure to retry.
+    retry: false,
+  });
+
+  return data ?? undefined;
+};

--- a/src/components/TransactionsList/useTransactionHeaders.ts
+++ b/src/components/TransactionsList/useTransactionHeaders.ts
@@ -1,5 +1,23 @@
+import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import { getTransactionHeaders, showsInOut } from './columns';
+import {
+  getTransactionColumns,
+  showsInOut,
+  TransactionColumnKey,
+} from './columns';
+
+const HEADER_I18N_KEY: Record<TransactionColumnKey, string> = {
+  hash: 'transactions:Table.TransactionHash',
+  type: 'transactions:Table.Type',
+  block: 'transactions:Table.Block',
+  age: 'transactions:Table.Age',
+  from: 'transactions:From',
+  direction: '',
+  to: 'transactions:To',
+  inOut: 'transactions:Table.InOut',
+  amount: 'transactions:Table.Amount',
+  fee: 'transactions:Table.Fee',
+};
 
 /**
  * Column headings for the shared transactions table.
@@ -8,9 +26,21 @@ import { getTransactionHeaders, showsInOut } from './columns';
  * depends on the URL, and it has to be decided from the same place
  * `transactionRowSections` decides it. Four call sites each answered that
  * question themselves, three of them by not asking it at all.
+ *
+ * Headings pass through `t()` with the column's English literal as the
+ * fallback. Translating them is safe for this table because no route passes
+ * `sortableColumns`, so no heading doubles as a sort key (issue #678 blocks
+ * the holders table for exactly that reason).
  */
 export const useTransactionHeaders = (): string[] => {
   const router = useRouter();
+  const { t } = useTranslation(['transactions']);
 
-  return getTransactionHeaders({ showInOut: showsInOut(router) });
+  return getTransactionColumns({ showInOut: showsInOut(router) }).map(column =>
+    // A deliberately unheaded column stays empty: i18next would render the
+    // key itself when handed an empty defaultValue.
+    HEADER_I18N_KEY[column.key] === ''
+      ? column.header
+      : t(HEADER_I18N_KEY[column.key], { defaultValue: column.header }),
+  );
 };

--- a/src/pages/asset/[asset].tsx
+++ b/src/pages/asset/[asset].tsx
@@ -2,6 +2,8 @@ import { AssetSummary } from '@/components/Asset/AssetSummary';
 import { AssetTabs } from '@/components/Asset/AssetTabs';
 import Tabs, { ITabs } from '@/components/NewTabs';
 import Table, { ITable } from '@/components/Table';
+import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
+import { TransactionsTableWrapper } from '@/components/TransactionsList/styles';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import Holders from '@/components/Tabs/Holders';
 import TransactionsFilters from '@/components/TransactionsFilters';
@@ -113,6 +115,8 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
     Filters: TransactionsFilters,
+    MobileCard: TransactionsMobileCard,
+    singleLineSkeleton: true,
   };
 
   // Rendered as elements, not as a component built during render: a fresh
@@ -121,7 +125,11 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
   const renderSelectedTab = (): ReactNode => {
     switch (selectedTab) {
       case `${t('common:Titles.Transactions')}`:
-        return <Table {...tableProps} />;
+        return (
+          <TransactionsTableWrapper>
+            <Table {...tableProps} />
+          </TransactionsTableWrapper>
+        );
       case `${t('common:Tabs.Holders')}`:
         if (asset && asset.assetType !== AssetTypeString.SemiFungible) {
           return <Holders asset={asset} />;

--- a/src/pages/asset/[asset]/[nonce].tsx
+++ b/src/pages/asset/[asset]/[nonce].tsx
@@ -3,6 +3,7 @@ import { NonFungibleView } from '@/components/Asset/NonFungibleView';
 import { SemiFungibleView } from '@/components/Asset/SemiFungibleView';
 import Title from '@/components/Layout/Title';
 import { ITable } from '@/components/Table';
+import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import TransactionsFilters from '@/components/TransactionsFilters';
 import { transactionRowSections } from '@/pages/transactions';
@@ -65,6 +66,8 @@ const AssetNonce: React.FC<PropsWithChildren> = () => {
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
     Filters: TransactionsFilters,
+    MobileCard: TransactionsMobileCard,
+    singleLineSkeleton: true,
   };
 
   return (

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -2,31 +2,39 @@ import { Transactions as Icon } from '@/assets/title-icons';
 import ExplorerLink from '@/components/ExplorerLink';
 import Title from '@/components/Layout/Title';
 import LinkWithDropdown from '@/components/LinkWithDropdown';
-import { MultiContractToolTip } from '@/components/MultiContractToolTip';
 import Table, { ITable } from '@/components/Table';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import {
   getTransactionColumns,
+  listsWholeChain,
   showsInOut,
   TransactionColumnKey,
 } from '@/components/TransactionsList/columns';
+import { BadgePill, VisuallyHidden } from '@/components/DataList/styles';
+import { CustomFieldWrapper } from '@/components/Table/styles';
 import {
-  CustomFieldWrapper,
-  InOutSpan,
-  Status,
-  TimestampInfo,
-} from '@/components/Table/styles';
+  InOutBadge,
+  MultiContractBadge,
+  statusVariant,
+  TransactionTypeBadge,
+} from '@/components/TransactionsList/badges';
+import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
+import ContractTargetLabel from '@/components/TransactionsList/ContractTargetLabel';
+import {
+  getTransactionRowDetails,
+  valueDirection,
+} from '@/components/TransactionsList/rowDetails';
+import TransactionsSummary from '@/components/TransactionsList/Summary';
+import {
+  ContractMark,
+  DirectionStatusBadge,
+  TransactionsTableWrapper,
+} from '@/components/TransactionsList/styles';
 import Tooltip from '@/components/Tooltip';
 import TransactionsFilters from '@/components/TransactionsFilters';
 import { useMobile } from '@/contexts/mobile';
 import api from '@/services/api';
-import {
-  CenteredRow,
-  Container,
-  DoubleRow,
-  Header,
-  Mono,
-} from '@/styles/common';
+import { CenteredRow, Container, Header, Mono } from '@/styles/common';
 import {
   IAssetTransactionResponse,
   IClaimReceipt,
@@ -35,11 +43,9 @@ import {
   ITransaction,
 } from '@/types';
 import {
-  Contract,
   ContractsName,
   IBuyContractPayload,
   IContract,
-  ITransferContract,
 } from '@/types/contracts';
 import {
   contractTypes,
@@ -48,12 +54,22 @@ import {
 } from '@/utils/contracts';
 import { capitalizeString } from '@/utils/convertString';
 import { findReceipt } from '@/utils/findKey';
-import { formatAmount, formatDate } from '@/utils/formatFunctions';
+import {
+  formatAmount,
+  formatDate,
+  formatDateWithSeconds,
+} from '@/utils/formatFunctions';
 import { KLV_PRECISION } from '@/utils/globalVariables';
 import { parseAddress } from '@/utils/parseValues';
 import { getPrecision } from '@/utils/precisionFunctions';
 import { TXType } from '@klever/connect';
 import { GetServerSideProps } from 'next';
+import {
+  MdAccessTime,
+  MdArrowForward,
+  MdOutlineDescription,
+  MdPriorityHigh,
+} from 'react-icons/md';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from 'next/link';
@@ -65,8 +81,17 @@ interface IRequestTxQuery {
   asset?: string;
   address?: string;
 }
+
+/** One glyph per status, so the arrow's color is never the only signal. */
+const DIRECTION_GLYPHS = {
+  success: MdArrowForward,
+  danger: MdPriorityHigh,
+  warning: MdAccessTime,
+  neutral: MdArrowForward,
+} as const;
 export const toAddressSectionElement = (
   toAddress: string,
+  chars = 16,
 ): React.ReactElement => {
   if (toAddress === '--') {
     return <Mono>{toAddress}</Mono>;
@@ -74,26 +99,27 @@ export const toAddressSectionElement = (
   return (
     <LinkWithDropdown link={`/account/${toAddress}`} address={toAddress}>
       <Link href={`/account/${toAddress}`} key={toAddress} className="address">
-        <Mono>{parseAddress(toAddress, 16)}</Mono>
+        <Mono>{parseAddress(toAddress, chars)}</Mono>
       </Link>
     </LinkWithDropdown>
   );
 };
 export const mobileAddressSectionElement = (
   toAddress: string,
+  chars = 16,
 ): React.ReactElement => {
   const { isMobile } = useMobile();
   if (isMobile) {
     return (
       <LinkWithDropdown link={`/account/${toAddress}`} address={toAddress}>
-        <Mono>{parseAddress(toAddress, 16)}</Mono>
+        <Mono>{parseAddress(toAddress, chars)}</Mono>
       </LinkWithDropdown>
     );
   }
   return (
     <LinkWithDropdown link={`/account/${toAddress}`} address={toAddress}>
       <Link href={`/account/${toAddress}`} key={toAddress} className="address">
-        <Mono>{parseAddress(toAddress, 16)}</Mono>
+        <Mono>{parseAddress(toAddress, chars)}</Mono>
       </Link>
     </LinkWithDropdown>
   );
@@ -261,142 +287,254 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
   } = props;
   const router = useRouter();
 
-  let toAddress = '--';
   const contractType = contractTypes(contract);
-  if (contractType === Contract.Transfer) {
-    const parameter = contract[0].parameter as ITransferContract;
+  // The counterparty, the second type badge and the contract-mark tooltip,
+  // straight from the raw parameter (the misc columns' element output cannot
+  // feed a string tooltip).
+  const details = getTransactionRowDetails({
+    contract,
+    contractType,
+    data,
+    sender,
+    receipts,
+  });
 
-    toAddress = parameter.toAddress;
-  }
-
-  const inOrOut = router?.query?.account === sender ? 'Out' : 'In';
+  const inOrOut = valueDirection({
+    account:
+      typeof router?.query?.account === 'string'
+        ? router.query.account
+        : undefined,
+    sender,
+    contractType,
+    receipts,
+  });
 
   const customFields = getCustomFields(contract, receipts, precision, data);
+  const customLabels = getLabelForTableField(contractType) ?? [];
+  // Amount first, else Price: a buy or a sell moves the amount its price
+  // names, and those label sets carry no field literally called Amount.
+  //
+  // This reads a position out of `contractLabels` and uses it to index the
+  // elements `filteredSections` built, so the two lists have to stay in the
+  // same order. They do today, checked per type: Transfer 0, Freeze 0,
+  // Claim 0, Vote 1, Withdraw 1, Buy 2, Sell 2, Deposit 2. Reordering either
+  // one alone puts the wrong field in this column with nothing to catch it,
+  // and nothing can: both modules reach the ESM dependency Jest cannot
+  // transform, so neither is importable by a unit test. If you touch the
+  // order in `@/utils/contracts` or `@/utils/transactionListSections`, this
+  // is what you break.
+  const amountLabelIndex = customLabels.indexOf('Amount');
+  const amountIndex =
+    amountLabelIndex >= 0 ? amountLabelIndex : customLabels.indexOf('Price');
+
+  // Computed once per row render, not inside the tooltip: the tooltip body
+  // mounts on hover, and a fresh formatDate there made the visible elapsed
+  // time jump the moment the pointer touched it.
+  const ageFullDate = formatDateWithSeconds(timestamp || Date.now());
+  // formatDate's elapsed form is "<n> <unit> ago (<date> UTC)"; the column
+  // shows the first half, the tooltip the full date.
+  const ageElapsed = formatDate(timestamp || Date.now(), {
+    showElapsedTime: true,
+  }).split(' (')[0];
+
+  const emptyCell = (
+    <>
+      {/* English like every other literal this builder renders: t() is out
+          of reach here, the builder also runs for the header-string probe
+          outside any i18n context. */}
+      <span aria-hidden="true">- -</span>
+      <VisuallyHidden>Not applicable</VisuallyHidden>
+    </>
+  );
 
   const sectionByColumn: Record<TransactionColumnKey, IRowSection> = {
     hash: {
       element: props => (
-        <DoubleRow {...props} key={hash}>
+        <CenteredRow key={hash}>
           <ExplorerLink
             type="transaction"
             value={hash}
-            label={parseAddress(hash, 24)}
+            label={parseAddress(hash, 14)}
             compact
+            dataTestId="transaction-link"
           />
-          <CenteredRow>
-            <TimestampInfo>
-              {formatDate(timestamp || Date.now(), {
-                showElapsedTime: true,
-              })}
-            </TimestampInfo>
-            <Status status={status?.toLowerCase()}>
-              {capitalizeString(status)}
-            </Status>
+        </CenteredRow>
+      ),
+      span: 1,
+      // Hinted like every other column: the one unhinted column would
+      // absorb all of the table's slack and open a gulf behind the hash.
+      width: 190,
+    },
+    type: {
+      element: props => (
+        <CenteredRow key={contractType}>
+          {contractType === 'Multi contract' ? (
+            <MultiContractBadge contract={contract} />
+          ) : (
+            <TransactionTypeBadge
+              label={
+                ContractsName[contractType as keyof typeof ContractsName] ??
+                contractType
+              }
+              contractType={contractType}
+            />
+          )}
+          {/* The refinement the Misc column used to carry (StakingClaim,
+              Mint, MarketBuy, ...), now riding with its type. */}
+          {details.typeDetail && (
+            <BadgePill $variant="neutral">{details.typeDetail}</BadgePill>
+          )}
+        </CenteredRow>
+      ),
+      span: 1,
+      width: 170,
+    },
+    block: {
+      element: props => (
+        <ExplorerLink type="block" value={String(blockNum || 0)} compact />
+      ),
+      span: 1,
+      width: 95,
+    },
+    age: {
+      element: props => (
+        <Tooltip
+          msg={ageFullDate}
+          focusable
+          Component={() => (
+            <CustomFieldWrapper>{ageElapsed}</CustomFieldWrapper>
+          )}
+        />
+      ),
+      span: 1,
+      width: 110,
+    },
+    from: {
+      element: props => (
+        <CenteredRow key={sender}>
+          {/* 16, the same as everywhere else, and not the 12 this column
+              briefly used to buy width.
+
+              A bech32 address ends in a six character checksum and opens with
+              a constant prefix, so 12 shows an attacker two free characters
+              to reproduce where 16 shows six: 2^40 against 2^60, hours of
+              grinding on one GPU against longer than anyone will wait. That
+              is the price of a poisoned row whose From cell reads exactly
+              like a real one, and the cell offers a prefilled transfer.
+
+              The width it bought did not settle anything either. Measured at
+              this font, the four characters are 33.7px a column and 67px
+              across both, against a 100px overflow at a 1100px viewport: the
+              table scrolled sideways at 12 as well, and at 1280 it scrolls at
+              neither. */}
+          {mobileAddressSectionElement(sender, 16)}
+        </CenteredRow>
+      ),
+      span: 1,
+      width: 140,
+    },
+    direction: {
+      element: props => {
+        // Glyph and color vary together (arrow, exclamation, clock), so the
+        // state survives color blindness; the word rides in the focusable
+        // tooltip and in hidden text.
+        const DirectionGlyph = DIRECTION_GLYPHS[statusVariant(status)];
+        return (
+          <CenteredRow key={status}>
+            <Tooltip
+              msg={capitalizeString(status ?? '')}
+              focusable
+              Component={() => (
+                <DirectionStatusBadge $variant={statusVariant(status)}>
+                  <DirectionGlyph size={11} aria-hidden="true" />
+                  <VisuallyHidden>
+                    {`Status: ${capitalizeString(status ?? '')}`}
+                  </VisuallyHidden>
+                </DirectionStatusBadge>
+              )}
+            />
           </CenteredRow>
-        </DoubleRow>
-      ),
-      span: 2,
+        );
+      },
+      span: 1,
+      width: 36,
     },
-    blockFees: {
+    to: {
       element: props => (
-        <DoubleRow {...props} key={blockNum}>
-          <ExplorerLink type="block" value={String(blockNum || 0)} compact />
-          <span>
-            {formatAmount((kAppFee + bandwidthFee) / 10 ** KLV_PRECISION)} KLV
-          </span>
-        </DoubleRow>
+        <CenteredRow key={details.target?.address ?? '--'}>
+          {details.target ? (
+            <>
+              <ExplorerLink
+                type={details.target.isContract ? 'smart-contract' : 'account'}
+                value={details.target.address}
+                label={
+                  <ContractTargetLabel
+                    address={details.target.address}
+                    isContract={details.target.isContract}
+                    truncateTo={16}
+                  />
+                }
+                // The label brings its own typography: a resolved contract
+                // name is words, the address it falls back to is a hash.
+                mono={false}
+                compact
+              />
+              {/* After the address, not before: this way every address in
+                  the column starts at the same x. */}
+              {details.target.isContract && (
+                <Tooltip
+                  msg={details.contractTooltip ?? 'Contract'}
+                  focusable
+                  Component={() => (
+                    <ContractMark>
+                      <MdOutlineDescription size={14} aria-hidden="true" />
+                      <VisuallyHidden>
+                        {details.contractTooltip ?? 'Contract'}
+                      </VisuallyHidden>
+                    </ContractMark>
+                  )}
+                />
+              )}
+            </>
+          ) : (
+            emptyCell
+          )}
+        </CenteredRow>
       ),
       span: 1,
-    },
-    fromTo: {
-      element: props => (
-        <DoubleRow {...props} key={sender}>
-          {mobileAddressSectionElement(sender)}
-          {toAddressSectionElement(toAddress)}
-        </DoubleRow>
-      ),
-      span: 1,
+      width: 150,
     },
     inOut: {
       element: props => (
-        <DoubleRow {...props} key={inOrOut}>
-          <CenteredRow>
-            {contractType === 'TransferContractType' ? (
-              <InOutSpan status={inOrOut === 'In' ? 'success' : 'pending'}>
-                {inOrOut}
-              </InOutSpan>
-            ) : (
-              <InOutSpan status={'icon'}>- -</InOutSpan>
-            )}
-          </CenteredRow>
-        </DoubleRow>
+        <CenteredRow key={inOrOut}>
+          {/* No badge where the transaction says nothing about direction: a
+              delegation aimed at this validator, or a send that failed and
+              moved nothing. Claiming one would be worse than leaving it. */}
+          {inOrOut ? <InOutBadge direction={inOrOut} /> : emptyCell}
+        </CenteredRow>
       ),
       span: 1,
+      width: 70,
     },
-    type: {
-      element: props =>
-        contractType === 'Multi contract' ? (
-          <DoubleRow {...props}>
-            <MultiContractToolTip
-              contract={contract}
-              contractType={contractType}
-            />
-            <CenteredRow>- -</CenteredRow>
-          </DoubleRow>
-        ) : (
-          <DoubleRow {...props}>
-            <CenteredRow key={contractType}>
-              <span>
-                {ContractsName[contractType as keyof typeof ContractsName]}
-              </span>
-            </CenteredRow>
-            <CenteredRow>
-              {getLabelForTableField(contractType)?.[0] ? (
-                <Tooltip
-                  msg={getLabelForTableField(contractType)[0]}
-                  Component={() => (
-                    <>
-                      <CustomFieldWrapper>{customFields[0]}</CustomFieldWrapper>
-                    </>
-                  )}
-                />
-              ) : (
-                <span> - - </span>
-              )}
-            </CenteredRow>
-          </DoubleRow>
-        ),
+    amount: {
+      element: props => (
+        <CenteredRow>
+          {amountIndex >= 0 && customFields[amountIndex]
+            ? customFields[amountIndex]
+            : emptyCell}
+        </CenteredRow>
+      ),
       span: 1,
+      width: 130,
     },
-    misc: {
-      element: props =>
-        contractType ? (
-          <DoubleRow {...props}>
-            {getLabelForTableField(contractType)?.[1] ? (
-              <Tooltip
-                msg={getLabelForTableField(contractType)[1]}
-                Component={() => (
-                  <CustomFieldWrapper>{customFields[1]}</CustomFieldWrapper>
-                )}
-              />
-            ) : (
-              <span> - - </span>
-            )}
-            {getLabelForTableField(contractType)?.[2] ? (
-              <Tooltip
-                msg={getLabelForTableField(contractType)[2]}
-                Component={() => (
-                  <CustomFieldWrapper>{customFields[2]}</CustomFieldWrapper>
-                )}
-              />
-            ) : (
-              <span> - - </span>
-            )}
-          </DoubleRow>
-        ) : (
-          <></>
-        ),
+    fee: {
+      element: props => (
+        <span>
+          {formatAmount((kAppFee + bandwidthFee) / 10 ** KLV_PRECISION)} KLV
+        </span>
+      ),
       span: 1,
+      width: 100,
     },
   };
 
@@ -419,6 +557,8 @@ const Transactions: React.FC<PropsWithChildren> = () => {
     dataName: 'transactions',
     request: (page, limit) => requestTransactionsDefault(page, limit, router),
     Filters: TransactionsFilters,
+    MobileCard: TransactionsMobileCard,
+    singleLineSkeleton: true,
   };
 
   return (
@@ -427,7 +567,16 @@ const Transactions: React.FC<PropsWithChildren> = () => {
         <Title title={t('common:Titles.Transactions')} Icon={Icon} />
       </Header>
 
-      <Table {...tableProps} />
+      {/* Only above an unscoped list. Every filter this page offers narrows
+          the rows below while leaving these figures chain-wide, so above a
+          filtered table they would describe something the reader is not
+          looking at. `?account=` is one of those filters: the query is mapped
+          onto `address` before the request goes out. */}
+      {listsWholeChain(router) && <TransactionsSummary />}
+
+      <TransactionsTableWrapper>
+        <Table {...tableProps} />
+      </TransactionsTableWrapper>
     </Container>
   );
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -160,11 +160,15 @@ export const withoutBody = async (
       const { route, query, service, apiVersion } = getProps(props);
       const requestMode: RequestMode = props?.requestMode ?? 'cors';
 
+      // No Content-Type here on purpose: this path carries no body, so the
+      // header describes nothing, and it is not on the CORS safelist. Sending
+      // it turned every cross-origin GET into a preflighted request, so the
+      // browser had to complete an OPTIONS round trip before it was allowed
+      // to ask for the data. Measured against mainnet, that preflight cost
+      // 107 to 229ms in front of the one request a list page waits on, and it
+      // is cached per URL, so paging paid it again on every page.
       const response = await fetch(getHost(route, query, service, apiVersion), {
         method: method.toString(),
-        headers: {
-          'Content-Type': 'application/json',
-        },
         mode: requestMode,
       });
 

--- a/src/services/requests/smartContracts/__tests__/names.test.ts
+++ b/src/services/requests/smartContracts/__tests__/names.test.ts
@@ -1,0 +1,78 @@
+import api from '@/services/api';
+import { smartContractNameCall } from '../names';
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+const mockedGet = api.get as jest.Mock;
+
+describe('smartContractNameCall', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('returns the name the chain carries for a contract', async () => {
+    mockedGet.mockResolvedValue({ data: { sc: { name: 'Bitcoin.me' } } });
+
+    await expect(smartContractNameCall('klv1contract')).resolves.toBe(
+      'Bitcoin.me',
+    );
+    expect(mockedGet).toHaveBeenCalledWith({
+      route: 'sc/klv1contract',
+      tries: 1,
+    });
+  });
+
+  it('asks once rather than letting api.get retry a decoration', async () => {
+    // Measured on mainnet: 3 of 9 contracts on one page answer 500 here, and
+    // the default of three tries spends nine requests on a name the row does
+    // not need.
+    mockedGet.mockResolvedValue({ error: 'boom' });
+
+    await smartContractNameCall('klv1contract');
+
+    expect(mockedGet.mock.calls[0][0].tries).toBe(1);
+  });
+
+  it('answers null for a contract that has no name', async () => {
+    // Roughly seven in eight contracts on chain are unnamed, so this is the
+    // ordinary case and not an error: the row shows its address instead.
+    mockedGet.mockResolvedValue({ data: { sc: { name: '' } } });
+
+    await expect(smartContractNameCall('klv1contract')).resolves.toBeNull();
+  });
+
+  it('answers null instead of throwing when the lookup fails', async () => {
+    // The name decorates a link that works without it, so a failure here must
+    // never reach the row, let alone a toast.
+    mockedGet.mockResolvedValue({ error: 'not found' });
+
+    await expect(smartContractNameCall('klv1contract')).resolves.toBeNull();
+  });
+
+  it('answers null when the request itself throws', async () => {
+    mockedGet.mockRejectedValue(new Error('network down'));
+
+    await expect(smartContractNameCall('klv1contract')).resolves.toBeNull();
+  });
+
+  it('asks nothing at all without an address', async () => {
+    await expect(smartContractNameCall('')).resolves.toBeNull();
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
+
+  it('escapes the address it puts in the route', async () => {
+    // buildUrlQuery interpolates raw values elsewhere in this codebase; the
+    // route segment is escaped here so a crafted address cannot reshape it.
+    mockedGet.mockResolvedValue({ data: { sc: { name: 'x' } } });
+
+    await smartContractNameCall('klv1abc/../list');
+
+    expect(mockedGet).toHaveBeenCalledWith({
+      route: 'sc/klv1abc%2F..%2Flist',
+      tries: 1,
+    });
+  });
+});

--- a/src/services/requests/smartContracts/names.ts
+++ b/src/services/requests/smartContracts/names.ts
@@ -1,0 +1,50 @@
+import api from '@/services/api';
+
+/**
+ * A contract's own name, for lists that would otherwise show nothing but a
+ * bech32 address.
+ *
+ * Only the single-contract endpoint carries the name: `sc/list` returns the
+ * deployer, the timestamps and the transaction count, but no name at all, so
+ * a list cannot be resolved in one request and each address is asked for on
+ * its own. That is cheaper than it sounds, because a page of transactions
+ * repeats the same few contracts: measured on mainnet, 300 consecutive
+ * contract calls came from 12 distinct addresses.
+ *
+ * Roughly one contract in eight is named, but the named ones are the busy
+ * ones: those same 300 calls were three quarters covered by three names.
+ */
+
+/** Names change only when a contract is redeployed under the same address. */
+export const CONTRACT_NAME_STALE_TIME = 60 * 60 * 1000;
+
+export const contractNameQueryKey = (address: string): [string, string] => [
+  'smartContractName',
+  address,
+];
+
+/**
+ * Answers null rather than throwing for a contract without a name or an
+ * address the node does not know. The name decorates a link that already
+ * works without it, so a failure here must never surface as an error.
+ */
+export const smartContractNameCall = async (
+  address: string,
+): Promise<string | null> => {
+  if (!address) return null;
+
+  try {
+    const response = await api.get({
+      route: `sc/${encodeURIComponent(address)}`,
+      // One attempt, against api.get's default of three with a 500ms gap.
+      // Measured on mainnet, 3 of 9 contracts on a single page answer 500
+      // here, and retrying each of them twice more spends nine requests over
+      // a second and a half on a decoration the row does not need.
+      tries: 1,
+    });
+    if (response?.error) return null;
+    return response?.data?.sc?.name || null;
+  } catch (error) {
+    return null;
+  }
+};

--- a/src/services/requests/transactions/__tests__/summary.test.ts
+++ b/src/services/requests/transactions/__tests__/summary.test.ts
@@ -1,0 +1,254 @@
+import api from '@/services/api';
+import {
+  summaryVariation,
+  totalGrowth,
+  transactionsSummaryCall,
+} from '../summary';
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+const mockedGet = api.get as jest.Mock;
+
+/** Newest bucket first, the order the API answers in. */
+const buckets = [
+  { doc_count: 8447, key: 1787664055000 },
+  { doc_count: 7124, key: 1787577655000 },
+  { doc_count: 6100, key: 1787491255000 },
+];
+
+/** doc_count per contract type index, for the type-filtered count calls. */
+const typeCounts: Record<number, number> = {
+  0: 5747, // Transfer
+  63: 1865, // Smart Contract
+  9: 592, // Claim
+  4: 228, // Freeze
+};
+
+const answerEach = (
+  answers: Partial<{ count: unknown; list: unknown; statistics: unknown }>,
+  perType: Record<number, number> = typeCounts,
+) => {
+  mockedGet.mockImplementation(
+    ({ route, query }: { route: string; query?: { type?: number } }) => {
+      if (route.startsWith('transaction/list/count')) {
+        // The breakdown asks the same route once per contract type.
+        if (query?.type !== undefined) {
+          const count = perType[query.type];
+          return Promise.resolve(
+            count === undefined
+              ? { data: { number_by_day: [] } }
+              : { data: { number_by_day: [{ doc_count: count, key: 1 }] } },
+          );
+        }
+        return Promise.resolve(
+          answers.count ?? { data: { number_by_day: [] } },
+        );
+      }
+      if (route === 'transaction/statistics') {
+        return Promise.resolve(answers.statistics ?? { data: {} });
+      }
+      return Promise.resolve(answers.list ?? { pagination: {} });
+    },
+  );
+};
+
+describe('transactionsSummaryCall', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reads the rolling windows, the total and the top asset', async () => {
+    answerEach({
+      count: { data: { number_by_day: buckets } },
+      list: { pagination: { totalRecords: 58_500_000 } },
+      statistics: {
+        data: { most_transacted: [{ key: 'KLV', doc_count: 43_564_012 }] },
+      },
+    });
+
+    const summary = await transactionsSummaryCall();
+
+    expect(summary.last24h).toBe(8447);
+    expect(summary.previous24h).toBe(7124);
+    expect(summary.totalTransactions).toBe(58_500_000);
+    expect(summary.mostTransactedAsset).toEqual({
+      assetId: 'KLV',
+      count: 43_564_012,
+    });
+  });
+
+  it('breaks the window down by contract type, largest first', async () => {
+    answerEach({ count: { data: { number_by_day: buckets } } });
+
+    const { breakdown } = await transactionsSummaryCall();
+
+    expect(breakdown).toEqual([
+      { name: 'Transfer', count: 5747 },
+      { name: 'Smart Contract', count: 1865 },
+      { name: 'Claim', count: 592 },
+      { name: 'Freeze', count: 228 },
+      // 8447 minus the named types: the chain's other 22 types together.
+      { name: 'Other', count: 15 },
+    ]);
+  });
+
+  it('leaves a type out when it did nothing in the window', async () => {
+    answerEach({ count: { data: { number_by_day: buckets } } }, { 0: 8447 });
+
+    const { breakdown } = await transactionsSummaryCall();
+
+    expect(breakdown).toEqual([{ name: 'Transfer', count: 8447 }]);
+  });
+
+  it('drops the remainder when the named types already fill the window', async () => {
+    // Separate requests can answer moments apart, so the parts can exceed
+    // the total; a negative remainder must not reach the bar.
+    answerEach(
+      { count: { data: { number_by_day: [{ doc_count: 100 }] } } },
+      {
+        0: 90,
+        63: 30,
+      },
+    );
+
+    const { breakdown } = await transactionsSummaryCall();
+
+    expect(breakdown.map(share => share.name)).toEqual([
+      'Transfer',
+      'Smart Contract',
+    ]);
+  });
+
+  it('answers undefined figures instead of throwing when every call fails', async () => {
+    answerEach({
+      count: { error: 'boom' },
+      list: { error: 'boom' },
+      statistics: { error: 'boom' },
+    });
+
+    const summary = await transactionsSummaryCall();
+
+    expect(summary).toEqual({
+      last24h: undefined,
+      previous24h: undefined,
+      breakdown: [],
+      totalTransactions: undefined,
+      mostTransactedAsset: undefined,
+    });
+  });
+
+  it('never turns one failed call into a zero next to a working one', async () => {
+    // The mixed case: a zero here would read as "this chain did nothing in
+    // the last 24 hours" while the total right beside it says 58 million.
+    answerEach({
+      count: { error: 'boom' },
+      list: { pagination: { totalRecords: 58_500_000 } },
+      statistics: {
+        data: { most_transacted: [{ key: 'KLV', doc_count: 43_564_012 }] },
+      },
+    });
+
+    const summary = await transactionsSummaryCall();
+
+    expect(summary.last24h).toBeUndefined();
+    expect(summary.previous24h).toBeUndefined();
+    expect(summary.breakdown).toEqual([]);
+    expect(summary.totalTransactions).toBe(58_500_000);
+    expect(summary.mostTransactedAsset?.assetId).toBe('KLV');
+  });
+
+  it('draws no bar when one type request failed, rather than calling it Other', async () => {
+    // The parts are separate requests. Reading a failed one as zero drops its
+    // segment and hands its share to the remainder, so a window that is two
+    // thirds transfers would draw as two thirds "Other" the one time that
+    // single request timed out.
+    mockedGet.mockImplementation(
+      ({ route, query }: { route: string; query?: { type?: number } }) => {
+        if (route.startsWith('transaction/list/count')) {
+          if (query?.type === 0) return Promise.resolve({ error: 'timeout' });
+          if (query?.type !== undefined) {
+            return Promise.resolve({
+              data: { number_by_day: [{ doc_count: typeCounts[query.type] }] },
+            });
+          }
+          return Promise.resolve({ data: { number_by_day: buckets } });
+        }
+        return Promise.resolve({ pagination: {} });
+      },
+    );
+
+    const { breakdown, last24h } = await transactionsSummaryCall();
+
+    // The tile above it still has its figure; only the composition is dropped.
+    expect(last24h).toBe(8447);
+    expect(breakdown).toEqual([]);
+  });
+
+  it('keeps a genuine zero apart from a failure', async () => {
+    answerEach({
+      count: { data: { number_by_day: [{ doc_count: 0, key: 1 }] } },
+      list: { pagination: { totalRecords: 0 } },
+    });
+
+    const summary = await transactionsSummaryCall();
+
+    expect(summary.last24h).toBe(0);
+    expect(summary.totalTransactions).toBe(0);
+  });
+
+  it('survives a statistics answer with no assets in it', async () => {
+    answerEach({ statistics: { data: { most_transacted: [] } } });
+
+    expect(
+      (await transactionsSummaryCall()).mostTransactedAsset,
+    ).toBeUndefined();
+  });
+});
+
+describe('summaryVariation', () => {
+  it('measures the change against the previous window', () => {
+    expect(summaryVariation({ last24h: 8447, previous24h: 7124 })).toBeCloseTo(
+      0.1857,
+      4,
+    );
+    expect(summaryVariation({ last24h: 500, previous24h: 1000 })).toBe(-0.5);
+  });
+
+  it('stays undefined without a baseline, rather than inventing +100%', () => {
+    expect(summaryVariation({ last24h: 8447, previous24h: 0 })).toBeUndefined();
+  });
+});
+
+describe('totalGrowth', () => {
+  it('measures the day against the total as it stood a day ago', () => {
+    // 100 new on a chain that held 900 before them is 11.1%, not 10%.
+    expect(totalGrowth({ last24h: 100, totalTransactions: 1000 })).toBeCloseTo(
+      100 / 900,
+      6,
+    );
+  });
+
+  it('handles the real scale without losing the figure to rounding', () => {
+    const growth = totalGrowth({
+      last24h: 8230,
+      totalTransactions: 58_550_000,
+    });
+    expect(growth).toBeCloseTo(8230 / (58_550_000 - 8230), 9);
+  });
+
+  it('stays undefined when either figure is missing', () => {
+    expect(totalGrowth({ last24h: 100 })).toBeUndefined();
+    expect(totalGrowth({ totalTransactions: 1000 })).toBeUndefined();
+  });
+
+  it('stays undefined when there is nothing to have grown from', () => {
+    // A chain whose whole history is this window has no yesterday to compare
+    // against, and dividing by it would print an infinity.
+    expect(
+      totalGrowth({ last24h: 1000, totalTransactions: 1000 }),
+    ).toBeUndefined();
+  });
+});

--- a/src/services/requests/transactions/summary.ts
+++ b/src/services/requests/transactions/summary.ts
@@ -1,0 +1,187 @@
+import api from '@/services/api';
+import { ContractsIndex } from '@/types/contracts';
+
+/**
+ * The figures above the transactions list.
+ *
+ * `transaction/list/count/<days>` answers one bucket per rolling 24 hour
+ * window ending now, not per calendar day: verified live by calling it twice
+ * seconds apart (the bucket keys move with the clock) and by matching its
+ * first bucket against a manual `startdate`/`enddate` query over the last 24
+ * hours (identical counts). So the first bucket is "the last 24 hours" and
+ * the second is the 24 hours before that.
+ */
+
+/** Two buckets: the last 24 hours and the 24 hours before it. */
+const SUMMARY_WINDOWS = 2;
+
+/**
+ * The contract types the composition bar names, in the order it draws them.
+ * The rest of the chain's 26 types share a computed "Other" segment: asking
+ * for each of them separately would be two dozen requests for slivers.
+ */
+export const BREAKDOWN_TYPES = [
+  ContractsIndex.Transfer,
+  ContractsIndex['Smart Contract'],
+  ContractsIndex.Claim,
+  ContractsIndex.Freeze,
+] as const;
+
+export interface ITransactionTypeShare {
+  /** Display name, or 'Other' for the computed remainder. */
+  name: string;
+  count: number;
+}
+
+/**
+ * Every figure is optional: a failed part answers undefined so the card can
+ * leave that tile out, rather than printing a zero the chain never had.
+ */
+export interface ITransactionsSummary {
+  last24h?: number;
+  previous24h?: number;
+  /** Last 24 hours by contract type, largest first, with the remainder. */
+  breakdown: ITransactionTypeShare[];
+  totalTransactions?: number;
+  mostTransactedAsset?: { assetId: string; count: number };
+}
+
+interface ICountBucket {
+  doc_count?: number;
+  key?: number;
+}
+
+const countsCall = async (
+  type?: number,
+): Promise<ICountBucket[] | undefined> => {
+  const response = await api.get({
+    route: `transaction/list/count/${SUMMARY_WINDOWS}`,
+    ...(type === undefined ? {} : { query: { type } }),
+  });
+  if (response?.error) return undefined;
+  return response?.data?.number_by_day ?? [];
+};
+
+const totalCall = async (): Promise<number | undefined> => {
+  const response = await api.get({
+    route: 'transaction/list',
+    query: { limit: 1, minify: true },
+  });
+  if (response?.error) return undefined;
+  return response?.pagination?.totalRecords;
+};
+
+const mostTransactedCall = async (): Promise<
+  ITransactionsSummary['mostTransactedAsset']
+> => {
+  const response = await api.get({
+    route: 'transaction/statistics',
+    query: { assetType: 'Fungible' },
+  });
+  if (response?.error) return undefined;
+  const top = response?.data?.most_transacted?.[0];
+  if (!top?.key) return undefined;
+  return { assetId: top.key, count: top.doc_count ?? 0 };
+};
+
+/**
+ * Builds the composition of the last 24 hours: one named share per listed
+ * contract type, largest first, plus whatever the chain's other types add
+ * up to. The remainder is the honest way to close the bar without asking
+ * for two dozen more counts, and it is clamped at zero because its parts
+ * are separate requests that can answer moments apart.
+ */
+const buildBreakdown = (
+  total: number | undefined,
+  typeCounts: Array<number | undefined>,
+): ITransactionTypeShare[] => {
+  if (total === undefined) return [];
+
+  // A part that did not answer is not a part that counted zero. Reading it as
+  // zero drops its segment and hands its share to the remainder, so a chain
+  // that is two thirds transfers would draw as two thirds "Other" the one
+  // time that single request timed out. No bar says less, but nothing false.
+  if (typeCounts.includes(undefined)) return [];
+
+  const named = BREAKDOWN_TYPES.map((type, index) => ({
+    name: String(ContractsIndex[type]),
+    count: typeCounts[index] ?? 0,
+  }))
+    .filter(share => share.count > 0)
+    .sort((a, b) => b.count - a.count);
+
+  const other = total - named.reduce((sum, share) => sum + share.count, 0);
+  return other > 0 ? [...named, { name: 'Other', count: other }] : named;
+};
+
+/**
+ * One request per figure, in parallel. Each part answers a neutral value on
+ * failure rather than throwing: the summary sits above the transactions
+ * table and must never be the reason a reader cannot see the list.
+ */
+export const transactionsSummaryCall =
+  async (): Promise<ITransactionsSummary> => {
+    const [buckets, totalTransactions, mostTransactedAsset, ...typeBuckets] =
+      await Promise.all([
+        countsCall(),
+        totalCall(),
+        mostTransactedCall(),
+        ...BREAKDOWN_TYPES.map(type => countsCall(type)),
+      ]);
+
+    const last24h = buckets?.[0]?.doc_count;
+
+    return {
+      last24h,
+      previous24h: buckets?.[1]?.doc_count,
+      breakdown: buildBreakdown(
+        last24h,
+        // The distinction survives only here: countsCall answers undefined
+        // for a request that failed and an empty list for one that succeeded
+        // with nothing to report. Read straight off the bucket both look the
+        // same, and a failure would be drawn as a genuine zero.
+        typeBuckets.map(typeBucket =>
+          typeBucket === undefined
+            ? undefined
+            : (typeBucket[0]?.doc_count ?? 0),
+        ),
+      ),
+      totalTransactions,
+      mostTransactedAsset,
+    };
+  };
+
+/**
+ * Change from the previous 24 hours, as a fraction. Undefined when there is
+ * no baseline to compare against: "+100%" against zero would be an invented
+ * figure.
+ */
+export const summaryVariation = (
+  summary: Pick<ITransactionsSummary, 'last24h' | 'previous24h'>,
+): number | undefined => {
+  if (!summary.previous24h || summary.last24h === undefined) return undefined;
+  return (summary.last24h - summary.previous24h) / summary.previous24h;
+};
+
+/**
+ * How much the chain's total grew in the last 24 hours, as a fraction of what
+ * it was a day ago. Measured against yesterday's total rather than today's,
+ * which is what "grew by" means and which the two differ on once the window
+ * is a real share of the whole.
+ *
+ * Undefined when there is nothing to grow from, so a chain with a day's worth
+ * of history and nothing before it shows no figure rather than an invented
+ * one.
+ */
+export const totalGrowth = (
+  summary: Pick<ITransactionsSummary, 'last24h' | 'totalTransactions'>,
+): number | undefined => {
+  const { last24h, totalTransactions } = summary;
+  if (last24h === undefined || totalTransactions === undefined)
+    return undefined;
+
+  const before = totalTransactions - last24h;
+  if (before <= 0) return undefined;
+
+  return last24h / before;
+};

--- a/src/styles/common/index.ts
+++ b/src/styles/common/index.ts
@@ -70,9 +70,19 @@ export const CardContainer = styled.section`
   }
 `;
 
+/**
+ * The surface a field, a select or a small card sits on.
+ *
+ * `white` in both themes: the token is the raised surface, not the colour
+ * white, so it reads #fff in the light theme and #151515 in the dark one.
+ * Dark used to reach for the table background here instead, which measured
+ * 1.03 against the page where the light theme's equivalent measures 1.10, and
+ * which was a third value agreeing with neither the page nor the cards. The
+ * light theme already puts fields and cards on one surface; this makes dark
+ * do the same.
+ */
 export const DefaultCardStyles = css`
-  background-color: ${props =>
-    props.theme.dark ? props.theme.table.background : props.theme.white};
+  background-color: ${props => props.theme.white};
 `;
 
 export const DefaultCardStyleWithBorder = css`

--- a/src/utils/formatFunctions/__tests__/formatDateWithSeconds.test.ts
+++ b/src/utils/formatFunctions/__tests__/formatDateWithSeconds.test.ts
@@ -1,0 +1,19 @@
+import { formatDateWithSeconds } from '..';
+
+describe('formatDateWithSeconds', () => {
+  it('renders the full UTC moment including seconds', () => {
+    // Date.UTC(2026, 7, 25, 13, 20, 55)
+    expect(formatDateWithSeconds(1787664055000)).toBe('08/25/26 13:20:55 UTC');
+  });
+
+  it('normalizes a seconds-precision chain timestamp the way formatDate does', () => {
+    expect(formatDateWithSeconds(1787664055)).toBe('08/25/26 13:20:55 UTC');
+  });
+
+  it('renders the epoch for a missing timestamp instead of looping forever', () => {
+    // 0 times 1000 stays 0: without the clamp the year never reaches 2000
+    // and the normalization loop hangs the tab.
+    expect(formatDateWithSeconds(0)).toBe('01/01/70 00:00:00 UTC');
+    expect(formatDateWithSeconds(Number.NaN)).toBe('01/01/70 00:00:00 UTC');
+  });
+});

--- a/src/utils/formatFunctions/index.ts
+++ b/src/utils/formatFunctions/index.ts
@@ -41,6 +41,39 @@ export const formatDate = (
     : `${dateString} UTC`;
 };
 
+/**
+ * The full moment down to the second, "MM/DD/YY HH:mm:ss UTC", for hover
+ * tooltips whose visible text only carries the elapsed time. Same timestamp
+ * normalization as formatDate: chain timestamps arrive in seconds or
+ * milliseconds depending on the endpoint.
+ */
+export const formatDateWithSeconds = (timestamp: number): string => {
+  // Multiplying 0 (or anything non-positive) never reaches the year 2000,
+  // so without this clamp the normalization below would loop forever; the
+  // epoch renders instead.
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    timestamp = 0;
+  }
+
+  while (timestamp > 0 && new Date(timestamp).getFullYear() < 2000) {
+    timestamp = timestamp * 10 ** 3;
+  }
+
+  while (new Date(timestamp).getFullYear() > 3000) {
+    timestamp = timestamp / 10 ** 3;
+  }
+
+  const date = new Date(timestamp || 0);
+  const year = String(date.getUTCFullYear()).slice(-2);
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+
+  return `${month}/${day}/${year} ${hours}:${minutes}:${seconds} UTC`;
+};
+
 const toFixedDown = (number: number, decimals: number) => {
   const factor = Math.pow(10, decimals);
   return Math.floor(number * factor) / factor;

--- a/src/utils/precisionFunctions/__tests__/knownPrecisions.test.ts
+++ b/src/utils/precisionFunctions/__tests__/knownPrecisions.test.ts
@@ -1,0 +1,68 @@
+import api from '@/services/api';
+import { KLV_PRECISION } from '../../globalVariables';
+import { getPrecision } from '../index';
+
+// The module reaches @/pages/transactions, whose import chain ends in an ESM
+// package Jest cannot transform. A factory mock never loads the real module.
+jest.mock('@/pages/transactions', () => ({
+  __esModule: true,
+  getAssetsAndCurrenciesList: jest.fn(() => []),
+  getTransactionPrecision: jest.fn(() => 8),
+}));
+
+jest.mock('@/services/api', () => ({
+  __esModule: true,
+  default: { post: jest.fn(), get: jest.fn() },
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { error: jest.fn() },
+}));
+
+const mockedPost = api.post as jest.Mock;
+
+/**
+ * The chain's own token is a constant, and resolving it used to cost a round
+ * trip that could not start until the row request had already finished. These
+ * lock in that a list denominated in KLV asks for nothing.
+ */
+describe('getPrecision and the chain constant', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('answers for KLV without asking the API', async () => {
+    await expect(getPrecision(['KLV'])).resolves.toEqual({
+      KLV: KLV_PRECISION,
+    });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('answers for a single KLV id without asking the API', async () => {
+    await expect(getPrecision('KLV')).resolves.toBe(KLV_PRECISION);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('still asks for the assets it does not know, and only those', async () => {
+    mockedPost.mockResolvedValue({
+      data: { precisions: { 'DVK-34ZH': 6 } },
+      error: '',
+    });
+
+    await expect(getPrecision(['KLV', 'DVK-34ZH'])).resolves.toEqual({
+      KLV: KLV_PRECISION,
+      'DVK-34ZH': 6,
+    });
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+    expect(mockedPost.mock.calls[0][0].body).toEqual({ assets: ['DVK-34ZH'] });
+  });
+
+  it('lets a stored precision override the constant', async () => {
+    // Whatever the chain later says wins, so this can never pin a wrong value.
+    localStorage.setItem('precisions', JSON.stringify({ KLV: 8 }));
+
+    await expect(getPrecision(['KLV'])).resolves.toEqual({ KLV: 8 });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/precisionFunctions/index.ts
+++ b/src/utils/precisionFunctions/index.ts
@@ -34,9 +34,17 @@ export async function getPrecision(
     ? assetIds.map(assetId => assetId.split('/')[0])
     : assetIds.split('/')[0];
 
-  const storedPrecisions: any = localStorage.getItem('precisions')
-    ? JSON.parse(localStorage.getItem('precisions') || '{}')
-    : {};
+  const storedPrecisions: any = {
+    // The chain's own token, known without asking. It is what a first-time
+    // reader's rows are almost always denominated in, and looking it up costs
+    // a round trip that cannot start until the row request has finished:
+    // measured at 340ms of pure waiting added to a cold transactions page.
+    // The rest of the file still treats it like any other cached precision.
+    KLV: KLV_PRECISION,
+    ...(localStorage.getItem('precisions')
+      ? JSON.parse(localStorage.getItem('precisions') || '{}')
+      : {}),
+  };
 
   if (
     typeof parsedAssetIds === 'object' &&

--- a/src/views/contract-validator/detail.ts
+++ b/src/views/contract-validator/detail.ts
@@ -26,8 +26,8 @@ export const Description = styled.p`
 export const Panel = styled.div`
   width: 100%;
   padding: 1rem;
-  background-color: ${({ theme }) =>
-    theme.dark ? theme.table.background : theme.white};
+  /* The raised surface, as everywhere else: #fff light, #151515 dark. */
+  background-color: ${({ theme }) => theme.white};
   border: 1px solid
     ${({ theme }) => (theme.dark ? theme.black20 : theme.black10)};
   border-radius: 24px;
@@ -318,8 +318,8 @@ export const ModalBox = styled.div`
   max-width: 440px;
   padding: 1.75rem;
   border-radius: 16px;
-  background-color: ${({ theme }) =>
-    theme.dark ? theme.table.background : theme.white};
+  /* The raised surface, as everywhere else: #fff light, #151515 dark. */
+  background-color: ${({ theme }) => theme.white};
   border: 1px solid
     ${({ theme }) => (theme.dark ? theme.black20 : theme.black10)};
   display: flex;


### PR DESCRIPTION
Re-lands #692, which was merged before it was ready and then reverted in #693. The tree here is identical to what was merged, verified against that commit. A second merge of the old branch would have been a no-op, because git still counts it as merged, so this branch reverts the revert instead.

The transactions table on all five routes (`/transactions`, `/asset/[asset]`, `/asset/[asset]/[nonce]`, `/block/[block]`, `/account/[account]`) moves from two stacked text lines per cell to one line with a column per fact, and the main transactions page gains a summary card above it.

## The row

`Hash · Type · Block · Age · From · → · To · [In/Out] · Amount · Fee`

- **Type** is a badge, with a second badge for the refinement the Misc column used to carry: Staking Claim, Mint, Market Buy. Hovering one badge marks every row of the same contract type.
- **Age** shows elapsed time; its tooltip carries the full moment down to the second.
- **The arrow has its own unheaded column**, so every address in From and To starts at the same x. It also carries the row's status: a green arrow for success, a red exclamation for a failure, an amber clock for pending. The glyph changes with the colour, so the state survives colour blindness, and the word itself rides in the tooltip and in visually hidden text.
- **To is filled where it used to be empty.** A smart-contract call shows the contract with a document mark and its invoked function in the tooltip; a claim or a withdrawal shows the account that was paid, read from the transfer receipt; a delegation shows the validator.
- **A contract shows its name** where the chain has one, and its address where it does not. Roughly one contract in eight is named, but the named ones are the busy ones: in 300 consecutive contract calls on mainnet, three names covered three quarters of the rows.
- **Misc is gone.** Its data moved into the type badge and those tooltips.

Every tooltip on the row goes through the shared Tooltip component, which gained an opt-in focusable mode so the status, the exact timestamp and the contract function are reachable by keyboard rather than by mouse only.

## In and Out

Shown only where the list is narrowed to one account, and answered by asking what the transaction did rather than who sent it.

An account that submitted a transaction made an outgoing move, with Claim and Withdraw as the exceptions, because those exist to pay their own submitter. For a transaction the account did not submit, the transfer receipts decide, and where none names the account the column stays empty rather than guessing.

Reading the receipts first looks more precise and is a trap: the staking contracts pay out accrued rewards in the same transaction, so a freeze carries a receipt paying its own sender. Measured against mainnet, that would have labelled 30 of 40 freezes, 16 of 40 unfreezes and 10 of 40 delegations as incoming on the account that submitted them. A failed inbound transfer would likewise have shown a green "In" beside an amount that never arrived.

## The summary card

Above the unscoped list only. Every filter this page offers narrows the rows below it while these figures stay chain-wide, so the card is drawn only when the query carries nothing but paging. `?account=` is one of those filters: the query is mapped onto `address` before the request goes out.

Three tiles (transactions in the last 24 hours with the change against the window before it, the chain total with its 24 hour growth, the leading fungible asset) and a composition bar breaking those 24 hours down by contract type. It reuses the assets registry strip's primitives and its exact shape, so both summary cards stand at the same height on their pages: 156px, measured.

The count endpoint answers rolling 24 hour windows rather than calendar days. Verified by calling it twice seconds apart, where the bucket boundaries move with the clock, and by matching its first bucket against a manual last-24-hours query. Each part of the request answers `undefined` on failure, so a struggling API leaves a tile out instead of printing a zero the chain never had, and can never keep the table itself from rendering.

## Speed

Three changes, each measured on a production build against mainnet with a cold cache, median of nine runs.

**A CORS preflight sat in front of every API call.** `services/api.ts` set a `Content-Type` header on GET requests. That header is not on the CORS safelist and describes nothing on a request with no body, but it turned every cross-origin GET into a preflighted one, so the browser had to complete an OPTIONS round trip before it was allowed to ask for the data. Measured at 107 to 229ms in front of the one request a list page waits on, and cached per URL, so paging paid it again on every page.

**A serial round trip before the rows could paint.** The row request waited for `transaction/list`, then started `assets/precisions`, which cannot begin until the first has answered. KLV is a chain constant and is now treated as known, which removes that hop for the lists it dominates: 340ms on a cold visit.

**Repeat navigation refetched a list it already had.** The shared table now holds a list for ten seconds, and only a list that actually has rows, so a failure is never cached as an empty result.

|  | before | after |
| --- | --- | --- |
| `/transactions` rows visible | 1231ms | 1056ms |
| `/assets` rows visible | 591ms | 339ms |
| `/assets` API time, summed | 2178ms | 1094ms |

`/transactions` still waits on one API call that varies between 230 and 1462ms. That is the origin, not the page.

## Dark mode

Six declarations across five files had no raised surface of their own in the dark theme. Four read `theme.background`, the page's own colour, and two read `theme.table.background`, which is barely lighter. A table, the cards that share its skin, the header bar, the filter fields and the dropdown panel that floats over them all measured 1.00 against the page, where the light theme measures 1.10. The dark theme already defines the raised surface under the name both themes use for it, so all six now read that and land at 1.11.

The borders were not the cause and are in fact more visible in the dark theme than in the light one. One had to move anyway: the header's own hairline read `theme.blue`, which is `#151515` in the dark theme, the exact colour the bar now fills with, so it would have vanished into it.

## What is deliberately not shown

- The most-transacted figure carries no period claim. Its window is not documented and differs per environment, and it is not on the same footing as the total beside it: unfiltered, that asset's figure exceeds the chain's own total, so an asset occurrence is not a transaction.
- No fee total, though not for want of an endpoint. `block/statistics-by-day` carries `totalTxFees` and `totalKappsFees`, but its buckets are UTC calendar days and the first one is the day so far, while the tiles beside it come from a window that rolls with the clock. Measured: the day bucket held 9,194 blocks against the 21,600 of a full day. A fee tile built on it would read low for most of the day next to figures that do not, so it needs either a rolling window from the proxy or a label that says which day it means.

## Untrusted text

A contract's name is set by whoever owns the account and reaches a cell that would otherwise hold an address, so it is treated as hostile: control and bidirectional characters are stripped, whitespace is collapsed, the length is capped and the box is fixed, and a name shaped like a wallet address is refused outright. Without that, a 200 character name widened the page to 3017px at a 1280px viewport, and a name carrying U+202E painted as a well known domain where the counterparty address belongs. The invoked function name, which comes from the sender's own data field, is bounded the same way.

## Accessibility

Status is never carried by colour alone. The badge palette gained the two derived colours this table needs, because the raw tokens fail AA at badge size: success measures 4.98:1 on its tint and 4.70:1 on a hovered row, danger 5.02:1 and 4.78:1. Badges use a minimum height rather than a fixed one, so they do not clip their own label at 200 percent browser text size. The empty placeholders are hidden from screen readers and paired with a spoken equivalent.

## Layout

Rows are 60px, matching the assets section. Addresses truncate to 16 characters, the same as everywhere else in the app: 12 was measured to leave an attacker two free characters to reproduce instead of six, and it did not buy the fit it was there for, since the table scrolled sideways at that width too. There is deliberately no scroll container around the table: one was measured to clip the hover dropdowns on the bottom rows, hide columns with no affordance, and silence the sticky header, while wide data still pushed the page sideways past its cap. Below the tablet breakpoint every row renders as its own card.

## Verification

- `tsc --noEmit` clean; Jest 711 tests across 61 suites; production build served and checked against its own BUILD_ID; Cypress 103 tests, 0 failing.
- Computed styles and rendered pixels measured in a real browser across the five routes, three widths and both themes, before and after.
- The two guarding e2e tests were proven to fail without the change, and the direction logic was mutation-tested: removing the receipt guard, the payout exception or the sender rule each fails a test that names the case.

## Beyond this table

Two changes reach further than the transactions list and are called out so a reviewer can weigh them separately. Dropping the GET `Content-Type` header touches every request the app makes, and the dark-mode surface fix touches the shared card, field and header styles, so it affects the home cards, forms and the contract-validator panels as well. Both were kept in one commit because splitting a one-line cause from the measurement that justifies it makes each half harder to review, but either reverts cleanly on its own.