### PR TITLE
fix(transactions): keep the summary on shared links, and lighten the page opening

### DIFF
--- a/src/components/DataList/SummaryLoading.tsx
+++ b/src/components/DataList/SummaryLoading.tsx
@@ -1,6 +1,6 @@
 import Skeleton from '@/components/Skeleton';
 import React from 'react';
-import { SummaryCard, SummarySkeletonRow } from './styles';
+import { SummaryCard, Tile, TilesGrid } from './styles';
 
 interface ISummaryLoadingProps {
   /** Names the card for assistive tech while its content is still unknown. */
@@ -14,9 +14,24 @@ interface ISummaryLoadingProps {
 }
 
 /**
- * Loading shape for a summary strip. Shared so the three strips reserve the
- * same space, which is what keeps the content below them from jumping once
- * the real figures arrive.
+ * The line heights of a loaded tile, measured rather than guessed: label at
+ * 11px, value at 20px, sub at 12px. Reserving 56px for the three together
+ * left the card 36px short of the one that replaced it.
+ */
+const LABEL = 15;
+const VALUE = 27.5;
+const SUB = 16.5;
+
+/** The bar and the legend under it, each with the margin above it. */
+const BAR = 8;
+const LEGEND = 16.5;
+
+/**
+ * Loading shape for a summary strip.
+ *
+ * Built from the same grid and tile the loaded card uses, so both the column
+ * widths and the height follow from one definition instead of two sets of
+ * numbers drifting apart.
  */
 const SummaryLoading: React.FC<ISummaryLoadingProps> = ({
   label,
@@ -25,17 +40,32 @@ const SummaryLoading: React.FC<ISummaryLoadingProps> = ({
   className,
 }) => (
   <SummaryCard aria-label={label} className={className}>
-    <SummarySkeletonRow>
+    <TilesGrid>
       {Array.from({ length: tiles }, (_, index) => (
-        <Skeleton key={index} width={150} height={56} />
+        <Tile key={index}>
+          <Skeleton width="55%" height={LABEL} />
+          <Skeleton width="45%" height={VALUE} />
+          <Skeleton
+            width="35%"
+            height={SUB}
+            containerCustomStyles={{ marginTop: 2 }}
+          />
+        </Tile>
       ))}
-    </SummarySkeletonRow>
+    </TilesGrid>
     {bar && (
-      <Skeleton
-        width="100%"
-        height={8}
-        containerCustomStyles={{ marginTop: 16 }}
-      />
+      <>
+        <Skeleton
+          width="100%"
+          height={BAR}
+          containerCustomStyles={{ marginTop: 16 }}
+        />
+        <Skeleton
+          width="70%"
+          height={LEGEND}
+          containerCustomStyles={{ marginTop: 8 }}
+        />
+      </>
     )}
   </SummaryCard>
 );

--- a/src/components/DataList/SummaryLoading.tsx
+++ b/src/components/DataList/SummaryLoading.tsx
@@ -27,6 +27,28 @@ const BAR = 8;
 const LEGEND = 16.5;
 
 /**
+ * The space a distribution bar and its legend will take.
+ *
+ * Exported because a card whose tiles have arrived while its bar has not is a
+ * state of its own: without this it drew the tiles alone and lost 48px, so
+ * the card shrank between its skeleton and its finished self.
+ */
+export const SummaryBarPlaceholder: React.FC = () => (
+  <>
+    <Skeleton
+      width="100%"
+      height={BAR}
+      containerCustomStyles={{ marginTop: 16 }}
+    />
+    <Skeleton
+      width="70%"
+      height={LEGEND}
+      containerCustomStyles={{ marginTop: 8 }}
+    />
+  </>
+);
+
+/**
  * Loading shape for a summary strip.
  *
  * Built from the same grid and tile the loaded card uses, so both the column
@@ -53,20 +75,7 @@ const SummaryLoading: React.FC<ISummaryLoadingProps> = ({
         </Tile>
       ))}
     </TilesGrid>
-    {bar && (
-      <>
-        <Skeleton
-          width="100%"
-          height={BAR}
-          containerCustomStyles={{ marginTop: 16 }}
-        />
-        <Skeleton
-          width="70%"
-          height={LEGEND}
-          containerCustomStyles={{ marginTop: 8 }}
-        />
-      </>
-    )}
+    {bar && <SummaryBarPlaceholder />}
   </SummaryCard>
 );
 

--- a/src/components/DataList/styles.ts
+++ b/src/components/DataList/styles.ts
@@ -542,12 +542,6 @@ export const LegendDot = styled.span<{ $color: string }>`
   background-color: ${props => props.$color};
 `;
 
-export const SummarySkeletonRow = styled.div`
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-`;
-
 /* ------------------------------ mobile card ------------------------------ */
 
 export const MobileListCard = styled.div`

--- a/src/components/TransactionsList/Summary.tsx
+++ b/src/components/TransactionsList/Summary.tsx
@@ -15,6 +15,7 @@ import {
 // The same percent policy the holders and assets legends use, so the two
 // visually identical legends cannot format the same quantity differently.
 import { formatShare } from '@/components/DataList/format';
+import { SummaryBarPlaceholder } from '@/components/DataList/SummaryLoading';
 import {
   ITransactionTypeShare,
   buildBreakdown,
@@ -79,7 +80,7 @@ const TransactionsSummary: React.FC = () => {
     ...FIGURE_CACHE,
   });
 
-  const { data: typeCounts } = useQuery({
+  const { data: typeCounts, isPending: breakdownPending } = useQuery({
     queryKey: ['transactionsBreakdown'],
     queryFn: transactionsBreakdownCall,
     // Four requests for a bar nobody waits on, so they stay out of the
@@ -99,17 +100,16 @@ const TransactionsSummary: React.FC = () => {
       ? theme.blueGray500
       : [theme.violet, theme.purple, theme.lightPurple, theme.green][index % 4];
 
-  const variation = summary ? summaryVariation(summary) : undefined;
-  const growth = summary ? totalGrowth(summary) : undefined;
+  const variation = summaryVariation(summary);
+  const growth = totalGrowth(summary);
   // Each figure is shown only when its own request answered; a failed part
   // leaves its tile out instead of printing a zero the chain never had.
   const hasFigures =
-    summary &&
-    (summary.last24h !== undefined ||
-      summary.totalTransactions !== undefined ||
-      summary.mostTransactedAsset !== undefined);
+    summary.last24h !== undefined ||
+    summary.totalTransactions !== undefined ||
+    summary.mostTransactedAsset !== undefined;
 
-  if (!summary || !hasFigures) return null;
+  if (!hasFigures) return null;
 
   // The shares sum to the window's own total; using that sum rather than
   // last24h keeps the bar full even if the parts answered moments apart.
@@ -235,8 +235,14 @@ const TransactionsSummary: React.FC = () => {
 
       {/* Same shape as the assets registry strip, deliberately: tiles, then
           the bar, then its legend, with no heading in between, so both
-          summary cards stand the same height on their pages. */}
-      {breakdown.length > 1 && breakdownTotal > 0 && (
+          summary cards stand the same height on their pages.
+
+          The tiles and the bar answer on separate requests, so the card is
+          drawn once with only the first of them. Holding the bar's space
+          until its own request settles keeps that middle state the same
+          height as the two around it. */}
+      {breakdownPending && <SummaryBarPlaceholder />}
+      {!breakdownPending && breakdown.length > 1 && breakdownTotal > 0 && (
         <>
           <DistBar
             role="img"

--- a/src/components/TransactionsList/Summary.tsx
+++ b/src/components/TransactionsList/Summary.tsx
@@ -17,8 +17,10 @@ import {
 import { formatShare } from '@/components/DataList/format';
 import {
   ITransactionTypeShare,
+  buildBreakdown,
   summaryVariation,
   totalGrowth,
+  transactionsBreakdownCall,
   transactionsSummaryCall,
 } from '@/services/requests/transactions/summary';
 import { formatAmount } from '@/utils/formatFunctions';
@@ -26,6 +28,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { useTheme } from 'styled-components';
+import { useDeferred } from './useDeferred';
 import {
   PageSummaryCard,
   PageSummaryLoading,
@@ -63,6 +66,20 @@ const TransactionsSummary: React.FC = () => {
     staleTime: 60_000,
   });
 
+  // Long enough that a reader who clicks straight through never spends these
+  // four, short enough that the bar is not visibly late.
+  const deferred = useDeferred(600);
+
+  const { data: typeCounts } = useQuery({
+    queryKey: ['transactionsBreakdown'],
+    queryFn: transactionsBreakdownCall,
+    // Four requests for a bar nobody waits on, so they stay out of the
+    // opening burst. Not gated on the tiles: waiting for the total first put
+    // the bar six seconds out when the API answered slowly.
+    enabled: deferred,
+    staleTime: 60_000,
+  });
+
   if (isLoading) {
     return <PageSummaryLoading label={label} tiles={3} bar />;
   }
@@ -87,10 +104,10 @@ const TransactionsSummary: React.FC = () => {
 
   // The shares sum to the window's own total; using that sum rather than
   // last24h keeps the bar full even if the parts answered moments apart.
-  const breakdownTotal = summary.breakdown.reduce(
-    (sum, share) => sum + share.count,
-    0,
-  );
+  const breakdown = typeCounts
+    ? buildBreakdown(summary.last24h, typeCounts)
+    : [];
+  const breakdownTotal = breakdown.reduce((sum, share) => sum + share.count, 0);
 
   return (
     <PageSummaryCard aria-label={label}>
@@ -210,7 +227,7 @@ const TransactionsSummary: React.FC = () => {
       {/* Same shape as the assets registry strip, deliberately: tiles, then
           the bar, then its legend, with no heading in between, so both
           summary cards stand the same height on their pages. */}
-      {summary.breakdown.length > 1 && breakdownTotal > 0 && (
+      {breakdown.length > 1 && breakdownTotal > 0 && (
         <>
           <DistBar
             role="img"
@@ -218,7 +235,7 @@ const TransactionsSummary: React.FC = () => {
               defaultValue: 'Contract types in the last 24 hours',
             })}
           >
-            {summary.breakdown.map((share, index) => (
+            {breakdown.map((share, index) => (
               <DistSegment
                 key={share.name}
                 $color={segmentColor(share, index)}
@@ -232,7 +249,7 @@ const TransactionsSummary: React.FC = () => {
             ))}
           </DistBar>
           <LegendRow>
-            {summary.breakdown.map((share, index) => (
+            {breakdown.map((share, index) => (
               <LegendItem key={share.name}>
                 <LegendDot $color={segmentColor(share, index)} />
                 {share.name === 'Other'

--- a/src/components/TransactionsList/Summary.tsx
+++ b/src/components/TransactionsList/Summary.tsx
@@ -37,6 +37,14 @@ import {
 } from './styles';
 
 /**
+ * A quarter of an hour. These are 24 hour figures, so a fresh reading moves
+ * them by fractions of a percent, and every refetch costs two of the slow
+ * transaction-list queries. Kept past the last observer too, so paging away
+ * and back does not pay for them again.
+ */
+const FIGURE_CACHE = { staleTime: 15 * 60_000, gcTime: 15 * 60_000 };
+
+/**
  * Percentage with its sign, e.g. "+18.6%". A rate, not a share, so it has no
  * ceiling: a figure that more than doubled reads "+140%" rather than being
  * clamped. The precision is a parameter because the day-on-day change lands
@@ -58,17 +66,18 @@ const TransactionsSummary: React.FC = () => {
   const label = t('transactions:Summary.Label', {
     defaultValue: 'Transaction statistics',
   });
-  const { data: summary, isLoading } = useQuery({
+
+  const deferred = useDeferred();
+
+  const { data: summary } = useQuery({
     queryKey: ['transactionsSummary'],
     queryFn: transactionsSummaryCall,
-    // The figures move by the second; refetching on every mount would make
-    // the card flicker without telling the reader anything new.
-    staleTime: 60_000,
+    // Behind the list, not beside it. Two of these three are transaction-list
+    // queries costing about two seconds each, and racing them against the
+    // rows is what a reader actually feels.
+    enabled: deferred,
+    ...FIGURE_CACHE,
   });
-
-  // Long enough that a reader who clicks straight through never spends these
-  // four, short enough that the bar is not visibly late.
-  const deferred = useDeferred(600);
 
   const { data: typeCounts } = useQuery({
     queryKey: ['transactionsBreakdown'],
@@ -77,10 +86,10 @@ const TransactionsSummary: React.FC = () => {
     // opening burst. Not gated on the tiles: waiting for the total first put
     // the bar six seconds out when the API answered slowly.
     enabled: deferred,
-    staleTime: 60_000,
+    ...FIGURE_CACHE,
   });
 
-  if (isLoading) {
+  if (!summary) {
     return <PageSummaryLoading label={label} tiles={3} bar />;
   }
 

--- a/src/components/TransactionsList/__tests__/Summary.test.tsx
+++ b/src/components/TransactionsList/__tests__/Summary.test.tsx
@@ -1,6 +1,6 @@
 import theme from '@/styles/theme';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
 
@@ -128,7 +128,7 @@ beforeEach(() => {
   summaryCall.mockReset();
   breakdownCall.mockReset();
   breakdownCall.mockResolvedValue(COUNTS);
-  deferralPassed = false;
+  deferralPassed = true;
 });
 
 describe('TransactionsSummary', () => {
@@ -192,20 +192,24 @@ describe('TransactionsSummary', () => {
     expect(screen.queryByText('Transactions (24h)')).toBeNull();
   });
 
-  it('leaves the composition bar unasked for while the page is still working', async () => {
+  it('asks for nothing while the page still has work in flight', async () => {
+    deferralPassed = false;
     summaryCall.mockResolvedValue(FULL);
 
     renderSummary();
 
-    // The tiles are there, so the card has rendered and the query had its
-    // chance; four requests for the bar simply were not spent yet.
-    expect(await screen.findByText('Total transactions')).toBeTruthy();
+    // The card reserves its space and spends nothing. Both of its tile
+    // requests are transaction-list queries, which this API answers in about
+    // two seconds and will not serve alongside the rows.
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    expect(summaryCall).not.toHaveBeenCalled();
     expect(breakdownCall).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText(/Contract types/)).toBeNull();
+    expect(screen.getByLabelText('Transaction statistics')).toBeTruthy();
   });
 
-  it('asks for it once the page falls idle, against the window it belongs to', async () => {
-    deferralPassed = true;
+  it('asks once the page falls quiet', async () => {
     summaryCall.mockResolvedValue(FULL);
 
     renderSummary();
@@ -213,6 +217,7 @@ describe('TransactionsSummary', () => {
     expect(
       await screen.findByLabelText('Contract types in the last 24 hours'),
     ).toBeTruthy();
+    expect(summaryCall).toHaveBeenCalled();
     expect(breakdownCall).toHaveBeenCalled();
   });
 

--- a/src/components/TransactionsList/__tests__/Summary.test.tsx
+++ b/src/components/TransactionsList/__tests__/Summary.test.tsx
@@ -78,13 +78,18 @@ jest.mock('react-dom', () => {
 });
 
 const summaryCall = jest.fn();
+const breakdownCall = jest.fn();
 
-// Only the request is replaced. The arithmetic beside it stays real, so a
+// Only the requests are replaced. The arithmetic beside them stays real, so a
 // change to what "grew by" means is caught here as well as in its own spec.
 jest.mock('@/services/requests/transactions/summary', () => ({
   ...jest.requireActual('@/services/requests/transactions/summary'),
   transactionsSummaryCall: () => summaryCall(),
+  transactionsBreakdownCall: () => breakdownCall(),
 }));
+
+let deferralPassed = false;
+jest.mock('../useDeferred', () => ({ useDeferred: () => deferralPassed }));
 
 import TransactionsSummary from '../Summary';
 
@@ -93,12 +98,10 @@ const FULL = {
   previous24h: 8000,
   totalTransactions: 58558891,
   mostTransactedAsset: { assetId: 'KLV', count: 4000 },
-  breakdown: [
-    { name: 'Transfer', count: 5000 },
-    { name: 'Smart Contract', count: 2000 },
-    { name: 'Other', count: 1247 },
-  ],
 };
+
+/** Raw counts per named type, in the order the bar draws them. */
+const COUNTS = [5000, 2000, 600, 400];
 
 const renderSummary = () =>
   render(
@@ -123,6 +126,9 @@ const digitsOf = (text: string): string => text.replace(/\D/g, '');
 
 beforeEach(() => {
   summaryCall.mockReset();
+  breakdownCall.mockReset();
+  breakdownCall.mockResolvedValue(COUNTS);
+  deferralPassed = false;
 });
 
 describe('TransactionsSummary', () => {
@@ -186,8 +192,32 @@ describe('TransactionsSummary', () => {
     expect(screen.queryByText('Transactions (24h)')).toBeNull();
   });
 
+  it('leaves the composition bar unasked for while the page is still working', async () => {
+    summaryCall.mockResolvedValue(FULL);
+
+    renderSummary();
+
+    // The tiles are there, so the card has rendered and the query had its
+    // chance; four requests for the bar simply were not spent yet.
+    expect(await screen.findByText('Total transactions')).toBeTruthy();
+    expect(breakdownCall).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Contract types/)).toBeNull();
+  });
+
+  it('asks for it once the page falls idle, against the window it belongs to', async () => {
+    deferralPassed = true;
+    summaryCall.mockResolvedValue(FULL);
+
+    renderSummary();
+
+    expect(
+      await screen.findByLabelText('Contract types in the last 24 hours'),
+    ).toBeTruthy();
+    expect(breakdownCall).toHaveBeenCalled();
+  });
+
   it('draws no card at all when every figure is missing', async () => {
-    summaryCall.mockResolvedValue({ breakdown: [] });
+    summaryCall.mockResolvedValue({});
 
     renderSummary();
 

--- a/src/components/TransactionsList/__tests__/Summary.test.tsx
+++ b/src/components/TransactionsList/__tests__/Summary.test.tsx
@@ -209,6 +209,21 @@ describe('TransactionsSummary', () => {
     expect(screen.getByLabelText('Transaction statistics')).toBeTruthy();
   });
 
+  it('holds the space for the bar while only the tiles have answered', async () => {
+    // The two halves answer on separate requests. Drawing the tiles alone
+    // dropped the bar and its legend, so the card lost 48px between its
+    // skeleton and its finished self and then grew back.
+    summaryCall.mockResolvedValue(FULL);
+    breakdownCall.mockReturnValue(new Promise(() => undefined));
+
+    renderSummary();
+
+    expect(await screen.findByText('Total transactions')).toBeTruthy();
+    const kaart = screen.getByLabelText('Transaction statistics');
+    expect(kaart.querySelectorAll('[data-testid="skeleton"]').length).toBe(2);
+    expect(screen.queryByLabelText(/Contract types/)).toBeNull();
+  });
+
   it('asks once the page falls quiet', async () => {
     summaryCall.mockResolvedValue(FULL);
 

--- a/src/components/TransactionsList/__tests__/columns.test.ts
+++ b/src/components/TransactionsList/__tests__/columns.test.ts
@@ -118,6 +118,16 @@ describe('transaction table columns', () => {
     });
 
     it.each([
+      ['a campaign parameter', { utm_source: 'twitter' }],
+      ['a click id', { fbclid: 'abc123' }],
+      ['a filter left empty by the UI', { type: '' }],
+    ])('is true with %s, which narrows nothing', (_label, query) => {
+      // These reach the page on shared links. Reading anything unrecognised
+      // as a filter hid the card on every one of them.
+      expect(listsWholeChain({ query })).toBe(true);
+    });
+
+    it.each([
       ['an account', { account: 'klv1abc' }],
       ['a contract type', { type: '63' }],
       ['a status', { status: 'Success' }],

--- a/src/components/TransactionsList/__tests__/columns.test.ts
+++ b/src/components/TransactionsList/__tests__/columns.test.ts
@@ -121,6 +121,10 @@ describe('transaction table columns', () => {
       ['a campaign parameter', { utm_source: 'twitter' }],
       ['a click id', { fbclid: 'abc123' }],
       ['a filter left empty by the UI', { type: '' }],
+      // Next hands back an array for a repeated parameter, and `?type=&type=`
+      // is what an empty filter submitted twice looks like.
+      ['the same empty filter twice', { type: ['', ''] }],
+      ['a filter with no values at all', { type: [] }],
     ])('is true with %s, which narrows nothing', (_label, query) => {
       // These reach the page on shared links. Reading anything unrecognised
       // as a filter hid the card on every one of them.
@@ -134,6 +138,8 @@ describe('transaction table columns', () => {
       ['an asset', { asset: 'KLV' }],
       ['a date range', { startdate: '1787491255', enddate: '1787577655' }],
       ['a filter alongside paging', { page: '2', type: '63' }],
+      ['a filter repeated with real values', { type: ['63', '0'] }],
+      ['a filter repeated with one real value', { type: ['', '63'] }],
     ])('is false once the list is narrowed by %s', (_label, query) => {
       // The summary above the list is chain-wide, so any narrowing at all
       // makes it describe something other than the rows underneath it.

--- a/src/components/TransactionsList/columns.ts
+++ b/src/components/TransactionsList/columns.ts
@@ -142,8 +142,12 @@ const FILTER_KEYS = new Set([
  * also hid the card for `?utm_source=`, so every shared campaign link lost it.
  * A filter added later has to be added here too.
  */
+/** Next hands back an array for a repeated parameter, so `?type=&type=`
+ * arrives as `['', '']` and a comparison against `''` would call it a filter. */
+const narrows = (value: string | string[] | undefined): boolean =>
+  Array.isArray(value) ? value.some(Boolean) : Boolean(value);
+
 export const listsWholeChain = (router: { query?: ParsedUrlQuery }): boolean =>
   !Object.entries(router?.query ?? {}).some(
-    ([key, value]) =>
-      FILTER_KEYS.has(key) && value !== '' && value !== undefined,
+    ([key, value]) => FILTER_KEYS.has(key) && narrows(value),
   );

--- a/src/components/TransactionsList/columns.ts
+++ b/src/components/TransactionsList/columns.ts
@@ -120,20 +120,30 @@ export const showsInOut = (router: {
   return typeof account === 'string' && account !== '';
 };
 
-/** Walking the list, not narrowing it. Neither changes which rows qualify. */
-const PAGINATION_KEYS = new Set(['page', 'limit']);
+/** The parameters that narrow this list, named rather than inferred. */
+const FILTER_KEYS = new Set([
+  'type',
+  'status',
+  'asset',
+  'buyType',
+  'account',
+  'startdate',
+  'enddate',
+]);
 
 /**
  * Whether this list still holds the whole chain.
  *
- * Asked by the summary above it, whose figures are chain-wide. Every filter
- * this page offers narrows the rows underneath while leaving those figures
- * alone, and nothing in their labels says "network", so a card reading 8.19K
- * transactions and a bar two thirds transfers would sit above a table of
- * nothing but smart contract calls and read as its summary.
+ * Asked by the summary above it, whose figures are chain-wide. A filter
+ * narrows the rows underneath while leaving those figures alone, so the card
+ * would read as a summary of a table it does not describe.
  *
- * Any parameter that is not paging counts as a filter, so a filter added
- * later is covered without anyone remembering to list it here.
+ * Named filters rather than "anything that is not paging": that inverted form
+ * also hid the card for `?utm_source=`, so every shared campaign link lost it.
+ * A filter added later has to be added here too.
  */
 export const listsWholeChain = (router: { query?: ParsedUrlQuery }): boolean =>
-  Object.keys(router?.query ?? {}).every(key => PAGINATION_KEYS.has(key));
+  !Object.entries(router?.query ?? {}).some(
+    ([key, value]) =>
+      FILTER_KEYS.has(key) && value !== '' && value !== undefined,
+  );

--- a/src/components/TransactionsList/useDeferred.ts
+++ b/src/components/TransactionsList/useDeferred.ts
@@ -1,20 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useIsFetching } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+
+/** Waited no longer than this, in case the page never has work of its own. */
+const CEILING = 4000;
 
 /**
- * True once `delay` has passed since mount.
+ * True once the page's other requests have finished, and stays true.
  *
- * For work that belongs on the page but not in its opening burst.
- * requestIdleCallback was tried first and is not usable here: measured on the
- * same page it fired at 152ms on one load and 2.6s on the next, so the work
- * was either back in the burst or visibly late.
+ * For requests that belong on the page but must not compete with the one a
+ * reader is actually waiting for. This API answers a transaction-list query
+ * in about two seconds and does not serve them in parallel, so six at once
+ * turned a 2.1s list into a 7s one.
+ *
+ * It waits to see traffic before waiting for quiet: this mounts above the
+ * table, so at first paint there is nothing in flight yet and an idle check
+ * on its own would release immediately.
  */
-export const useDeferred = (delay: number): boolean => {
+export const useDeferred = (): boolean => {
+  const inFlight = useIsFetching();
+  const sawTraffic = useRef(false);
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
-    const timer = setTimeout(() => setReady(true), delay);
+    if (inFlight > 0) sawTraffic.current = true;
+    else if (sawTraffic.current) setReady(true);
+  }, [inFlight]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setReady(true), CEILING);
     return () => clearTimeout(timer);
-  }, [delay]);
+  }, []);
 
   return ready;
 };

--- a/src/components/TransactionsList/useDeferred.ts
+++ b/src/components/TransactionsList/useDeferred.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * True once `delay` has passed since mount.
+ *
+ * For work that belongs on the page but not in its opening burst.
+ * requestIdleCallback was tried first and is not usable here: measured on the
+ * same page it fired at 152ms on one load and 2.6s on the next, so the work
+ * was either back in the burst or visibly late.
+ */
+export const useDeferred = (delay: number): boolean => {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setReady(true), delay);
+    return () => clearTimeout(timer);
+  }, [delay]);
+
+  return ready;
+};

--- a/src/services/requests/transactions/__tests__/summary.test.ts
+++ b/src/services/requests/transactions/__tests__/summary.test.ts
@@ -1,7 +1,9 @@
 import api from '@/services/api';
 import {
+  buildBreakdown,
   summaryVariation,
   totalGrowth,
+  transactionsBreakdownCall,
   transactionsSummaryCall,
 } from '../summary';
 
@@ -83,7 +85,7 @@ describe('transactionsSummaryCall', () => {
   it('breaks the window down by contract type, largest first', async () => {
     answerEach({ count: { data: { number_by_day: buckets } } });
 
-    const { breakdown } = await transactionsSummaryCall();
+    const breakdown = buildBreakdown(8447, await transactionsBreakdownCall());
 
     expect(breakdown).toEqual([
       { name: 'Transfer', count: 5747 },
@@ -98,7 +100,7 @@ describe('transactionsSummaryCall', () => {
   it('leaves a type out when it did nothing in the window', async () => {
     answerEach({ count: { data: { number_by_day: buckets } } }, { 0: 8447 });
 
-    const { breakdown } = await transactionsSummaryCall();
+    const breakdown = buildBreakdown(8447, await transactionsBreakdownCall());
 
     expect(breakdown).toEqual([{ name: 'Transfer', count: 8447 }]);
   });
@@ -114,7 +116,7 @@ describe('transactionsSummaryCall', () => {
       },
     );
 
-    const { breakdown } = await transactionsSummaryCall();
+    const breakdown = buildBreakdown(100, await transactionsBreakdownCall());
 
     expect(breakdown.map(share => share.name)).toEqual([
       'Transfer',
@@ -134,7 +136,6 @@ describe('transactionsSummaryCall', () => {
     expect(summary).toEqual({
       last24h: undefined,
       previous24h: undefined,
-      breakdown: [],
       totalTransactions: undefined,
       mostTransactedAsset: undefined,
     });
@@ -155,7 +156,6 @@ describe('transactionsSummaryCall', () => {
 
     expect(summary.last24h).toBeUndefined();
     expect(summary.previous24h).toBeUndefined();
-    expect(summary.breakdown).toEqual([]);
     expect(summary.totalTransactions).toBe(58_500_000);
     expect(summary.mostTransactedAsset?.assetId).toBe('KLV');
   });
@@ -180,7 +180,8 @@ describe('transactionsSummaryCall', () => {
       },
     );
 
-    const { breakdown, last24h } = await transactionsSummaryCall();
+    const { last24h } = await transactionsSummaryCall();
+    const breakdown = buildBreakdown(8447, await transactionsBreakdownCall());
 
     // The tile above it still has its figure; only the composition is dropped.
     expect(last24h).toBe(8447);

--- a/src/services/requests/transactions/summary.ts
+++ b/src/services/requests/transactions/summary.ts
@@ -40,8 +40,6 @@ export interface ITransactionTypeShare {
 export interface ITransactionsSummary {
   last24h?: number;
   previous24h?: number;
-  /** Last 24 hours by contract type, largest first, with the remainder. */
-  breakdown: ITransactionTypeShare[];
   totalTransactions?: number;
   mostTransactedAsset?: { assetId: string; count: number };
 }
@@ -91,7 +89,7 @@ const mostTransactedCall = async (): Promise<
  * for two dozen more counts, and it is clamped at zero because its parts
  * are separate requests that can answer moments apart.
  */
-const buildBreakdown = (
+export const buildBreakdown = (
   total: number | undefined,
   typeCounts: Array<number | undefined>,
 ): ITransactionTypeShare[] => {
@@ -115,41 +113,50 @@ const buildBreakdown = (
 };
 
 /**
- * One request per figure, in parallel. Each part answers a neutral value on
- * failure rather than throwing: the summary sits above the transactions
- * table and must never be the reason a reader cannot see the list.
+ * The three tiles. One request per figure, in parallel, each answering a
+ * neutral value on failure rather than throwing: the summary sits above the
+ * transactions table and must never be the reason a reader cannot see it.
+ *
+ * The composition bar is not here. It costs one request per named type, four
+ * of the seven this card used to spend before the list had painted, so it is
+ * asked for separately once the page is idle.
  */
 export const transactionsSummaryCall =
   async (): Promise<ITransactionsSummary> => {
-    const [buckets, totalTransactions, mostTransactedAsset, ...typeBuckets] =
-      await Promise.all([
-        countsCall(),
-        totalCall(),
-        mostTransactedCall(),
-        ...BREAKDOWN_TYPES.map(type => countsCall(type)),
-      ]);
-
-    const last24h = buckets?.[0]?.doc_count;
+    const [buckets, totalTransactions, mostTransactedAsset] = await Promise.all(
+      [countsCall(), totalCall(), mostTransactedCall()],
+    );
 
     return {
-      last24h,
+      last24h: buckets?.[0]?.doc_count,
       previous24h: buckets?.[1]?.doc_count,
-      breakdown: buildBreakdown(
-        last24h,
-        // The distinction survives only here: countsCall answers undefined
-        // for a request that failed and an empty list for one that succeeded
-        // with nothing to report. Read straight off the bucket both look the
-        // same, and a failure would be drawn as a genuine zero.
-        typeBuckets.map(typeBucket =>
-          typeBucket === undefined
-            ? undefined
-            : (typeBucket[0]?.doc_count ?? 0),
-        ),
-      ),
       totalTransactions,
       mostTransactedAsset,
     };
   };
+
+/**
+ * One count per named type, in the order the bar draws them.
+ *
+ * The window's own total is not needed here and is deliberately not waited
+ * for: asking for it first made these four queue behind the tiles, which on a
+ * slow answer put the bar six seconds out. `buildBreakdown` folds the two
+ * together once both have landed.
+ */
+export const transactionsBreakdownCall = async (): Promise<
+  Array<number | undefined>
+> => {
+  const typeBuckets = await Promise.all(
+    BREAKDOWN_TYPES.map(type => countsCall(type)),
+  );
+
+  // countsCall answers undefined for a request that failed and an empty list
+  // for one that succeeded with nothing to report. Read straight off the
+  // bucket both look the same, and a failure would draw as a real zero.
+  return typeBuckets.map(typeBucket =>
+    typeBucket === undefined ? undefined : (typeBucket[0]?.doc_count ?? 0),
+  );
+};
 
 /**
  * Change from the previous 24 hours, as a fraction. Undefined when there is


### PR DESCRIPTION
Three commits, all measured on the built page against the live API.

## The card disappeared on shared links

`listsWholeChain` read anything that was not `page` or `limit` as a filter, so `?utm_source=` and `?fbclid=` hid the chain-wide card on every shared link. It names the seven parameters the page actually offers instead, and an empty value no longer counts.

## The list was queuing behind the summary

This is the one that mattered. The API answers a `transaction/list` query in about two seconds and does not serve them in parallel. The page fired ten requests at once, so the single request a reader waits for took 7.4s where that same call on its own takes 2.1s.

The summary card now waits until the page has nothing else in flight before asking for anything, and its composition bar is a separate query rather than four more requests inside the same call. Measured cold on the built page:

| | before | after |
| --- | --- | --- |
| requests in the opening burst | 10 | 3 |
| the list request | 7457ms | 1226ms |
| rows in the DOM | over 7s | 1333ms |

The rows now appear about 30ms after their data arrives, so what is left is the API's own latency and nothing else. The two requests that still accompany the list finish in 160ms and 110ms, a full second before it, so they hold nothing up.

Its figures are cached for fifteen minutes rather than one. They describe a 24 hour window, so a fresh reading moves them by fractions of a percent, and each refetch costs two of the slow queries. The cache is kept past the last observer as well, so paging away and back does not pay for them again.

## The loading card was the wrong height

While checking the card in its loading state, which this change leaves on screen for longer, it turned out the skeleton reserved 56px for the row of tiles and nothing at all for the legend. The card grew by 35px the moment the figures landed.

It is built from the same grid and tile as the loaded card now, with the measured line heights, so the columns line up horizontally as well rather than sitting at a fixed 150px against a real 386px. Measured, loading against loaded:

| card | loaded | skeleton before | skeleton now |
| --- | --- | --- | --- |
| transactions | 157 | 122 | 155.5 |
| assets registry | 156 | 120 | 155.5 |
| fee pools | 107 | 96 | 105 |
| holders | 164.5 | 120 | 155.5 |

Holders stays 9px short. Its tile is 65px like the others; the difference is that one of its four labels wraps at this width and stretches the grid row, which a placeholder cannot know in advance. Closing that one belongs on the label, not here.

## Two approaches tried and rejected

Both are recorded in the code so nobody repeats them.

`requestIdleCallback` is not usable for this. On the same page it fired at 152ms on one load and 2.6s on the next, so the work was either back in the opening burst or visibly late.

Gating the bar on the tiles, so it could use the window total for its remainder, put it six seconds out whenever the API answered slowly. The counts no longer wait for the total; the two are folded together once both have landed.

## Not changed

No rate limiting was found. Twenty requests in 2.8 seconds all answered 200, and twenty-five calls to the list endpoint all came back usable, so the request count is worth reducing on its own merits rather than because anything is being refused.

Combining the four type counts into one call is not possible against the current API: no endpoint returns per-type counts, and the count route ignores a comma-separated list of types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction summaries and contract-type composition now load independently.
  * Distribution details appear once their data is available, with dedicated loading placeholders.

* **Bug Fixes**
  * Whole-chain summaries remain visible for unrelated, empty, or unrecognized filters.
  * Explicit filtering parameters correctly narrow the displayed summary.
  * Loading states remain visible until requests finish or data becomes available.

* **Performance**
  * Summary requests are deferred while the page is busy to reduce unnecessary loading activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->