### PR TITLE
fix(lists): keyboard access, stable rows and exact amounts across the shared list primitives

### DIFF
--- a/public/locales/en/accounts.json
+++ b/public/locales/en/accounts.json
@@ -62,7 +62,8 @@
     "NewWindow": "New ({{days}}d)",
     "AcrossDays_one": "across {{count}} day",
     "AcrossDays_other": "across {{count}} days",
-    "Nonce": "Nonce"
+    "Nonce": "Nonce",
+    "ValidatorBadgesLoaded": "Validator badges loaded"
   },
   "Common": {
     "CopyAddress": "Copy address",

--- a/public/locales/pt-BR/accounts.json
+++ b/public/locales/pt-BR/accounts.json
@@ -62,7 +62,8 @@
     "NewWindow": "Novas ({{days}}d)",
     "AcrossDays_one": "em {{count}} dia",
     "AcrossDays_other": "em {{count}} dias",
-    "Nonce": "Nonce"
+    "Nonce": "Nonce",
+    "ValidatorBadgesLoaded": "Selos de validador carregados"
   },
   "Common": {
     "CopyAddress": "Copiar endereço",

--- a/src/components/AccountsList/AccountBadges.tsx
+++ b/src/components/AccountsList/AccountBadges.tsx
@@ -1,4 +1,5 @@
-import { BadgePill } from '@/components/DataList/styles';
+import { BadgePill, VisuallyHidden } from '@/components/DataList/styles';
+import Tooltip from '@/components/Tooltip';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 import type { IAccountBadges } from './badges';
@@ -26,25 +27,35 @@ const AccountBadges: React.FC<IAccountBadgesProps> = ({ badges }) => {
       })
     : '';
 
+  // Focusable tooltips instead of `title`: a title never opens from the
+  // keyboard or on touch, and readers expose it inconsistently (#699). The
+  // list state also rides inside the pill as hidden text, so it reads with
+  // the badge; visible it is not, because it changes per epoch and this row
+  // is not where someone comes to read it.
   return (
     <>
       {foundation && (
-        <BadgePill
-          $variant="accent"
-          title={t('accounts:Badges.FoundationTooltip')}
-        >
-          {t('accounts:Badges.Foundation')}
-        </BadgePill>
+        <Tooltip
+          msg={t('accounts:Badges.FoundationTooltip')}
+          focusable
+          Component={() => (
+            <BadgePill $variant="accent">
+              {t('accounts:Badges.Foundation')}
+            </BadgePill>
+          )}
+        />
       )}
       {validator && (
-        <BadgePill
-          $variant={genesisValidator ? 'success' : 'neutral'}
-          // List state rides in the tooltip, not its own badge: it changes per
-          // epoch and this row is not where someone comes to read it.
-          title={listState ? `${roleTooltip} (${listState})` : roleTooltip}
-        >
-          {t(`accounts:Badges.${roleKey}`)}
-        </BadgePill>
+        <Tooltip
+          msg={listState ? `${roleTooltip} (${listState})` : roleTooltip}
+          focusable
+          Component={() => (
+            <BadgePill $variant={genesisValidator ? 'success' : 'neutral'}>
+              {t(`accounts:Badges.${roleKey}`)}
+              {listState && <VisuallyHidden>{`, ${listState}`}</VisuallyHidden>}
+            </BadgePill>
+          )}
+        />
       )}
     </>
   );

--- a/src/components/AccountsList/AccountBadges.tsx
+++ b/src/components/AccountsList/AccountBadges.tsx
@@ -27,32 +27,36 @@ const AccountBadges: React.FC<IAccountBadgesProps> = ({ badges }) => {
       })
     : '';
 
+  const foundationMsg = t('accounts:Badges.FoundationTooltip');
+  const roleMsg = listState ? `${roleTooltip} (${listState})` : roleTooltip;
+
   // Focusable tooltips instead of `title`: a title never opens from the
   // keyboard or on touch, and readers expose it inconsistently (#699). The
-  // list state also rides inside the pill as hidden text, so it reads with
-  // the badge; visible it is not, because it changes per epoch and this row
-  // is not where someone comes to read it.
+  // full message also rides inside each pill as hidden text, per the
+  // multi-contract badge precedent: the tooltip mounts only on focus, so a
+  // reader in browse mode would otherwise never meet the text at all.
   return (
     <>
       {foundation && (
         <Tooltip
-          msg={t('accounts:Badges.FoundationTooltip')}
+          msg={foundationMsg}
           focusable
           Component={() => (
             <BadgePill $variant="accent">
               {t('accounts:Badges.Foundation')}
+              <VisuallyHidden>{`, ${foundationMsg}`}</VisuallyHidden>
             </BadgePill>
           )}
         />
       )}
       {validator && (
         <Tooltip
-          msg={listState ? `${roleTooltip} (${listState})` : roleTooltip}
+          msg={roleMsg}
           focusable
           Component={() => (
             <BadgePill $variant={genesisValidator ? 'success' : 'neutral'}>
               {t(`accounts:Badges.${roleKey}`)}
-              {listState && <VisuallyHidden>{`, ${listState}`}</VisuallyHidden>}
+              <VisuallyHidden>{`, ${roleMsg}`}</VisuallyHidden>
             </BadgePill>
           )}
         />

--- a/src/components/AccountsList/BadgesAnnouncement.tsx
+++ b/src/components/AccountsList/BadgesAnnouncement.tsx
@@ -1,0 +1,23 @@
+import { VisuallyHidden } from '@/components/DataList/styles';
+import React from 'react';
+import type { ValidatorOwners } from '@/services/requests/accounts';
+
+export interface IBadgesAnnouncementProps {
+  owners: ValidatorOwners | null | undefined;
+  message: string;
+}
+
+/**
+ * Polite announcement for the deliberately late validator badges: the set
+ * lands well after the rows have painted, and a reader that already passed a
+ * row never learns it gained a badge (#699). Empty until the set actually
+ * arrives; a failed fetch (null) stays silent, matching the badge itself.
+ */
+export const BadgesAnnouncement: React.FC<IBadgesAnnouncementProps> = ({
+  owners,
+  message,
+}) => (
+  <VisuallyHidden role="status" aria-live="polite">
+    {owners ? message : ''}
+  </VisuallyHidden>
+);

--- a/src/components/AccountsList/__tests__/AccountBadges.test.tsx
+++ b/src/components/AccountsList/__tests__/AccountBadges.test.tsx
@@ -37,6 +37,30 @@ jest.mock('next-i18next', () => {
   return { useTranslation: () => ({ t: translate }) };
 });
 
+// Thin, like every suite that meets it: the real one renders through
+// react-tooltip's portal after a delay. What this suite owns is which msg a
+// badge hands it and whether the trigger joined the tab order.
+jest.mock('@/components/Tooltip', () => ({
+  __esModule: true,
+  default: ({
+    msg,
+    focusable,
+    Component,
+  }: {
+    msg: string;
+    focusable?: boolean;
+    Component?: React.FC;
+  }) => (
+    <span
+      title={msg}
+      tabIndex={focusable ? 0 : undefined}
+      data-testid="tooltip-trigger"
+    >
+      {Component ? <Component /> : null}
+    </span>
+  ),
+}));
+
 jest.mock('react-dom', () => {
   const actual = jest.requireActual('react-dom');
   const client = jest.requireActual('react-dom/client');
@@ -89,6 +113,10 @@ const renderBadges = (badges: Partial<IAccountBadges>) =>
     </ThemeProvider>,
   );
 
+/** The focusable trigger wrapping a pill, per the mock above. */
+const triggerOf = (element: HTMLElement) =>
+  element.closest('[data-testid="tooltip-trigger"]');
+
 describe('AccountBadges', () => {
   it('renders nothing at all for an ordinary account', () => {
     const { container } = renderBadges({});
@@ -99,27 +127,44 @@ describe('AccountBadges', () => {
   it('renders the foundation badge on its own, with its own tooltip', () => {
     renderBadges({ foundation: true });
 
-    const pill = screen.getByText('Foundation');
+    const trigger = triggerOf(screen.getByText('Foundation'));
     expect(screen.queryByText('Validator')).toBeNull();
-    // The validator pill's title was checked twice and this one never: swapping the two keys passed the whole suite.
-    expect(pill.getAttribute('title')).toBe(
+    // The validator pill's tooltip was checked twice and this one never: swapping the two keys passed the whole suite.
+    expect(trigger?.getAttribute('title')).toBe(
       "Created in the chain's first block",
     );
   });
 
-  it('renders the plain validator badge with its role tooltip', () => {
+  it('renders the plain validator badge with its role tooltip, and no state text', () => {
     renderBadges({ validator: true });
 
     const pill = screen.getByText('Validator');
-    expect(pill.getAttribute('title')).toBe('Owns a registered validator node');
+    expect(pill.textContent).toBe('Validator');
+    expect(triggerOf(pill)?.getAttribute('title')).toBe(
+      'Owns a registered validator node',
+    );
   });
 
-  it('appends the list state to the tooltip when the chain reports one', () => {
+  it('reads the list state with the badge and appends it to the tooltip', () => {
     renderBadges({ validator: true, validatorList: 'jailed' });
 
-    expect(screen.getByText('Validator').getAttribute('title')).toBe(
+    // The hidden span makes a reader say "Validator, Jailed" in the row
+    // itself, instead of hiding the state behind a hover-only title.
+    const trigger = screen.getByTestId('tooltip-trigger');
+    expect(trigger.textContent).toBe('Validator, Jailed');
+    expect(trigger.getAttribute('title')).toBe(
       'Owns a registered validator node (Jailed)',
     );
+  });
+
+  it('puts every badge trigger in the tab order', () => {
+    renderBadges({ foundation: true, validator: true });
+
+    const triggers = screen.getAllByTestId('tooltip-trigger');
+    expect(triggers).toHaveLength(2);
+    triggers.forEach(trigger => {
+      expect(trigger.getAttribute('tabindex')).toBe('0');
+    });
   });
 
   it('falls back to the raw state for one the bundle does not carry', () => {
@@ -127,7 +172,9 @@ describe('AccountBadges', () => {
     // measured live, and a fifth must read as itself rather than a raw key.
     renderBadges({ validator: true, validatorList: 'somethingNew' });
 
-    expect(screen.getByText('Validator').getAttribute('title')).toBe(
+    const trigger = screen.getByTestId('tooltip-trigger');
+    expect(trigger.textContent).toBe('Validator, somethingNew');
+    expect(trigger.getAttribute('title')).toBe(
       'Owns a registered validator node (somethingNew)',
     );
   });
@@ -139,8 +186,9 @@ describe('AccountBadges', () => {
       validatorList: 'elected',
     });
 
-    const pill = screen.getByText('Genesis validator');
-    expect(pill.getAttribute('title')).toBe(
+    const trigger = screen.getByTestId('tooltip-trigger');
+    expect(trigger.textContent).toBe('Genesis validator, Elected');
+    expect(trigger.getAttribute('title')).toBe(
       'Owns a validator registered in the genesis block (Elected)',
     );
     // A genesis validator is a validator; saying both would say it twice.

--- a/src/components/AccountsList/__tests__/AccountBadges.test.tsx
+++ b/src/components/AccountsList/__tests__/AccountBadges.test.tsx
@@ -124,23 +124,30 @@ describe('AccountBadges', () => {
     expect(container.textContent).toBe('');
   });
 
-  it('renders the foundation badge on its own, with its own tooltip', () => {
+  it('renders the foundation badge on its own, with its message readable in place', () => {
     renderBadges({ foundation: true });
 
-    const trigger = triggerOf(screen.getByText('Foundation'));
+    const trigger = screen.getByTestId('tooltip-trigger');
     expect(screen.queryByText('Validator')).toBeNull();
     // The validator pill's tooltip was checked twice and this one never: swapping the two keys passed the whole suite.
-    expect(trigger?.getAttribute('title')).toBe(
+    expect(trigger.getAttribute('title')).toBe(
       "Created in the chain's first block",
+    );
+    // The tooltip only mounts on focus; the hidden copy is what browse-mode
+    // readers get, per the multi-contract badge precedent.
+    expect(trigger.textContent).toBe(
+      "Foundation, Created in the chain's first block",
     );
   });
 
-  it('renders the plain validator badge with its role tooltip, and no state text', () => {
+  it('renders the plain validator badge with its role message, no state', () => {
     renderBadges({ validator: true });
 
-    const pill = screen.getByText('Validator');
-    expect(pill.textContent).toBe('Validator');
-    expect(triggerOf(pill)?.getAttribute('title')).toBe(
+    const trigger = screen.getByTestId('tooltip-trigger');
+    expect(trigger.textContent).toBe(
+      'Validator, Owns a registered validator node',
+    );
+    expect(trigger.getAttribute('title')).toBe(
       'Owns a registered validator node',
     );
   });
@@ -148,10 +155,10 @@ describe('AccountBadges', () => {
   it('reads the list state with the badge and appends it to the tooltip', () => {
     renderBadges({ validator: true, validatorList: 'jailed' });
 
-    // The hidden span makes a reader say "Validator, Jailed" in the row
-    // itself, instead of hiding the state behind a hover-only title.
     const trigger = screen.getByTestId('tooltip-trigger');
-    expect(trigger.textContent).toBe('Validator, Jailed');
+    expect(trigger.textContent).toBe(
+      'Validator, Owns a registered validator node (Jailed)',
+    );
     expect(trigger.getAttribute('title')).toBe(
       'Owns a registered validator node (Jailed)',
     );
@@ -173,7 +180,9 @@ describe('AccountBadges', () => {
     renderBadges({ validator: true, validatorList: 'somethingNew' });
 
     const trigger = screen.getByTestId('tooltip-trigger');
-    expect(trigger.textContent).toBe('Validator, somethingNew');
+    expect(trigger.textContent).toBe(
+      'Validator, Owns a registered validator node (somethingNew)',
+    );
     expect(trigger.getAttribute('title')).toBe(
       'Owns a registered validator node (somethingNew)',
     );
@@ -187,7 +196,9 @@ describe('AccountBadges', () => {
     });
 
     const trigger = screen.getByTestId('tooltip-trigger');
-    expect(trigger.textContent).toBe('Genesis validator, Elected');
+    expect(trigger.textContent).toBe(
+      'Genesis validator, Owns a validator registered in the genesis block (Elected)',
+    );
     expect(trigger.getAttribute('title')).toBe(
       'Owns a validator registered in the genesis block (Elected)',
     );
@@ -199,7 +210,9 @@ describe('AccountBadges', () => {
     // Suppression happens upstream in accountBadges; this component renders what it is handed.
     renderBadges({ foundation: true, validator: true });
 
-    expect(screen.getByText('Foundation')).toBeTruthy();
-    expect(screen.getByText('Validator')).toBeTruthy();
+    const triggers = screen.getAllByTestId('tooltip-trigger');
+    expect(triggers).toHaveLength(2);
+    expect(triggers[0].textContent?.startsWith('Foundation')).toBe(true);
+    expect(triggers[1].textContent?.startsWith('Validator')).toBe(true);
   });
 });

--- a/src/components/AccountsList/__tests__/BadgesAnnouncement.test.tsx
+++ b/src/components/AccountsList/__tests__/BadgesAnnouncement.test.tsx
@@ -1,0 +1,94 @@
+import theme from '@/styles/theme';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { BadgesAnnouncement } from '../BadgesAnnouncement';
+
+const MESSAGE = 'Validator badges loaded';
+
+const renderAnnouncement = (
+  owners: Record<string, { isGenesis: boolean; list: string }> | null | undefined,
+) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <BadgesAnnouncement owners={owners} message={MESSAGE} />
+    </ThemeProvider>,
+  );
+
+describe('BadgesAnnouncement', () => {
+  it('exists as an empty live region while the validator set is still loading', () => {
+    renderAnnouncement(undefined);
+
+    // The region must be in the DOM before its content changes, or readers
+    // never treat the later fill as an update worth announcing.
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(region.textContent).toBe('');
+  });
+
+  it('announces once the validator set has landed', () => {
+    const view = renderAnnouncement(undefined);
+
+    view.rerender(
+      <ThemeProvider theme={theme}>
+        <BadgesAnnouncement
+          owners={{ klv1abc: { isGenesis: false, list: 'elected' } }}
+          message={MESSAGE}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('status').textContent).toBe(MESSAGE);
+  });
+
+  it('stays silent when the fetch failed, matching the absent badges', () => {
+    const view = renderAnnouncement(undefined);
+
+    view.rerender(
+      <ThemeProvider theme={theme}>
+        <BadgesAnnouncement owners={null} message={MESSAGE} />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+});

--- a/src/components/AccountsList/badges.ts
+++ b/src/components/AccountsList/badges.ts
@@ -31,7 +31,7 @@ export const accountBadges = (
   genesisTimestamp: number | undefined,
   // Undefined while the validator set loads, which means "not known yet",
   // never "not a validator".
-  owners: ValidatorOwners | undefined,
+  owners: ValidatorOwners | null | undefined,
 ): IAccountBadges => {
   const validator = owners?.[address];
 

--- a/src/components/AccountsList/useAccountBadgeSources.ts
+++ b/src/components/AccountsList/useAccountBadgeSources.ts
@@ -4,7 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { genesisTimestampQuery, validatorOwnersQuery } from './badgeQueries';
 
 export interface IAccountBadgeSources {
-  owners: ValidatorOwners | undefined;
+  /** undefined while loading or held back; null when the fetch failed. */
+  owners: ValidatorOwners | null | undefined;
   genesisTimestamp: number | undefined;
 }
 
@@ -25,7 +26,10 @@ export const useAccountBadgeSources = (
   });
 
   return {
-    owners: owners ?? undefined,
+    // Passed through as-is: the query resolves null on failure
+    // (failure-as-data), and erasing that to undefined here made the
+    // announcement's failed-fetch silence contract unreachable.
+    owners,
     genesisTimestamp: genesisTimestamp ?? undefined,
   };
 };

--- a/src/components/Asset/OverviewTab.tsx
+++ b/src/components/Asset/OverviewTab.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import Copy from '@/components/Copy';
-import { formatShare } from '@/components/DataList/format';
+import { exactAmount, formatShare } from '@/components/DataList/format';
 import { InlineShare } from '@/components/DataList/styles';
 import QrCodeModal from '@/components/QrCodeModal';
 import Skeleton from '@/components/Skeleton';
@@ -68,7 +68,10 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
 
   const formatSupply = (
     value?: number,
-    { infiniteOnZero = false }: { infiniteOnZero?: boolean } = {},
+    {
+      infiniteOnZero = false,
+      exact,
+    }: { infiniteOnZero?: boolean; exact?: string } = {},
   ) => {
     if (isSftCollection) return value;
     if (!asset) return 'N/A';
@@ -76,6 +79,11 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
     // that was never reported, which is the failure this metric prevents.
     if (typeof value !== 'number') return 'N/A';
     if (infiniteOnZero && value === 0) return '∞';
+    // The exact digit twin from the parse boundary (#679), rendered with the
+    // same fixed-decimals presentation the number path produces.
+    if (exact !== undefined) {
+      return exactAmount(exact, asset.precision, { trimFraction: false });
+    }
     return toLocaleFixed(value / 10 ** asset.precision, asset.precision);
   };
 
@@ -84,7 +92,9 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
   // 'loading' state of voidRowState, spelled out here so it narrows the type.
   const renderCirculatingSupply = () => {
     if (!asset) return <Skeleton />;
-    return formatSupply(asset.netCirculatingSupply);
+    return formatSupply(asset.netCirculatingSupply, {
+      exact: asset.netCirculatingSupplyString,
+    });
   };
 
   const renderVoidValue = () => {
@@ -92,7 +102,11 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
     return (
       <Link href={`/account/${VOID_ADDRESS}`} legacyBehavior>
         <HoverAnchor>
-          <small>{formatSupply(asset.voidedSupply)}</small>
+          <small>
+            {formatSupply(asset.voidedSupply, {
+              exact: asset.voidedSupplyString,
+            })}
+          </small>
         </HoverAnchor>
       </Link>
     );
@@ -125,7 +139,10 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
         <span>
           <small>
             {asset ? (
-              formatSupply(asset?.maxSupply, { infiniteOnZero: true })
+              formatSupply(asset?.maxSupply, {
+                infiniteOnZero: true,
+                exact: asset?.maxSupplyString,
+              })
             ) : (
               <Skeleton />
             )}
@@ -138,7 +155,13 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
         </span>
         <span>
           <small>
-            {asset ? formatSupply(asset?.initialSupply) : <Skeleton />}
+            {asset ? (
+              formatSupply(asset?.initialSupply, {
+                exact: asset?.initialSupplyString,
+              })
+            ) : (
+              <Skeleton />
+            )}
           </small>
         </span>
       </Row>
@@ -148,7 +171,13 @@ export const OverviewTab: React.FC<PropsWithChildren<AssetProps>> = ({
         </span>
         <div>
           <small>
-            {asset ? formatSupply(asset?.circulatingSupply) : <Skeleton />}
+            {asset ? (
+              formatSupply(asset?.circulatingSupply, {
+                exact: asset?.circulatingSupplyString,
+              })
+            ) : (
+              <Skeleton />
+            )}
           </small>
           <Tooltip
             msg={t('assets:Overview.TotalSupplyTooltip')}

--- a/src/components/Asset/__tests__/OverviewTab.exact.test.tsx
+++ b/src/components/Asset/__tests__/OverviewTab.exact.test.tsx
@@ -1,0 +1,139 @@
+import theme from '@/styles/theme';
+import { IAsset } from '@/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The requests module reaches parseValues/precisionFunctions, untransformable
+// by Jest; the tab only imports two count calls from it, disabled here anyway
+// via router.isReady false.
+jest.mock('@/services/requests/asset', () => ({
+  holdersCall: jest.fn(),
+  transactionCall: jest.fn(),
+}));
+
+// QrCodeModal reaches utils/hooks and from there the react-syntax-highlighter
+// ESM chain; the views barrel reaches the same chain through PrePageTooltip.
+// Neither is under test here; severed wholesale like every other suite.
+jest.mock('@/components/QrCodeModal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('@/utils/precisionFunctions', () => ({}));
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => value,
+}));
+// Pulled in by the views barrel, not by the tab; drags the search tooltip and
+// the contract-modal chain along.
+jest.mock('@/components/InputGlobal', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+// Thin, like every suite that meets it: react-tooltip does not load under
+// jest; what this suite owns is the figures, not the tips.
+jest.mock('@/components/Tooltip', () => ({
+  __esModule: true,
+  default: ({ msg }: { msg: string }) => <span title={msg} />,
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: { asset: 'BIG-TEST' }, isReady: false }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { OverviewTab } from '../OverviewTab';
+
+/**
+ * The seam between the parse boundary and the renderer: an asset whose twins
+ * deliberately differ from their doubles in the last digit, so only the twin
+ * can produce the asserted text. The initial supply carries no twin, pinning
+ * the unchanged number path in the same render.
+ */
+const ASSET = {
+  assetId: 'BIG-TEST',
+  assetType: 'Fungible',
+  precision: 8,
+  ownerAddress: '',
+  circulatingSupply: 100000000000000000,
+  circulatingSupplyString: '100000000000000001',
+  maxSupply: 100000000000000000,
+  maxSupplyString: '100000000000000002',
+  initialSupply: 5000000000000000,
+  burnedValue: 0,
+  mintedValue: 0,
+  uris: {},
+} as unknown as IAsset;
+
+const renderTab = (asset: IAsset) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ThemeProvider theme={theme}>
+        <OverviewTab asset={asset} />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+
+describe('OverviewTab exact supply figures', () => {
+  it('renders the digit twins with fixed decimals, and the number path without a twin', () => {
+    renderTab(ASSET);
+
+    // Twin paths: last digits 1 and 2 exist only in the strings.
+    expect(screen.getByText('1,000,000,000.00000001')).toBeInTheDocument();
+    expect(screen.getByText('1,000,000,000.00000002')).toBeInTheDocument();
+    // Number path (no twin): toLocaleFixed presentation, unchanged.
+    expect(screen.getByText('50,000,000.00000000')).toBeInTheDocument();
+  });
+
+  it('falls back to the rounded double when no twin arrived', () => {
+    renderTab({
+      ...ASSET,
+      circulatingSupplyString: undefined,
+      maxSupplyString: undefined,
+    } as IAsset);
+
+    // Twice: circulating and max both land on the same double now.
+    expect(screen.getAllByText('1,000,000,000.00000000')).toHaveLength(2);
+  });
+});

--- a/src/components/AssetsList/__tests__/exactTwins.test.tsx
+++ b/src/components/AssetsList/__tests__/exactTwins.test.tsx
@@ -83,7 +83,7 @@ jest.mock('react-dom', () => {
   };
 });
 
-import Assets from '../index';
+import Assets from '@/pages/assets';
 import { IRowSection } from '@/types/index';
 
 /**

--- a/src/components/AssetsPools/MobileCard.tsx
+++ b/src/components/AssetsPools/MobileCard.tsx
@@ -82,7 +82,7 @@ const PoolsMobileCard: React.FC<IPoolsMobileCardProps> = ({
       </MobileTotalRow>
       <MobileMetaRow>
         <MobileMetaItem
-          title={`${exactAmount(pool.klvBalance, KLV_PRECISION)} KLV`}
+          title={`${exactAmount(pool.klvBalanceString ?? pool.klvBalance, KLV_PRECISION)} KLV`}
         >
           KLV reserve {formatAmount(pool.klvBalance / 10 ** KLV_PRECISION)}
         </MobileMetaItem>
@@ -90,7 +90,7 @@ const PoolsMobileCard: React.FC<IPoolsMobileCardProps> = ({
           title={
             precision === undefined
               ? undefined
-              : `${exactAmount(pool.kdaBalance, precision)} ${displayTicker}`
+              : `${exactAmount(pool.kdaBalanceString ?? pool.kdaBalance, precision)} ${displayTicker}`
           }
         >
           {displayTicker} reserve{' '}

--- a/src/components/AssetsPools/__tests__/exactTwins.test.tsx
+++ b/src/components/AssetsPools/__tests__/exactTwins.test.tsx
@@ -1,0 +1,176 @@
+import theme from '@/styles/theme';
+import { IAssetPoolRow } from '@/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const capturedTableProps: Array<Record<string, unknown>> = [];
+
+// Capture pattern, as the validators page suite does: the table itself is
+// pinned by its own suite; what this one owns is the rowSections wiring.
+jest.mock('../../Table', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    capturedTableProps.push(props);
+    return null;
+  },
+}));
+
+jest.mock('@/services/requests/assetsPools', () => ({
+  requestAssetsPoolsQuery: jest.fn(),
+  requestAllAssetsPools: jest.fn(async () => []),
+}));
+
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => value,
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: {}, pathname: '/assets', isReady: true }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import AssetsPools from '../index';
+import PoolsMobileCard from '../MobileCard';
+import { IRowSection } from '@/types/index';
+
+/** Twins whose last digit differs from the double: only the twin renders it. */
+const POOL = {
+  kda: 'BIG-8DGT',
+  active: true,
+  ownerAddress: 'klv1owner',
+  adminAddress: 'klv1owner',
+  klvBalance: 10000000000000000,
+  klvBalanceString: '10000000000000001',
+  kdaBalance: 20000000000000000,
+  kdaBalanceString: '20000000000000002',
+  fRatioKLV: 1,
+  fRatioKDA: 1,
+  ticker: 'BIG',
+  name: 'Big Token',
+  precision: 8,
+} as unknown as IAssetPoolRow;
+
+const wrap = (element: React.ReactElement) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <ThemeProvider theme={theme}>{element}</ThemeProvider>
+  </QueryClientProvider>
+);
+
+describe('AssetsPools desktop reserve tooltips', () => {
+  it('pairs each reserve with its twin, precision and unit', () => {
+    capturedTableProps.length = 0;
+    render(wrap(<AssetsPools />));
+
+    const rowSections = capturedTableProps[0]
+      ?.rowSections as (pool: IAssetPoolRow) => IRowSection[];
+    expect(typeof rowSections).toBe('function');
+
+    const { container } = render(
+      wrap(
+        <>
+          {rowSections(POOL).map((section, index) => (
+            <div key={index}>{section.element({})}</div>
+          ))}
+        </>,
+      ),
+    );
+
+    const titles = Array.from(container.querySelectorAll('[title]')).map(
+      element => element.getAttribute('title'),
+    );
+    // KLV reserve: twin digits at KLV precision 6.
+    expect(
+      titles.some(title => title?.includes('10,000,000,000.000001 KLV')),
+    ).toBe(true);
+    // KDA reserve: its own twin at the asset's precision 8.
+    expect(
+      titles.some(title => title?.includes('200,000,000.00000002 BIG')),
+    ).toBe(true);
+  });
+});
+
+describe('PoolsMobileCard reserve tooltips', () => {
+  it('pairs the same twins on the mobile card', () => {
+    const { container } = render(wrap(<PoolsMobileCard item={POOL} index={0} />));
+
+    const titles = Array.from(container.querySelectorAll('[title]')).map(
+      element => element.getAttribute('title'),
+    );
+    expect(
+      titles.some(title => title?.includes('10,000,000,000.000001 KLV')),
+    ).toBe(true);
+    expect(
+      titles.some(title => title?.includes('200,000,000.00000002 BIG')),
+    ).toBe(true);
+  });
+
+  it('falls back to the doubles when no twins arrived', () => {
+    const { container } = render(
+      wrap(
+        <PoolsMobileCard
+          item={
+            {
+              ...POOL,
+              klvBalanceString: undefined,
+              kdaBalanceString: undefined,
+            } as IAssetPoolRow
+          }
+          index={0}
+        />,
+      ),
+    );
+
+    const titles = Array.from(container.querySelectorAll('[title]')).map(
+      element => element.getAttribute('title'),
+    );
+    expect(
+      titles.some(title => title?.includes('10,000,000,000 KLV')),
+    ).toBe(true);
+    expect(titles.some(title => title?.includes('200,000,000 BIG'))).toBe(
+      true,
+    );
+  });
+});

--- a/src/components/AssetsPools/index.tsx
+++ b/src/components/AssetsPools/index.tsx
@@ -128,6 +128,10 @@ const AssetsPools: React.FC<PropsWithChildren> = () => {
     const displayTicker = ticker || kda.split('-')[0] || 'KDA';
     const rate = getPoolRate(pool?.fRatioKLV, pool?.fRatioKDA, precision);
     const separateAdmin = !!pool && hasSeparateAdmin(pool);
+    // Exact digit twins from the parse boundary (#679) for the reserve
+    // tooltips; the numbers stay the fallback.
+    const klvBalanceExact = pool?.klvBalanceString ?? klvBalance;
+    const kdaBalanceExact = pool?.kdaBalanceString ?? kdaBalance;
 
     return [
       {
@@ -180,7 +184,7 @@ const AssetsPools: React.FC<PropsWithChildren> = () => {
       {
         element: () => (
           <AmountPrimary
-            title={`${exactAmount(klvBalance, KLV_PRECISION)} KLV · ${t(POOL_KLV_RESERVE_TOOLTIP)}`}
+            title={`${exactAmount(klvBalanceExact, KLV_PRECISION)} KLV · ${t(POOL_KLV_RESERVE_TOOLTIP)}`}
           >
             {formatAmount(klvBalance / 10 ** KLV_PRECISION)}
           </AmountPrimary>
@@ -194,7 +198,7 @@ const AssetsPools: React.FC<PropsWithChildren> = () => {
             title={
               precision === undefined
                 ? t('assets:Pools.PrecisionUnavailable')
-                : `${exactAmount(kdaBalance, precision)} ${displayTicker}`
+                : `${exactAmount(kdaBalanceExact, precision)} ${displayTicker}`
             }
           >
             <span>

--- a/src/components/BlocksList/__tests__/rows.test.tsx
+++ b/src/components/BlocksList/__tests__/rows.test.tsx
@@ -89,11 +89,8 @@ const BLOCK = {
 const renderCell = (key: string, block: IBlock = BLOCK) => {
   const sections = blockRowSections(block);
   const index = BLOCK_COLUMNS.findIndex(column => column.key === key);
-  const Element = sections[index].element;
   return render(
-    <ThemeProvider theme={theme}>
-      <Element />
-    </ThemeProvider>,
+    <ThemeProvider theme={theme}>{sections[index].element({})}</ThemeProvider>,
   );
 };
 

--- a/src/components/DataList/__tests__/format.test.ts
+++ b/src/components/DataList/__tests__/format.test.ts
@@ -66,6 +66,38 @@ describe('exactAmount', () => {
     expect(exactAmount(NaN, 6)).toBe('--');
     expect(exactAmount(-1, 6)).toBe('--');
   });
+
+  it('renders exact digits from a string past what a double can carry', () => {
+    // EMT-NO9T live: JSON.parse rounds this to ...000; the string twin from
+    // the parse boundary keeps the final 1 (#679).
+    expect(exactAmount('100000000000000001', 8)).toBe(
+      '1,000,000,000.00000001',
+    );
+  });
+
+  it('rejects a string that is not pure digits', () => {
+    expect(exactAmount('', 6)).toBe('--');
+    expect(exactAmount('1.5', 6)).toBe('--');
+    expect(exactAmount('-3', 6)).toBe('--');
+    expect(exactAmount('1e17', 6)).toBe('--');
+    expect(exactAmount('abc', 6)).toBe('--');
+  });
+
+  it('walks digit counts far past the double range', () => {
+    expect(exactAmount('123456789012345678901234567890', 6)).toBe(
+      '123,456,789,012,345,678,901,234.56789',
+    );
+  });
+
+  it('keeps the full fraction when asked not to trim', () => {
+    // The fixed-decimals presentation the asset overview shows in body text.
+    expect(exactAmount('9663453870058599', 6, { trimFraction: false })).toBe(
+      '9,663,453,870.058599',
+    );
+    expect(exactAmount('10000000000000000', 8, { trimFraction: false })).toBe(
+      '100,000,000.00000000',
+    );
+  });
 });
 
 describe('klvAmount', () => {

--- a/src/components/DataList/__tests__/format.test.ts
+++ b/src/components/DataList/__tests__/format.test.ts
@@ -97,6 +97,8 @@ describe('exactAmount', () => {
     expect(exactAmount('10000000000000000', 8, { trimFraction: false })).toBe(
       '100,000,000.00000000',
     );
+    // Precision 0: no fraction exists, trimmed or not.
+    expect(exactAmount('123', 0, { trimFraction: false })).toBe('123');
   });
 });
 

--- a/src/components/DataList/format.ts
+++ b/src/components/DataList/format.ts
@@ -37,24 +37,37 @@ export const formatShare = (part: number, total: number): string => {
 };
 
 /**
- * Human-readable amount for tooltips, where compact notation lies. Divides by
- * 10^precision through string math, because float division rounds the last
- * decimal on 16-digit raw supplies.
+ * Human-readable amount for tooltips and full-value figures, where compact
+ * notation lies. Divides by 10^precision through string math, because float
+ * division rounds the last decimal on 16-digit raw supplies.
  *
- * The exactness ceiling is the input rather than this function: a raw supply
- * above Number.MAX_SAFE_INTEGER already lost its value in JSON.parse, so what
- * comes out is an exact rendering of the stored double, not necessarily of the
- * chain figure. Closing that gap means carrying the supply as a string from
- * the API boundary, tracked in issue #679. Note that a string path cannot just
- * be passed in here: the guard below rejects it and BigInt(Math.trunc(raw))
- * coerces through Number anyway, so it would have to feed BigInt the raw
- * digits instead.
+ * A string input is the exact digit twin the parse boundary injects for
+ * values past 2^53 (#679): those digits feed the walk directly and the
+ * result is genuinely exact. A number input is exact only up to what a
+ * double can carry, which is why callers prefer the string when present.
+ *
+ * `trimFraction: false` keeps the fraction at full precision, matching the
+ * fixed-decimals presentation of `toLocaleFixed` for figures shown in body
+ * text rather than tooltips.
  */
-export const exactAmount = (raw: number, precision: number): string => {
-  if (!Number.isFinite(raw) || raw < 0) return '--';
+const exactDigitsOf = (raw: number | string): string | undefined => {
+  if (typeof raw === 'string') {
+    // Digits only: anything else did not come from the parse boundary.
+    return /^\d+$/.test(raw) ? raw : undefined;
+  }
+  if (!Number.isFinite(raw) || raw < 0) return undefined;
   // BigInt rather than toString(): a double at or above 1e21 stringifies to
   // exponent form, which the digit walk below cannot read.
-  const rawString = BigInt(Math.trunc(raw)).toString();
+  return BigInt(Math.trunc(raw)).toString();
+};
+
+export const exactAmount = (
+  raw: number | string,
+  precision: number,
+  { trimFraction = true }: { trimFraction?: boolean } = {},
+): string => {
+  const rawString = exactDigitsOf(raw);
+  if (rawString === undefined) return '--';
   const padded = rawString.padStart(precision + 1, '0');
   const whole = precision > 0 ? padded.slice(0, -precision) : padded;
   const fraction = precision > 0 ? padded.slice(-precision) : '';
@@ -64,6 +77,10 @@ export const exactAmount = (raw: number, precision: number): string => {
     grouped += whole[index];
     const remaining = whole.length - index - 1;
     if (remaining > 0 && remaining % 3 === 0) grouped += ',';
+  }
+
+  if (!trimFraction) {
+    return fraction ? `${grouped}.${fraction}` : grouped;
   }
 
   let fractionEnd = fraction.length;

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -402,6 +402,28 @@ describe('Filter keyboard operation', () => {
     expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
   });
 
+  it('selects nothing on Enter while no option is active', async () => {
+    const onClick = jest.fn();
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    // Typing resets the cursor to none; Enter must not guess an option.
+    fireEvent.change(input, { target: { value: 'Suc' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('Search Status')).toBeInTheDocument();
+  });
+
   it('wraps the cursor from the first option up to the last', async () => {
     renderWithTheme(
       <Filter
@@ -482,6 +504,68 @@ describe('Filter keyboard operation', () => {
 
     fireEvent.click(openerElement);
     expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('toggles from the chevron with the mouse, as before', async () => {
+    const { container } = renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    const arrow = container.querySelector('[aria-hidden="true"]');
+    fireEvent.click(arrow as Element);
+    expect(await screen.findByLabelText('Search Status')).toBeInTheDocument();
+
+    fireEvent.click(arrow as Element);
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('closes when focus leaves the control, but not when it moves inside', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current="Fail"
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Status Fail' }));
+    const input = await screen.findByLabelText('Search Status');
+
+    // To the clear button: still inside the control, must stay open.
+    fireEvent.blur(input, {
+      relatedTarget: screen.getByRole('button', {
+        name: 'Clear Status filter',
+      }),
+    });
+    expect(screen.getByLabelText('Search Status')).toBeInTheDocument();
+
+    // Out of the control entirely: closes.
+    fireEvent.blur(input, { relatedTarget: null });
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('does not close on blur while the pointer rests on the control', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    fireEvent.mouseEnter(screen.getByTestId('selector'));
+    fireEvent.blur(input, { relatedTarget: null });
+    expect(screen.getByLabelText('Search Status')).toBeInTheDocument();
   });
 
   it('names the clear control and clears back to All through it', () => {

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -349,3 +349,154 @@ describe('Filter', () => {
     expect(screen.queryByLabelText('Search Version')).not.toBeInTheDocument();
   });
 });
+
+describe('Filter keyboard operation', () => {
+  const opener = () => screen.getByRole('button', { name: 'Status All' });
+
+  it('opens from the opener button and reports the expanded state', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(opener()).toHaveAttribute('aria-expanded', 'false');
+    expect(opener()).toHaveAttribute('aria-haspopup', 'listbox');
+
+    fireEvent.click(opener());
+
+    const input = await screen.findByLabelText('Search Status');
+    expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('walks options with the arrow keys and selects the active one on Enter', async () => {
+    const onClick = jest.fn();
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    // The cursor seeds on the current value ("All", index 0), like a select.
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const activeId = input.getAttribute('aria-activedescendant');
+    expect(activeId).toBeTruthy();
+    expect(document.getElementById(activeId as string)).toHaveTextContent(
+      'Success',
+    );
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledWith('Success');
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('wraps the cursor from the first option up to the last', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    const activeId = input.getAttribute('aria-activedescendant');
+    expect(document.getElementById(activeId as string)).toHaveTextContent(
+      'Fail',
+    );
+  });
+
+  it('closes on Escape and puts focus back on the opener', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+    expect(opener()).toHaveAttribute('aria-expanded', 'false');
+    expect(opener()).toHaveFocus();
+  });
+
+  it('keeps the opener inert when disabledInput is set', () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+        disabledInput
+      />,
+    );
+
+    expect(opener()).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(opener());
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+    expect(opener()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles rather than double-firing in non-typeahead mode', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+        inputType="button"
+        isHiddenInput={false}
+      />,
+    );
+
+    // Captured once: while open the value span empties, so the accessible
+    // name shrinks to the title and a name-based lookup would miss.
+    const openerElement = opener();
+
+    // Pins the toggle itself: open on the first activation, closed on the
+    // second, with the click also bubbling into Content's own handler.
+    fireEvent.click(openerElement);
+    expect(await screen.findByLabelText('Search Status')).toBeInTheDocument();
+
+    fireEvent.click(openerElement);
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('names the clear control and clears back to All through it', () => {
+    const onClick = jest.fn();
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current="Fail"
+        onClick={onClick}
+      />,
+    );
+
+    const clear = screen.getByRole('button', { name: 'Clear Status filter' });
+    fireEvent.click(clear);
+    expect(onClick).toHaveBeenCalledWith('All');
+  });
+});

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -550,6 +550,69 @@ describe('Filter keyboard operation', () => {
     expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
   });
 
+  it('closes when the second Tab hop leaves via the opener, not just via the input', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    const openerElement = opener();
+    fireEvent.click(openerElement);
+    const input = await screen.findByLabelText('Search Status');
+
+    // Hop one: input to opener stays inside, must not close.
+    fireEvent.blur(input, { relatedTarget: openerElement });
+    expect(screen.getByLabelText('Search Status')).toBeInTheDocument();
+
+    // Hop two: opener to the rest of the page. Handled on Content, so the
+    // panel cannot be orphaned open the way an input-only handler allowed.
+    fireEvent.blur(openerElement, { relatedTarget: document.body });
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+  });
+
+  it('takes the opener out of the tab order while open, and the listbox always', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    const openerElement = opener();
+    expect(openerElement).not.toHaveAttribute('tabindex');
+
+    fireEvent.click(openerElement);
+    await screen.findByLabelText('Search Status');
+
+    expect(openerElement).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('listbox')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('returns focus to the opener after clearing, instead of dropping it on body', () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current="Fail"
+        onClick={jest.fn()}
+      />,
+    );
+
+    const openerElement = screen.getByRole('button', { name: 'Status Fail' });
+    const clear = screen.getByRole('button', { name: 'Clear Status filter' });
+    clear.focus();
+
+    // Clearing flips the focused button to display:none via `empty`.
+    fireEvent.click(clear);
+    expect(openerElement).toHaveFocus();
+  });
+
   it('does not close on blur while the pointer rests on the control', async () => {
     renderWithTheme(
       <Filter

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -613,6 +613,51 @@ describe('Filter keyboard operation', () => {
     expect(openerElement).toHaveFocus();
   });
 
+  it('closes the panel when clearing while open, same order as selecting', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current="Fail"
+        onClick={jest.fn()}
+      />,
+    );
+
+    const openerElement = screen.getByRole('button', { name: 'Status Fail' });
+    fireEvent.click(openerElement);
+    await screen.findByLabelText('Search Status');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Status filter' }));
+
+    // Without the close, the listbox stayed stranded open behind an opener
+    // whose activation is a no-op in typeahead mode.
+    expect(screen.queryByLabelText('Search Status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(openerElement).toHaveFocus();
+  });
+
+  it('survives arrow keys when the search matches nothing', async () => {
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current={undefined}
+        onClick={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(opener());
+    const input = await screen.findByLabelText('Search Status');
+
+    fireEvent.change(input, { target: { value: 'zzz' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    // Empty list: no active descendant, no crash, panel still open.
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
+    expect(screen.getByLabelText('Search Status')).toBeInTheDocument();
+  });
+
   it('does not close on blur while the pointer rests on the control', async () => {
     renderWithTheme(
       <Filter

--- a/src/components/Filter/__tests__/index.test.tsx
+++ b/src/components/Filter/__tests__/index.test.tsx
@@ -691,4 +691,25 @@ describe('Filter keyboard operation', () => {
     fireEvent.click(clear);
     expect(onClick).toHaveBeenCalledWith('All');
   });
+
+  // `disabledInput` gates opening the panel, but the clear button sat outside
+  // that gate: a disabled filter could still be reset, and the reset reached
+  // the router through onClick.
+  it('does not clear through a disabled filter', () => {
+    const onClick = jest.fn();
+    renderWithTheme(
+      <Filter
+        title="Status"
+        data={['Success', 'Fail']}
+        current="Fail"
+        disabledInput
+        onClick={onClick}
+      />,
+    );
+
+    const clear = screen.getByRole('button', { name: 'Clear Status filter' });
+    expect(clear).toBeDisabled();
+    fireEvent.click(clear);
+    expect(onClick).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -262,8 +262,11 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     if (onClick) {
       onClick(allItem);
     }
+    // Same order as handleSelect: close first, then land focus on the opener.
     // Clearing empties the button under the keyboard user's focus (the
-    // `empty` style is display:none); land it on the opener, not on <body>.
+    // `empty` style is display:none), and without the close an open panel
+    // stayed stranded behind an opener whose activation is a no-op.
+    closeDropDown();
     openerRef.current?.focus({ preventScroll: true });
   };
 

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -448,6 +448,10 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
               clearLabel ?? (title ? `Clear ${title} filter` : 'Clear filter')
             }
             empty={selected === allItem}
+            // `disabledInput` blocks opening the panel, but left this button
+            // live: a disabled filter could still be reset, and the reset ran
+            // onClick, pushing the change through to the router.
+            disabled={disabledInput}
             onClick={handleClear}
           >
             <AiOutlineClose />

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -262,6 +262,9 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     if (onClick) {
       onClick(allItem);
     }
+    // Clearing empties the button under the keyboard user's focus (the
+    // `empty` style is display:none); land it on the opener, not on <body>.
+    openerRef.current?.focus({ preventScroll: true });
   };
 
   const handleChange = ({
@@ -336,7 +339,12 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     }
   };
 
-  const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+  // On Content rather than on the input: React's onBlur is the bubbling
+  // focusout, so this sees EVERY hop out of the widget. On the input alone,
+  // Tab parked on the opener first ("inside", no close) and the next Tab
+  // left from the opener with no handler, orphaning the panel open.
+  const handleContentBlur = (event: React.FocusEvent<HTMLElement>) => {
+    if (closed) return;
     if (dontBlur) return;
     // Focus moving to the clear button or an option is not "leaving".
     const next = event.relatedTarget as Node | null;
@@ -374,12 +382,12 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
       <Content
         onMouseEnter={() => setDontBlur(true)}
         onMouseLeave={() => setDontBlur(false)}
+        onBlur={handleContentBlur}
         data-testid="selector"
         {...contentProps}
       >
         {!closed && (
           <HiddenInput
-            onBlur={handleInputBlur}
             onKeyDown={handleInputKeyDown}
             value={inputValue}
             type={inputType}
@@ -405,6 +413,10 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
         <OpenerButton
           ref={openerRef}
           type="button"
+          // Out of the Tab order while open: focus lives on the search input
+          // then, and this button is a dead stop with a collapsed name. The
+          // Escape/select focus return uses .focus(), which -1 still allows.
+          tabIndex={closed ? undefined : -1}
           aria-haspopup="listbox"
           aria-expanded={!closed}
           aria-controls={!closed ? listboxId : undefined}
@@ -452,6 +464,9 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
             role="listbox"
             id={listboxId}
             aria-labelledby={labelId}
+            // Chromium makes a scrollable box without focusable children a
+            // Tab stop; in an activedescendant pattern the list must not be.
+            tabIndex={-1}
           >
             {!filteredArray.length && !loading ? (
               <span>{notFoundLabel ?? `${title} not found!`}</span>

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -3,6 +3,7 @@ import React, {
   PropsWithChildren,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -17,6 +18,7 @@ import {
   HiddenInput,
   Item,
   LoadContainer,
+  OpenerButton,
   SelectorContainer,
 } from './styles';
 
@@ -25,9 +27,11 @@ export interface IFilterItem {
 }
 
 interface ISelectorItemProps {
+  id: string;
   value: string;
   label: string;
   isSelected: boolean;
+  isActive: boolean;
   onSelect: (value: string) => void;
 }
 
@@ -40,19 +44,36 @@ interface ISelectorItemProps {
  * cannot change what reaches the URL and the API.
  */
 const SelectorItem: React.FC<ISelectorItemProps> = ({
+  id,
   value,
   label,
   isSelected,
+  isActive,
   onSelect,
-}) => (
-  <Item
-    onClick={() => onSelect(value)}
-    selected={isSelected}
-    data-testid="selector-item"
-  >
-    <p>{label}</p>
-  </Item>
-);
+}) => {
+  const itemRef = useRef<HTMLDivElement>(null);
+
+  // The panel scrolls at 15rem; keep the arrow-key cursor in view. Optional
+  // call: jsdom has no scrollIntoView.
+  useEffect(() => {
+    if (isActive) itemRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [isActive]);
+
+  return (
+    <Item
+      ref={itemRef}
+      id={id}
+      role="option"
+      aria-selected={isSelected}
+      onClick={() => onSelect(value)}
+      selected={isSelected}
+      $active={isActive}
+      data-testid="selector-item"
+    >
+      <p>{label}</p>
+    </Item>
+  );
+};
 
 export interface IFilter {
   title?: string;
@@ -92,6 +113,8 @@ export interface IFilter {
    * namespace at all, so a `t()` in here would render raw keys on their pages.
    */
   notFoundLabel?: string;
+  /** Accessible name for the clear button; same no-translator rule as above. */
+  clearLabel?: string;
   onClick?(selected: string): void;
   onChange?(value: string): void;
   current: string | undefined;
@@ -108,6 +131,7 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   renderLabel,
   placeholder,
   notFoundLabel,
+  clearLabel,
   onClick,
   onChange,
   current: initial,
@@ -125,6 +149,14 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   const [closed, setClosed] = useState(true);
   const [dontBlur, setDontBlur] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  // The arrow-key cursor over the option list; -1 is "none". Options are not
+  // focusable: focus stays on the input, aria-activedescendant points here.
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const baseId = useId();
+  const labelId = title ? `${baseId}-label` : undefined;
+  const listboxId = `${baseId}-listbox`;
+  const optionId = (index: number) => `${baseId}-option-${index}`;
 
   // Keep display in sync when parent changes `current` (e.g. URL / external chips).
   useEffect(() => {
@@ -134,6 +166,7 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const selectorRef = useRef<HTMLDivElement>(null);
   const focusRef = useRef<HTMLInputElement>(null);
+  const openerRef = useRef<HTMLButtonElement>(null);
 
   // Input only mounts after open; focus once it exists so the caret is visible.
   useEffect(() => {
@@ -162,19 +195,31 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   const closeDropDown = useCallback(() => {
     setClosed(true);
     setInputValue('');
+    setActiveIndex(-1);
   }, []);
+
+  const getDataArray = useCallback(
+    () => (hideAllOption ? data : [allItem].concat(data)),
+    [hideAllOption, data, allItem],
+  );
+
+  const open = useCallback(() => {
+    setClosed(false);
+    // Start the arrow-key cursor on the current value, as a native select does.
+    setActiveIndex(getDataArray().indexOf(selected));
+  }, [getDataArray, selected]);
 
   const openDropdown = useCallback(() => {
     if (disabledInput) return;
     if (closed) {
-      setClosed(false);
+      open();
       return;
     }
     // Non-typeahead mode: second click on the control closes.
     if (!isHiddenInput) {
       closeDropDown();
     }
-  }, [closed, closeDropDown, disabledInput, isHiddenInput]);
+  }, [closed, closeDropDown, disabledInput, isHiddenInput, open]);
 
   const arrowOnClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -182,7 +227,7 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     if (!closed) {
       closeDropDown();
     } else {
-      setClosed(false);
+      open();
     }
   };
 
@@ -203,6 +248,9 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
       }
       setSelected(value);
       closeDropDown();
+      // The input the focus was on unmounts with the panel; land it back on
+      // the opener so keyboard users are not dropped to <body>.
+      openerRef.current?.focus({ preventScroll: true });
     },
     [onClick, closeDropDown],
   );
@@ -226,11 +274,11 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
     // label unsearchable. Nothing needs the sanitising: the match below is a
     // literal `includes`, never a RegExp, so the input cannot be a pattern.
     setInputValue(value);
+    setActiveIndex(-1);
     if (onChange) {
       onChange(value);
     }
   };
-  const getDataArray = () => (hideAllOption ? data : [allItem].concat(data));
 
   const filterArrayByInput = (input: string) => {
     if (input === '') {
@@ -255,6 +303,47 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   };
   const filteredArray = filterArrayByInput(inputValue);
 
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const length = filteredArray.length;
+      if (!length) return;
+      const goingDown = event.key === 'ArrowDown';
+      setActiveIndex(previous => {
+        // The cursor may have been seeded against the unfiltered list; treat
+        // an out-of-range value as "none" so the walk starts at an edge.
+        const inRange = previous >= 0 && previous < length;
+        if (goingDown) {
+          return ((inRange ? previous : -1) + 1) % length;
+        }
+        return ((inRange ? previous : 0) - 1 + length) % length;
+      });
+      return;
+    }
+    if (event.key === 'Enter') {
+      if (activeIndex >= 0 && activeIndex < filteredArray.length) {
+        event.preventDefault();
+        handleSelect(filteredArray[activeIndex]);
+      }
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      // Only this dropdown: a page dialog listening for Escape must not close.
+      event.stopPropagation();
+      closeDropDown();
+      openerRef.current?.focus({ preventScroll: true });
+    }
+  };
+
+  const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (dontBlur) return;
+    // Focus moving to the clear button or an option is not "leaving".
+    const next = event.relatedTarget as Node | null;
+    if (next && contentRef.current?.contains(next)) return;
+    closeDropDown();
+  };
+
   const contentProps = useMemo(() => {
     return {
       ref: contentRef,
@@ -266,7 +355,6 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
   const selectorProps = {
     ref: selectorRef,
     open: closed,
-    overFlow,
     onClick: () => closeDropDown(),
   };
   // The specific prompts used to be picked by comparing `title` against five
@@ -282,7 +370,7 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
       open={!closed}
       data-testid={testId ? `filter-${testId}` : undefined}
     >
-      <span>{title}</span>
+      <span id={labelId}>{title}</span>
       <Content
         onMouseEnter={() => setDontBlur(true)}
         onMouseLeave={() => setDontBlur(false)}
@@ -291,7 +379,8 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
       >
         {!closed && (
           <HiddenInput
-            onBlur={() => !dontBlur && closeDropDown()}
+            onBlur={handleInputBlur}
+            onKeyDown={handleInputKeyDown}
             value={inputValue}
             type={inputType}
             ref={focusRef}
@@ -300,25 +389,70 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
             onChange={handleChange}
             isHiddenInput={isHiddenInput}
             aria-label={title ? `Search ${title}` : 'Search filter'}
+            role="combobox"
+            aria-expanded={!closed}
+            aria-controls={listboxId}
+            aria-activedescendant={
+              activeIndex >= 0 && activeIndex < filteredArray.length
+                ? optionId(activeIndex)
+                : undefined
+            }
+            aria-autocomplete="list"
             autoComplete="off"
             spellCheck={false}
           />
         )}
-        <span style={{ overflow: overFlow ? overFlow : 'hidden' }}>
-          {closed && selected ? labelOf(selected) : ''}
-        </span>
+        <OpenerButton
+          ref={openerRef}
+          type="button"
+          aria-haspopup="listbox"
+          aria-expanded={!closed}
+          aria-controls={!closed ? listboxId : undefined}
+          aria-labelledby={labelId ? `${labelId} ${baseId}-value` : undefined}
+          aria-disabled={disabledInput || undefined}
+          onClick={event => {
+            // Content also opens on click; the second call in the same batch
+            // happens to be idempotent only because it reads a stale `closed`.
+            // Stopping here keeps the toggle off that batching subtlety.
+            event.stopPropagation();
+            openDropdown();
+          }}
+        >
+          <span
+            id={`${baseId}-value`}
+            style={{ overflow: overFlow ?? 'hidden' }}
+          >
+            {closed && selected ? labelOf(selected) : ''}
+          </span>
+        </OpenerButton>
 
         {!hideAllOption && (
-          <CloseContainer empty={selected === allItem} onClick={handleClear}>
+          <CloseContainer
+            type="button"
+            aria-label={
+              clearLabel ?? (title ? `Clear ${title} filter` : 'Clear filter')
+            }
+            empty={selected === allItem}
+            onClick={handleClear}
+          >
             <AiOutlineClose />
           </CloseContainer>
         )}
 
-        <ArrowDownContainer onClick={arrowOnClick} open={!closed}>
+        <ArrowDownContainer
+          onClick={arrowOnClick}
+          open={!closed}
+          aria-hidden="true"
+        >
           <FilterArrowDown />
         </ArrowDownContainer>
         {!closed && (
-          <SelectorContainer {...selectorProps}>
+          <SelectorContainer
+            {...selectorProps}
+            role="listbox"
+            id={listboxId}
+            aria-labelledby={labelId}
+          >
             {!filteredArray.length && !loading ? (
               <span>{notFoundLabel ?? `${title} not found!`}</span>
             ) : (
@@ -327,9 +461,11 @@ const Filter: React.FC<PropsWithChildren<IFilter>> = ({
                   // Values are not guaranteed unique: the validators filter
                   // lists on-chain names, which nothing dedupes.
                   key={`${index}-${value}`}
+                  id={optionId(index)}
                   value={value}
                   label={labelOf(value)}
                   isSelected={value === selected}
+                  isActive={index === activeIndex}
                   onSelect={handleSelect}
                 />
               ))

--- a/src/components/Filter/styles.ts
+++ b/src/components/Filter/styles.ts
@@ -222,6 +222,9 @@ export const Item = styled.div<{ selected: boolean; $active?: boolean }>`
     props.$active &&
     css`
       background-color: ${props => transparentize(0.75, props.theme.lightGray)};
+      /* The tint alone measured ~1.12:1 against unhighlighted rows; the
+         cursor is where Enter lands, so it gets the app's focus color. */
+      border-color: ${props => props.theme.violet};
     `}
 
   &:hover {

--- a/src/components/Filter/styles.ts
+++ b/src/components/Filter/styles.ts
@@ -103,6 +103,36 @@ export const Content = styled.div<{ open: boolean }>`
   }
 `;
 
+/**
+ * The keyboard entry point of the closed control. Wraps only the value span,
+ * stretched over the free row space, so the visual layout stays exactly what
+ * the bare span produced. `color: inherit` is load-bearing: the global
+ * \`button\` rule paints button text in \`theme.white\`, which on this white
+ * card renders the value invisible.
+ */
+export const OpenerButton = styled.button`
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  align-items: center;
+
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid ${props => props.theme.violet};
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+`;
+
 export const SelectorContainer = styled.div<{ open: boolean }>`
   padding: 0.25rem;
   padding-left: 0.5rem;
@@ -168,7 +198,7 @@ export const LoadContainer = styled.div`
   padding: 0.5rem 0.75rem;
 `;
 
-export const Item = styled.div<{ selected: boolean }>`
+export const Item = styled.div<{ selected: boolean; $active?: boolean }>`
   padding: 0.25rem 0.5rem;
 
   display: flex;
@@ -186,6 +216,12 @@ export const Item = styled.div<{ selected: boolean }>`
     css`
       border: 1px solid ${props => props.theme.black10};
       backdrop-filter: brightness(2);
+    `}
+
+  ${props =>
+    props.$active &&
+    css`
+      background-color: ${props => transparentize(0.75, props.theme.lightGray)};
     `}
 
   &:hover {
@@ -246,15 +282,21 @@ export const HiddenInput = styled.input<{
   }
 `;
 
-export const CloseContainer = styled.div<{ empty: boolean }>`
+export const CloseContainer = styled.button<{ empty: boolean }>`
   display: grid;
   place-items: center;
 
   padding: 6px;
+  margin: 0;
   margin-top: 0 !important;
   margin-left: auto;
   position: relative;
   z-index: 3;
+
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
 
   ${props =>
     props.empty &&
@@ -267,6 +309,12 @@ export const CloseContainer = styled.div<{ empty: boolean }>`
     path {
       fill: ${props => props.theme.violet};
     }
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${props => props.theme.violet};
+    outline-offset: 2px;
+    border-radius: 4px;
   }
 `;
 

--- a/src/components/Home/BlockCardFetcher/__tests__/cells.test.tsx
+++ b/src/components/Home/BlockCardFetcher/__tests__/cells.test.tsx
@@ -1,0 +1,131 @@
+import theme from '@/styles/theme';
+import { IBlock } from '@/types/blocks';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The chains the module under test does NOT need, but its sibling index pulls
+// in for the drift test below: precisionFunctions and the full ExplorerLink
+// are untransformable by Jest; replaced wholesale like every other suite.
+jest.mock('@/utils/precisionFunctions', () => ({}));
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => `${value.slice(0, 10)}...`,
+}));
+jest.mock('@/components/ExplorerLink', () => ({
+  __esModule: true,
+  default: ({ value, label }: { value?: string; label?: string }) => (
+    <a href={`#${value ?? ''}`}>{label ?? value}</a>
+  ),
+}));
+jest.mock('@/components/Logo/AssetLogo', () => ({
+  __esModule: true,
+  default: () => <span data-testid="asset-logo" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { blockFeesCell, blockRewardsCell, blockSizeTxsCell } from '../cells';
+import { blocksRowSections, blocksTabletRowSections } from '../index';
+
+// Same mainnet block 32739281 the BlocksList rows suite uses.
+const BLOCK = {
+  nonce: 32739281,
+  epoch: 6076,
+  size: 479,
+  producerName: 'MOONLABS-1',
+  producerOwnerAddress:
+    'klv1qqqqqqqqqqqqqpgqp09vtjvv3rr57vvs6zaaaj4ddd736rthnqup6tmn4w',
+  timestamp: 1787871964,
+  txCount: 1,
+  txFees: 6143952,
+  kAppFees: 2000000,
+  txBurnedFees: 3071976,
+  blockRewards: 15000000,
+} as IBlock;
+
+const renderCell = (cell: { element: (props: object) => React.ReactNode }) =>
+  render(<ThemeProvider theme={theme}>{cell.element({})}</ThemeProvider>);
+
+describe('home block cells', () => {
+  it('renders size and a singular TX count', () => {
+    renderCell(blockSizeTxsCell(BLOCK));
+    expect(screen.getByText('479 Bytes')).toBeTruthy();
+    expect(screen.getByText('1 TX')).toBeTruthy();
+  });
+
+  it('pluralizes the TX count above one', () => {
+    renderCell(blockSizeTxsCell({ ...BLOCK, txCount: 2 } as IBlock));
+    expect(screen.getByText('2 TXs')).toBeTruthy();
+  });
+
+  it('renders kApp and burned fees in KLV', () => {
+    renderCell(blockFeesCell(BLOCK));
+    expect(screen.getByText('2 KLV')).toBeTruthy();
+    expect(screen.getByText('3.07 KLV')).toBeTruthy();
+  });
+
+  it('renders the fee reward half and the block reward', () => {
+    renderCell(blockRewardsCell(BLOCK));
+    expect(screen.getByText('3.07 KLV')).toBeTruthy();
+    expect(screen.getByText('15 KLV')).toBeTruthy();
+  });
+
+  it('renders zeroes rather than NaN when the fee fields are missing', () => {
+    renderCell(
+      blockFeesCell({
+        ...BLOCK,
+        kAppFees: undefined,
+        txBurnedFees: undefined,
+      } as unknown as IBlock),
+    );
+    expect(screen.getAllByText('0 KLV')).toHaveLength(2);
+  });
+
+  // The drift guard #700 asks for: both home variants must keep rendering the
+  // shared cells identically. Positions 2 to 4 in both builders.
+  it('keeps the desktop and tablet builders on the same three cells', () => {
+    const desktop = blocksRowSections(BLOCK).slice(2, 5);
+    const tablet = blocksTabletRowSections(BLOCK).slice(2, 5);
+
+    desktop.forEach((section, index) => {
+      const a = renderCell(section);
+      const b = renderCell(tablet[index]);
+      expect(a.container.innerHTML).toBe(b.container.innerHTML);
+    });
+  });
+});

--- a/src/components/Home/BlockCardFetcher/__tests__/cells.test.tsx
+++ b/src/components/Home/BlockCardFetcher/__tests__/cells.test.tsx
@@ -116,6 +116,17 @@ describe('home block cells', () => {
     expect(screen.getAllByText('0 KLV')).toHaveLength(2);
   });
 
+  it('renders zeroes in the rewards cell when its fields are missing', () => {
+    renderCell(
+      blockRewardsCell({
+        ...BLOCK,
+        txFees: undefined,
+        blockRewards: undefined,
+      } as unknown as IBlock),
+    );
+    expect(screen.getAllByText('0 KLV')).toHaveLength(2);
+  });
+
   // The drift guard #700 asks for: both home variants must keep rendering the
   // shared cells identically. Positions 2 to 4 in both builders.
   it('keeps the desktop and tablet builders on the same three cells', () => {

--- a/src/components/Home/BlockCardFetcher/cells.tsx
+++ b/src/components/Home/BlockCardFetcher/cells.tsx
@@ -1,0 +1,55 @@
+import { DoubleRow } from '@/styles/common';
+import { IBlock } from '@/types/blocks';
+import { IRowSection } from '@/types/index';
+import { bandwidthFeeReward } from '@/utils/fees';
+import { formatAmount } from '@/utils/formatFunctions';
+import { KLV_PRECISION } from '@/utils/globalVariables';
+import React from 'react';
+
+/** The three cells the desktop and tablet home block rows share (#700). */
+export const blockSizeTxsCell = (block: IBlock): IRowSection => {
+  const { size, txCount } = block;
+  return {
+    element: props => (
+      <DoubleRow {...props} key={txCount + size}>
+        <span>{size} Bytes</span>
+        <span>
+          {txCount} TX{txCount > 1 ? 's' : ''}
+        </span>
+      </DoubleRow>
+    ),
+    span: 1,
+  };
+};
+
+export const blockFeesCell = (block: IBlock): IRowSection => {
+  const { kAppFees, txBurnedFees } = block;
+  return {
+    element: props => (
+      <DoubleRow {...props} key={String(kAppFees) + String(txBurnedFees)}>
+        <span>{formatAmount((kAppFees || 0) / 10 ** KLV_PRECISION)} KLV</span>
+        <span>{`${formatAmount(
+          (txBurnedFees || 0) / 10 ** KLV_PRECISION,
+        )} KLV`}</span>
+      </DoubleRow>
+    ),
+    span: 1,
+  };
+};
+
+export const blockRewardsCell = (block: IBlock): IRowSection => {
+  const { txFees, blockRewards } = block;
+  return {
+    element: props => (
+      <DoubleRow {...props} key={String(txFees) + String(blockRewards)}>
+        <span>
+          {formatAmount(bandwidthFeeReward(txFees) / 10 ** KLV_PRECISION)} KLV
+        </span>
+        <span>
+          {formatAmount((blockRewards || 0) / 10 ** KLV_PRECISION)} KLV
+        </span>
+      </DoubleRow>
+    ),
+    span: 1,
+  };
+};

--- a/src/components/Home/BlockCardFetcher/index.tsx
+++ b/src/components/Home/BlockCardFetcher/index.tsx
@@ -5,12 +5,9 @@ import Table, { ITable } from '@/components/Table';
 import { homeDefaultInterval, useHomeData } from '@/contexts/mainPage';
 import { useMobile } from '@/contexts/mobile';
 import { defaultPagination } from '@/services/apiCalls';
-import { CenteredRow, DoubleRow, Mono } from '@/styles/common';
+import { CenteredRow, DoubleRow } from '@/styles/common';
 import { IBlock } from '@/types/blocks';
 import { IPaginatedResponse, IRowSection } from '@/types/index';
-import { formatAmount } from '@/utils/formatFunctions';
-import { bandwidthFeeReward } from '@/utils/fees';
-import { KLV_PRECISION } from '@/utils/globalVariables';
 import { parseAddress } from '@/utils/parseValues';
 import {
   ArrowHide,
@@ -22,7 +19,7 @@ import ExplorerLink from '@/components/ExplorerLink';
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
 import React, { useState } from 'react';
-import { ValidatorName } from './style';
+import { blockFeesCell, blockRewardsCell, blockSizeTxsCell } from './cells';
 import SkeletonTable from '@/components/SkeletonTable';
 
 export const blocksHeader = [
@@ -32,29 +29,10 @@ export const blocksHeader = [
   'Fees(Kapp/Burned)',
   'Rewards(Fee/Block)',
 ];
-export const blocksTabletHeader = [
-  '',
-  'Block',
-  'Size/TXs',
-  'Fees(Kapp/Burned)',
-  'Rewards(Fee/Block)',
-];
 
 export const blocksRowSections = (block: IBlock): IRowSection[] => {
-  const {
-    nonce,
-    size,
-    epoch,
-    producerName,
-    producerOwnerAddress,
-    producerLogo,
-    timestamp,
-    txCount,
-    txFees,
-    kAppFees,
-    txBurnedFees,
-    blockRewards,
-  } = block;
+  const { nonce, epoch, producerName, producerOwnerAddress, producerLogo } =
+    block;
 
   const producerNameIsAddress = producerName === producerOwnerAddress;
 
@@ -91,61 +69,17 @@ export const blocksRowSections = (block: IBlock): IRowSection[] => {
       ),
       span: 1,
     },
-    {
-      element: props => (
-        <DoubleRow {...props} key={txCount + size}>
-          <span>{size} Bytes</span>
-          <span>
-            {txCount} TX{txCount > 1 ? 's' : ''}
-          </span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
-    {
-      element: props => (
-        <DoubleRow {...props} key={String(kAppFees) + String(txBurnedFees)}>
-          <span>{formatAmount((kAppFees || 0) / 10 ** KLV_PRECISION)} KLV</span>
-          <span>{`${formatAmount(
-            (txBurnedFees || 0) / 10 ** KLV_PRECISION,
-          )} KLV`}</span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
-    {
-      element: props => (
-        <DoubleRow {...props} key={String(txFees) + String(blockRewards)}>
-          <span>
-            {formatAmount(bandwidthFeeReward(txFees) / 10 ** KLV_PRECISION)} KLV
-          </span>
-          <span>
-            {formatAmount((blockRewards || 0) / 10 ** KLV_PRECISION)} KLV
-          </span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
+    blockSizeTxsCell(block),
+    blockFeesCell(block),
+    blockRewardsCell(block),
   ];
 
   return sections;
 };
 
 export const blocksTabletRowSections = (block: IBlock): IRowSection[] => {
-  const {
-    nonce,
-    size,
-    epoch,
-    producerName,
-    producerOwnerAddress,
-    producerLogo,
-    timestamp,
-    txCount,
-    txFees,
-    kAppFees,
-    txBurnedFees,
-    blockRewards,
-  } = block;
+  const { nonce, epoch, producerName, producerOwnerAddress, producerLogo } =
+    block;
 
   const sections: IRowSection[] = [
     {
@@ -177,41 +111,9 @@ export const blocksTabletRowSections = (block: IBlock): IRowSection[] => {
       ),
       span: 1,
     },
-    {
-      element: props => (
-        <DoubleRow {...props} key={txCount + size}>
-          <span>{size} Bytes</span>
-          <span>
-            {txCount} TX{txCount > 1 ? 's' : ''}
-          </span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
-    {
-      element: props => (
-        <DoubleRow {...props} key={String(kAppFees) + String(txBurnedFees)}>
-          <span>{formatAmount((kAppFees || 0) / 10 ** KLV_PRECISION)} KLV</span>
-          <span>{`${formatAmount(
-            (txBurnedFees || 0) / 10 ** KLV_PRECISION,
-          )} KLV`}</span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
-    {
-      element: props => (
-        <DoubleRow {...props} key={String(txFees) + String(blockRewards)}>
-          <span>
-            {formatAmount(bandwidthFeeReward(txFees) / 10 ** KLV_PRECISION)} KLV
-          </span>
-          <span>
-            {formatAmount((blockRewards || 0) / 10 ** KLV_PRECISION)} KLV
-          </span>
-        </DoubleRow>
-      ),
-      span: 1,
-    },
+    blockSizeTxsCell(block),
+    blockFeesCell(block),
+    blockRewardsCell(block),
   ];
 
   return sections;
@@ -219,7 +121,6 @@ export const blocksTabletRowSections = (block: IBlock): IRowSection[] => {
 
 const BlockCardFetcher: React.FC<PropsWithChildren> = () => {
   const { blocks, loadingBlocks } = useHomeData();
-  const { t: commonT } = useTranslation('common');
   const { t } = useTranslation('blocks');
   const [hideMenu, setHideMenu] = useState(false);
   const { isTablet } = useMobile();
@@ -242,7 +143,7 @@ const BlockCardFetcher: React.FC<PropsWithChildren> = () => {
 
   const tableProps: ITable = {
     type: 'blocks',
-    header: isTablet ? blocksTabletHeader : blocksHeader,
+    header: blocksHeader,
     rowSections: isTablet ? blocksTabletRowSections : blocksRowSections,
     dataName: 'blocks',
     request: (page: number, limit: number) => homeBlocksCall(page, limit),

--- a/src/components/ITOTable/__tests__/index.test.tsx
+++ b/src/components/ITOTable/__tests__/index.test.tsx
@@ -1,0 +1,138 @@
+import theme from '@/styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+// The real module reaches precisionFunctions, whose ESM chain Jest cannot
+// transform; this table needs only the one hook from it.
+jest.mock('@/utils/hooks', () => {
+  const { useEffect, useRef } = jest.requireActual('react');
+  return {
+    useDidUpdateEffect: (fn: () => void, inputs: unknown[]): void => {
+      const didMountRef = useRef(false);
+      useEffect(() => {
+        if (didMountRef.current) return fn();
+        didMountRef.current = true;
+      }, inputs);
+    },
+  };
+});
+
+// Same chain, via utils/csv and utils/contracts.
+jest.mock('../ExportButton', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    pathname: '/ito',
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/mobile', () => ({
+  useMobile: () => ({ isMobile: false, isTablet: false }),
+}));
+
+import Table, { ITable } from '../index';
+
+/** Same pin as the shared Table suite: cell state must survive a re-render,
+ *  which the old mount-as-component-type path destroyed (#697). */
+const StatefulCell: React.FC = () => {
+  const [count, setCount] = React.useState(0);
+  return (
+    <button
+      type="button"
+      data-testid="stateful-cell"
+      onClick={() => setCount(current => current + 1)}
+    >
+      count:{count}
+    </button>
+  );
+};
+
+const makeProps = (): ITable => ({
+  type: 'launchPad',
+  header: ['Cell'],
+  rowSections: () => [{ element: () => <StatefulCell />, span: 1 }],
+  request: async () => ({
+    data: { items: [{ id: 1 }] },
+    error: '',
+    code: '',
+    pagination: {
+      self: 1,
+      next: 1,
+      previous: 1,
+      perPage: 10,
+      totalPages: 1,
+      totalRecords: 1,
+    },
+  }),
+  dataName: 'items',
+  showLimit: false,
+  showPagination: false,
+});
+
+describe('ITOTable row cells', () => {
+  it('updates a cell in place across re-renders, keeping DOM node and state', async () => {
+    const client = new QueryClient();
+    const wrap = (element: React.ReactElement) => (
+      <QueryClientProvider client={client}>
+        <ThemeProvider theme={theme}>{element}</ThemeProvider>
+      </QueryClientProvider>
+    );
+    const view = render(wrap(<Table {...makeProps()} />));
+
+    const cell = await screen.findByTestId('stateful-cell');
+    fireEvent.click(cell);
+    expect(cell).toHaveTextContent('count:1');
+
+    view.rerender(wrap(<Table {...makeProps()} />));
+
+    const cellAfter = screen.getByTestId('stateful-cell');
+    expect(cellAfter).toBe(cell);
+    expect(cellAfter).toHaveTextContent('count:1');
+  });
+});

--- a/src/components/ITOTable/index.tsx
+++ b/src/components/ITOTable/index.tsx
@@ -284,30 +284,28 @@ const Table: React.FC<PropsWithChildren<ITable>> = ({
                         {...props}
                         rowSections={true}
                       >
-                        {rowSections(item)?.map(
-                          ({ element: Element, span }, index2) => {
-                            const [updatedSpanCount, isRightAligned] =
-                              processRowSectionsLayout(spanCount, span);
-                            spanCount = updatedSpanCount;
-                            return (
-                              <MobileCardItem
-                                isAssets={
-                                  type === 'assets' || type === 'proposals'
-                                }
-                                isRightAligned={
-                                  (isMobile || isTablet) && isRightAligned
-                                }
-                                key={String(index2) + String(index)}
-                                columnSpan={span}
-                              >
-                                {isMobile || isTablet ? (
-                                  <MobileHeader>{header[index2]}</MobileHeader>
-                                ) : null}
-                                <Element />
-                              </MobileCardItem>
-                            );
-                          },
-                        )}
+                        {rowSections(item)?.map(({ element, span }, index2) => {
+                          const [updatedSpanCount, isRightAligned] =
+                            processRowSectionsLayout(spanCount, span);
+                          spanCount = updatedSpanCount;
+                          return (
+                            <MobileCardItem
+                              isAssets={
+                                type === 'assets' || type === 'proposals'
+                              }
+                              isRightAligned={
+                                (isMobile || isTablet) && isRightAligned
+                              }
+                              key={String(index2) + String(index)}
+                              columnSpan={span}
+                            >
+                              {isMobile || isTablet ? (
+                                <MobileHeader>{header[index2]}</MobileHeader>
+                              ) : null}
+                              {element({})}
+                            </MobileCardItem>
+                          );
+                        })}
                       </Row>
                     )}
                   </React.Fragment>

--- a/src/components/MultsignComponent/MultSign/MultiSignList/index.tsx
+++ b/src/components/MultsignComponent/MultSign/MultiSignList/index.tsx
@@ -17,7 +17,9 @@ export const MultiSignList: React.FC<PropsWithChildren<IMultisignList>> = ({
   const items = [
     {
       title: 'Transactions hash',
-      data: hashs || 'None',
+      // The interface wants string[]; the old `hashs || 'None'` handed the
+      // filter a bare string, which only worked by accident of concat.
+      data: hashs?.length ? hashs : ['None'],
       onClick: (selected: string) => setSelectedHash(selected),
       current: selectedHash,
       loading: false,
@@ -29,7 +31,7 @@ export const MultiSignList: React.FC<PropsWithChildren<IMultisignList>> = ({
     <MultiSigList>
       <FilterContainer>
         {items.map(filter => (
-          <Filter key={JSON.stringify(filter)} {...filter} />
+          <Filter key={filter.title} {...filter} />
         ))}
       </FilterContainer>
     </MultiSigList>

--- a/src/components/PrePageTooltip/__tests__/index.test.tsx
+++ b/src/components/PrePageTooltip/__tests__/index.test.tsx
@@ -1,0 +1,144 @@
+import theme from '@/styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The five lookups the tooltip can fan out to; only the transaction one is
+// exercised here, the rest exist so the module loads without its ESM chains.
+const getTransactionMock = jest.fn();
+jest.mock('@/services/requests/asset', () => ({
+  getAssetByPartialSymbol: jest.fn(),
+}));
+jest.mock('@/services/requests/searchBar/account', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('@/services/requests/searchBar/block', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('@/services/requests/transaction', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => getTransactionMock(...args),
+}));
+jest.mock('@/services/requests/searchBar/smartContract', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/utils/gtag', () => ({ searchEvent: jest.fn() }));
+jest.mock('@/contexts/inputSearch', () => ({
+  useInputSearch: () => ({ setSearchValue: jest.fn() }),
+}));
+jest.mock('@/utils/precisionFunctions', () => ({
+  getPrecision: jest.fn(async () => 6),
+}));
+jest.mock('@/assets/icons', () => new Proxy({}, { get: () => () => null }));
+jest.mock('@/assets/status', () => ({
+  getStatusIcon: () => () => null,
+}));
+jest.mock('@/components/ExplorerLink', () => ({
+  __esModule: true,
+  default: ({ value, label }: { value?: string; label?: string }) => (
+    <a href={`#${value ?? ''}`}>{label ?? value}</a>
+  ),
+}));
+jest.mock('@/components/Logo/AssetLogo', () => ({
+  __esModule: true,
+  default: () => <span data-testid="asset-logo" />,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import PrePageTooltip from '../index';
+
+const HASH =
+  'd971ae9f093d97d6bf6989116ba8d84765c947ceee841e0d7e2fc370f183052a';
+
+/**
+ * Renders the search preview end to end for a transaction hash, which is the
+ * one `element()` call site no other suite reaches: the cards below only
+ * exist if getCorrectRowSections ran and every cell function was invoked.
+ * A FAILED transaction on purpose: search must present those like any other.
+ */
+describe('PrePageTooltip', () => {
+  it('renders the card cells for a failed transaction hash', async () => {
+    getTransactionMock.mockResolvedValue({
+      data: {
+        transaction: {
+          hash: HASH,
+          status: 'fail',
+          sender: 'klv1senderaddress',
+          blockNum: 123456,
+          timestamp: 1787871964000,
+          contract: [
+            {
+              type: 0,
+              parameter: {
+                toAddress: 'klv1receiveraddress',
+                amount: 1000000,
+                assetId: 'KLV',
+              },
+            },
+          ],
+        },
+      },
+      error: '',
+      code: 'successful',
+    });
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <ThemeProvider theme={theme}>
+          <PrePageTooltip
+            search={HASH}
+            setShowTooltip={jest.fn()}
+            isInHomePage={false}
+          />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('card-item').length).toBeGreaterThan(0);
+    });
+    expect(getTransactionMock).toHaveBeenCalledWith(HASH);
+  });
+});

--- a/src/components/PrePageTooltip/index.tsx
+++ b/src/components/PrePageTooltip/index.tsx
@@ -245,23 +245,21 @@ const PrePageTooltip: React.FC<PropsWithChildren<IPrePageTooltip>> = ({
       {!isLoading && canSearchResult && data?.data && (
         <TooltipWrapper>
           {data &&
-            getCorrectRowSections(data).map(
-              ({ element: Element, span }, index) => {
-                const [updatedSpanCount, isRightAligned] =
-                  processRowSectionsLayout(spanCount, span);
-                spanCount = updatedSpanCount;
-                return (
-                  <CardItem
-                    key={index}
-                    isRightAligned={isRightAligned}
-                    columnSpan={span}
-                    data-testid="card-item"
-                  >
-                    <Element />
-                  </CardItem>
-                );
-              },
-            )}
+            getCorrectRowSections(data).map(({ element, span }, index) => {
+              const [updatedSpanCount, isRightAligned] =
+                processRowSectionsLayout(spanCount, span);
+              spanCount = updatedSpanCount;
+              return (
+                <CardItem
+                  key={index}
+                  isRightAligned={isRightAligned}
+                  columnSpan={span}
+                  data-testid="card-item"
+                >
+                  {element({})}
+                </CardItem>
+              );
+            })}
         </TooltipWrapper>
       )}
       {!isLoading && !canSearchResult && (

--- a/src/components/SmartContractsList/Filters.tsx
+++ b/src/components/SmartContractsList/Filters.tsx
@@ -84,7 +84,7 @@ const ContractsFilters: React.FC = () => {
       {router.isReady && (
         <>
           {filters.map(filter => (
-            <Filter key={`${filter.testId}-${filter.current}`} {...filter} />
+            <Filter key={filter.testId} {...filter} />
           ))}
           <ActiveFilter />
         </>

--- a/src/components/Table/__tests__/index.test.tsx
+++ b/src/components/Table/__tests__/index.test.tsx
@@ -1,0 +1,196 @@
+import theme from '@/styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+// The real module reaches precisionFunctions, whose ESM chain Jest cannot
+// transform; the table needs only this one hook from it.
+jest.mock('@/utils/hooks', () => {
+  const { useEffect, useRef } = jest.requireActual('react');
+  return {
+    useDidUpdateEffect: (fn: () => void, inputs: unknown[]): void => {
+      const didMountRef = useRef(false);
+      useEffect(() => {
+        if (didMountRef.current) return fn();
+        didMountRef.current = true;
+      }, inputs);
+    },
+  };
+});
+
+// Same chain, via utils/csv and utils/contracts.
+jest.mock('../ExportButton', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    pathname: '/test',
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}));
+
+jest.mock('@/contexts/mobile', () => ({
+  useMobile: () => ({ isMobile: false, isTablet: false }),
+}));
+
+import Table, { ITable } from '../index';
+
+/** The state-holding cell content: the bug this suite pins was every cell
+ *  remounting per table render, which reset exactly this kind of state. */
+const StatefulCell: React.FC = () => {
+  const [count, setCount] = React.useState(0);
+  return (
+    <button
+      type="button"
+      data-testid="stateful-cell"
+      onClick={() => setCount(current => current + 1)}
+    >
+      count:{count}
+    </button>
+  );
+};
+
+const makeResponse = (items: Array<Record<string, unknown>>) => ({
+  data: { items },
+  error: '',
+  code: '',
+  pagination: {
+    self: 1,
+    next: 1,
+    previous: 1,
+    perPage: 10,
+    totalPages: 1,
+    totalRecords: items.length,
+  },
+});
+
+/**
+ * Built fresh per call, exactly as the pages do: every render hands the table
+ * new arrow functions for `rowSections` and its cells, the situation that used
+ * to give each cell a new component identity and remount it.
+ */
+const makeProps = (
+  request: ITable['request'],
+  options: { refreshKey?: number; smaller?: boolean } = {},
+): ITable => ({
+  type: 'accounts',
+  header: ['Cell', 'Other'],
+  rowSections: () => [
+    { element: () => <StatefulCell />, span: 1 },
+    {
+      element: ({ $smaller }) => (
+        <span data-testid="plain-cell">{String(!!$smaller)}</span>
+      ),
+      span: 1,
+    },
+  ],
+  request,
+  dataName: 'items',
+  showLimit: false,
+  showPagination: false,
+  refreshKey: options.refreshKey,
+  smaller: options.smaller,
+});
+
+const renderTable = (ui: React.ReactElement) => {
+  const client = new QueryClient();
+  const wrap = (element: React.ReactElement) => (
+    <QueryClientProvider client={client}>
+      <ThemeProvider theme={theme}>{element}</ThemeProvider>
+    </QueryClientProvider>
+  );
+  const view = render(wrap(ui));
+  return {
+    rerenderTable: (next: React.ReactElement) => view.rerender(wrap(next)),
+  };
+};
+
+describe('Table row cells', () => {
+  it('updates a cell in place across re-renders, keeping DOM node and state', async () => {
+    const request = async () => makeResponse([{ id: 1 }]);
+    const { rerenderTable } = renderTable(<Table {...makeProps(request)} />);
+
+    const cell = await screen.findByTestId('stateful-cell');
+    fireEvent.click(cell);
+    expect(cell).toHaveTextContent('count:1');
+
+    rerenderTable(<Table {...makeProps(request)} />);
+
+    const cellAfter = screen.getByTestId('stateful-cell');
+    expect(cellAfter).toBe(cell);
+    expect(cellAfter).toHaveTextContent('count:1');
+  });
+
+  // The opposite direction, so in-place updating cannot overshoot: new data
+  // means a new row key, and that remount is what refreshes cell state that
+  // was seeded from the old item.
+  it('still remounts the row when the item itself changes', async () => {
+    let items = [{ id: 1 }];
+    const request = async () => makeResponse(items);
+    const { rerenderTable } = renderTable(
+      <Table {...makeProps(request, { refreshKey: 1 })} />,
+    );
+
+    const cell = await screen.findByTestId('stateful-cell');
+    fireEvent.click(cell);
+    expect(cell).toHaveTextContent('count:1');
+
+    items = [{ id: 2 }];
+    rerenderTable(<Table {...makeProps(request, { refreshKey: 2 })} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stateful-cell')).toHaveTextContent('count:0');
+    });
+    expect(screen.getByTestId('stateful-cell')).not.toBe(cell);
+  });
+
+  it('hands every cell the $smaller prop', async () => {
+    const request = async () => makeResponse([{ id: 1 }]);
+    renderTable(<Table {...makeProps(request, { smaller: true })} />);
+
+    expect(await screen.findByTestId('plain-cell')).toHaveTextContent('true');
+  });
+});

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -435,7 +435,7 @@ const Table = <TCard,>({
                 >
                   {rowSections &&
                     rowSections(item)?.map(
-                      ({ element: Element, span, width, maxWidth }, index2) => {
+                      ({ element, span, width, maxWidth }, index2) => {
                         const [updatedSpanCount, isRightAligned] =
                           processRowSectionsLayout(spanCount, span);
                         spanCount = updatedSpanCount;
@@ -459,7 +459,11 @@ const Table = <TCard,>({
                             {isMobile || isTablet ? (
                               <MobileHeader>{header[index2]}</MobileHeader>
                             ) : null}
-                            <Element $smaller={smaller} />
+                            {/* Called, not mounted as a component type: the
+                                builder returns a fresh arrow per render, and
+                                as a type that remounted every cell, dropping
+                                focus and cell state (#697). */}
+                            {element({ $smaller: smaller })}
                           </MobileCardItem>
                         );
                       },

--- a/src/components/Tabs/Proposals/index.tsx
+++ b/src/components/Tabs/Proposals/index.tsx
@@ -152,7 +152,7 @@ const Proposals: React.FC<PropsWithChildren<IProposalsProps>> = ({
         return (
           <Tooltip
             Component={() => (
-              <DoubleRow {...props}>
+              <DoubleRow>
                 {renderProposalsNetworkParams(parsedParameters)}
               </DoubleRow>
             )}

--- a/src/components/Tooltip/__tests__/index.test.tsx
+++ b/src/components/Tooltip/__tests__/index.test.tsx
@@ -1,0 +1,106 @@
+import theme from '@/styles/theme';
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import Tooltip from '../index';
+
+/**
+ * Pins the document-level Escape dismissal for hover-only tooltips (WCAG
+ * 1.4.13): keyboard events go to the focused element, and a hover trigger
+ * holds no focus, so the dismissal must live on the document while a tip is
+ * showing. The visual half (react-tooltip actually hiding) is library
+ * behavior, verified in a real browser; what this suite owns is that the
+ * listener exists exactly while a tip shows, and that Escape ends it.
+ */
+describe('Tooltip hover dismissal', () => {
+  it('arms a document Escape listener only while showing, and Escape disarms it', () => {
+    const addSpy = jest.spyOn(document, 'addEventListener');
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Tooltip msg="hover hint" Component={() => <span>pill</span>} />
+      </ThemeProvider>,
+    );
+
+    const keydownAdds = () =>
+      addSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+    const keydownRemoves = () =>
+      removeSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+
+    const before = keydownAdds();
+    const trigger = container.querySelector('.button-tooltip') as Element;
+    fireEvent.mouseOver(trigger);
+    expect(keydownAdds()).toBe(before + 1);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(keydownRemoves()).toBeGreaterThanOrEqual(1);
+
+    // Disarmed: a second Escape adds nothing and removes nothing further.
+    const removesAfterDismiss = keydownRemoves();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(keydownRemoves()).toBe(removesAfterDismiss);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('ignores other keys while showing', () => {
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+    const { container } = render(
+      <ThemeProvider theme={theme}>
+        <Tooltip msg="hover hint" Component={() => <span>pill</span>} />
+      </ThemeProvider>,
+    );
+
+    fireEvent.mouseOver(container.querySelector('.button-tooltip') as Element);
+    const removesBefore = removeSpy.mock.calls.filter(
+      ([type]) => type === 'keydown',
+    ).length;
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(
+      removeSpy.mock.calls.filter(([type]) => type === 'keydown').length,
+    ).toBe(removesBefore);
+
+    removeSpy.mockRestore();
+  });
+});

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { IconHelp } from '@/assets/help';
 import { ICustomStyles } from '@/types/index';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyledTooltip, ToolTipSpan } from './styles';
 
 interface ITooltipProps {
@@ -29,14 +29,28 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
 }) => {
   const [displayMessage, setDisplayMessage] = useState(false);
   const parsedMsgs = msg.split('\n');
+
+  // WCAG 1.4.13: content shown on hover or focus must be dismissible without
+  // moving either. Keyboard events go to the FOCUSED element, and hover-only
+  // tooltips hold no focus, so the span handler below cannot reach them: a
+  // document listener, alive only while a tip is showing, covers that case.
+  useEffect(() => {
+    if (!displayMessage) return;
+    const dismiss = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setDisplayMessage(false);
+    };
+    document.addEventListener('keydown', dismiss);
+    return () => document.removeEventListener('keydown', dismiss);
+  }, [displayMessage]);
+
   return (
     <ToolTipSpan
       className="button-tooltip"
       onMouseOver={() => setDisplayMessage(true)}
       onMouseLeave={() => setDisplayMessage(false)}
-      // WCAG 1.4.13: content shown on hover or focus must be dismissible
-      // without moving either. Stops propagation only while actually open,
-      // so a surrounding dialog's Escape keeps working when no tip shows.
+      // The focused-trigger path: same dismissal, plus it stops propagation
+      // so a surrounding dialog's Escape does not also fire while a tip is
+      // open under focus.
       onKeyDown={event => {
         if (event.key === 'Escape' && displayMessage) {
           event.stopPropagation();

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -34,6 +34,15 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
       className="button-tooltip"
       onMouseOver={() => setDisplayMessage(true)}
       onMouseLeave={() => setDisplayMessage(false)}
+      // WCAG 1.4.13: content shown on hover or focus must be dismissible
+      // without moving either. Stops propagation only while actually open,
+      // so a surrounding dialog's Escape keeps working when no tip shows.
+      onKeyDown={event => {
+        if (event.key === 'Escape' && displayMessage) {
+          event.stopPropagation();
+          setDisplayMessage(false);
+        }
+      }}
       {...(focusable && {
         tabIndex: 0,
         onFocus: () => setDisplayMessage(true),

--- a/src/components/TransactionsFilters/index.tsx
+++ b/src/components/TransactionsFilters/index.tsx
@@ -161,9 +161,12 @@ const TransactionsFilters: React.FC<
           directly, only the local `query` copy, which is {} on both sides
           until the effect runs. */}
       {filters.map(filter => (
-        // Keyed on the identifier, not the title: a translated title would
-        // otherwise change the key and remount the control.
-        <Filter key={`${filter?.testId}-${filter?.current}`} {...filter} />
+        // Keyed on the identifier alone: a translated title would change a
+        // title-based key, and keying on `current` remounted the control on
+        // every selection, dropping the keyboard focus it now hands back to
+        // its opener. The displayed value keeps up through Filter's own
+        // `current` sync effect.
+        <Filter key={filter?.testId} {...filter} />
       ))}
       <DateFilter />
     </FilterContainer>

--- a/src/pages/accounts/index.tsx
+++ b/src/pages/accounts/index.tsx
@@ -6,6 +6,7 @@ import AccountsMobileCard, {
 import AccountsFilters from '@/components/AccountsList/Filters';
 import AccountsSummary from '@/components/AccountsList/Summary';
 import { accountBadges } from '@/components/AccountsList/badges';
+import { BadgesAnnouncement } from '@/components/AccountsList/BadgesAnnouncement';
 import { accountsFilteredCall } from '@/components/AccountsList/filteredList';
 import { klvAmount } from '@/components/AccountsList/format';
 import { AccountsTableWrapper } from '@/components/AccountsList/styles';
@@ -155,6 +156,12 @@ const Accounts: React.FC<PropsWithChildren> = () => {
 
       <AccountsSummary />
 
+      <BadgesAnnouncement
+        owners={owners}
+        message={t('accounts:List.ValidatorBadgesLoaded', {
+          defaultValue: 'Validator badges loaded',
+        })}
+      />
       <AccountsTableWrapper>
         <Table {...tableProps} />
       </AccountsTableWrapper>

--- a/src/pages/assets/__tests__/exactTwins.test.tsx
+++ b/src/pages/assets/__tests__/exactTwins.test.tsx
@@ -1,0 +1,186 @@
+import theme from '@/styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IAsset } from '@/types';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const capturedTableProps: Array<Record<string, unknown>> = [];
+
+// Capture pattern, as the validators page suite does.
+jest.mock('@/components/Table', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    capturedTableProps.push(props);
+    return null;
+  },
+}));
+
+// Raw svg imports do not resolve to components under jest; every icon the
+// page graph touches becomes an inert stub.
+jest.mock('@/assets/icons', () =>
+  new Proxy({}, { get: () => () => null }),
+);
+jest.mock('@/assets/title-icons', () =>
+  new Proxy({}, { get: () => () => null }),
+);
+
+// The page reaches parseValues (and through it the contract-modal ESM chain)
+// via the AssetsPools tab import; severed wholesale like every other suite.
+jest.mock('@/utils/parseValues', () => ({
+  parseAddress: (value: string) => value,
+}));
+jest.mock('@/utils/precisionFunctions', () => ({}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: {}, pathname: '/assets', isReady: true }),
+}));
+
+jest.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The registry strip reads the app theme context; the strip is not under test.
+jest.mock('@/contexts/theme', () => ({
+  useTheme: () => ({ theme: jest.requireActual('@/styles/theme').default, isDarkTheme: false }),
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import Assets from '../index';
+import { IRowSection } from '@/types/index';
+
+/**
+ * The seam test the review asked for: an asset whose twins differ from their
+ * doubles in the last digit, walked through the page's own rowSections, so
+ * every exact tooltip provably reads the twin at the right precision.
+ */
+const ASSET = {
+  assetId: 'BIG-8DGT',
+  name: 'Big Token',
+  ticker: 'BIG',
+  logo: '',
+  assetType: 'Fungible',
+  precision: 8,
+  verified: false,
+  circulatingSupply: 100000000000000000,
+  circulatingSupplyString: '100000000000000001',
+  maxSupply: 100000000000000000,
+  maxSupplyString: '100000000000000002',
+  initialSupply: 100000000000000000,
+  initialSupplyString: '100000000000000003',
+  burnedValue: 100000000000000000,
+  burnedValueString: '100000000000000004',
+  staking: {
+    interestType: 'APRI',
+    totalStaked: 100000000000000000,
+    totalStakedString: '100000000000000005',
+    apr: [],
+  },
+  attributes: { isPaused: false },
+  uris: {},
+} as unknown as IAsset;
+
+describe('assets list exact tooltips', () => {
+  const renderCells = (asset: IAsset) => {
+    capturedTableProps.length = 0;
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <ThemeProvider theme={theme}>
+          <Assets />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    );
+    const rowSections = capturedTableProps[0]?.rowSections as (
+      item: IAsset,
+    ) => IRowSection[];
+    expect(typeof rowSections).toBe('function');
+    return render(
+      <ThemeProvider theme={theme}>
+        <>
+          {rowSections(asset).map((section, index) => (
+            <div key={index}>{section.element({})}</div>
+          ))}
+        </>
+      </ThemeProvider>,
+    );
+  };
+
+  it('pairs every figure in the supply and staked tooltips with its twin', () => {
+    const { container } = renderCells(ASSET);
+    const titles = Array.from(container.querySelectorAll('[title]')).map(
+      element => element.getAttribute('title') ?? '',
+    );
+
+    const supplyTitle = titles.find(title => title.includes('Circulating'));
+    expect(supplyTitle).toContain('Circulating 1,000,000,000.00000001 BIG');
+    expect(supplyTitle).toContain('Max 1,000,000,000.00000002');
+    expect(supplyTitle).toContain('Initial 1,000,000,000.00000003');
+    expect(supplyTitle).toContain('Burned 1,000,000,000.00000004');
+
+    expect(
+      titles.some(title => title.startsWith('1,000,000,000.00000002 BIG')),
+    ).toBe(true);
+    expect(
+      titles.some(title =>
+        title.includes('1,000,000,000.00000005 BIG staked'),
+      ),
+    ).toBe(true);
+  });
+
+  it('falls back to the doubles when no twins arrived', () => {
+    const { container } = renderCells({
+      ...ASSET,
+      circulatingSupplyString: undefined,
+      maxSupplyString: undefined,
+      initialSupplyString: undefined,
+      burnedValueString: undefined,
+      staking: {
+        ...(ASSET.staking as object),
+        totalStakedString: undefined,
+      },
+    } as unknown as IAsset);
+
+    const supplyTitle = Array.from(container.querySelectorAll('[title]'))
+      .map(element => element.getAttribute('title') ?? '')
+      .find(title => title.includes('Circulating'));
+    expect(supplyTitle).toContain('Circulating 1,000,000,000 BIG');
+    expect(supplyTitle).toContain('Max 1,000,000,000');
+  });
+});

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -160,24 +160,41 @@ const Assets: React.FC<PropsWithChildren> = () => {
 
     const precisionDivisor = 10 ** precision;
     const { circulating, capBasis } = assetSupplyViews(asset);
+    // Exact digit twins from the parse boundary (#679), preferred wherever a
+    // figure is promised exactly; the number stays the fallback. The
+    // circulating twin mirrors assetSupplyViews' net-versus-raw choice.
+    const circulatingExact = hasVoidSupply(asset)
+      ? (asset.netCirculatingSupplyString ?? circulating)
+      : (asset.circulatingSupplyString ?? circulating);
+    const maxSupplyExact = asset.maxSupplyString ?? maxSupply;
+    const initialSupplyExact = asset.initialSupplyString ?? initialSupply;
+    const burnedValueExact = asset.burnedValueString ?? burnedValue;
     // The cap limits minted minus burned, which is the gross circulating
     // supply: tokens parked on the void address were minted and never
     // burned, so they still take up cap headroom.
     const cap = getCapUsage(capBasis, maxSupply);
     const rewards = getRewardsModel(staking);
     const totalStaked = staking?.totalStaked ?? 0;
+    const totalStakedExact = staking?.totalStakedString ?? totalStaked;
 
     // The cell shows a net circulating figure beside a gross cap, so without
     // the void amount the row reads as a contradiction: "Max 10 M ·
     // Circulating 209 K · Cap Used >99.9%". Burned is a different quantity and
     // invites the wrong reconciliation, so name the void explicitly.
     const supplyTitle = [
-      `Circulating ${exactAmount(circulating, precision)} ${ticker}`,
-      `Max ${maxSupply > 0 ? exactAmount(maxSupply, precision) : 'unlimited'}`,
-      `Initial ${exactAmount(initialSupply, precision)}`,
-      `Burned ${exactAmount(burnedValue, precision)}`,
+      `Circulating ${exactAmount(circulatingExact, precision)} ${ticker}`,
+      `Max ${
+        maxSupply > 0 ? exactAmount(maxSupplyExact, precision) : 'unlimited'
+      }`,
+      `Initial ${exactAmount(initialSupplyExact, precision)}`,
+      `Burned ${exactAmount(burnedValueExact, precision)}`,
       ...(hasVoidSupply(asset)
-        ? [`Void ${exactAmount(asset.voidedSupply, precision)}`]
+        ? [
+            `Void ${exactAmount(
+              asset.voidedSupplyString ?? asset.voidedSupply,
+              precision,
+            )}`,
+          ]
         : []),
       `Precision ${precision}`,
     ].join(' · ');
@@ -245,7 +262,7 @@ const Assets: React.FC<PropsWithChildren> = () => {
         element: () =>
           maxSupply > 0 ? (
             <SupplyCell
-              title={`${exactAmount(maxSupply, precision)} ${ticker}`}
+              title={`${exactAmount(maxSupplyExact, precision)} ${ticker}`}
             >
               <SupplyPrimary>
                 {formatAmount(maxSupply / precisionDivisor)}
@@ -307,7 +324,7 @@ const Assets: React.FC<PropsWithChildren> = () => {
         element: () =>
           staking ? (
             <AmountMuted
-              title={`${exactAmount(totalStaked, precision)} ${ticker} staked · ${formatShare(
+              title={`${exactAmount(totalStakedExact, precision)} ${ticker} staked · ${formatShare(
                 totalStaked,
                 circulating,
               )} of the circulating supply`}

--- a/src/pages/ito/index.tsx
+++ b/src/pages/ito/index.tsx
@@ -64,15 +64,15 @@ export const requestITOSQuery = async (
   return dataITOs;
 };
 
-interface RenderViewAssetButtonProps {
+interface ViewAssetButtonProps {
   assetId: string;
   reference?: string;
 }
 
-export const renderViewAssetButton = ({
+export const ViewAssetButton: React.FC<ViewAssetButtonProps> = ({
   assetId,
   reference,
-}: RenderViewAssetButtonProps): React.ReactElement => {
+}) => {
   const router = useRouter();
   return (
     <ParticipateButton
@@ -85,6 +85,44 @@ export const renderViewAssetButton = ({
     >
       View Asset
     </ParticipateButton>
+  );
+};
+
+interface ParticipateCellProps {
+  asset: IParsedITO;
+  reference?: string;
+  setITO: (asset: IParsedITO) => void;
+  setOpenParticipateModal: (open: boolean) => void;
+}
+
+/**
+ * A real component rather than logic in the row closure: it reads the wallet
+ * context, and the tables call `element` as a plain function, where a hook
+ * would break the rules of hooks.
+ */
+const ParticipateCell: React.FC<ParticipateCellProps> = ({
+  asset,
+  reference,
+  setITO,
+  setOpenParticipateModal,
+}) => {
+  const { walletAddress } = useExtension();
+  const { assetId, whitelistInfo } = asset;
+  const isParticipateEnabled =
+    !whitelistInfo ||
+    (walletAddress &&
+      whitelistInfo.some(info => info.address === walletAddress));
+  return isParticipateEnabled ? (
+    <ParticipateButton
+      onClick={() => {
+        setITO(asset);
+        setOpenParticipateModal(true);
+      }}
+    >
+      Participate
+    </ParticipateButton>
+  ) : (
+    <ViewAssetButton assetId={assetId} reference={reference} />
   );
 };
 
@@ -110,7 +148,6 @@ export const getITOrowSections =
       endTime,
       whitelistStartTime,
       whitelistEndTime,
-      whitelistInfo,
     } = asset;
 
     const bestKLVRate = getBestKLVRate(packData);
@@ -208,25 +245,14 @@ export const getITOrowSections =
         span: 1,
       },
       {
-        element: props => {
-          const { walletAddress } = useExtension();
-          const isParticipateEnabled =
-            !whitelistInfo ||
-            (walletAddress &&
-              whitelistInfo.some(info => info.address === walletAddress));
-          return isParticipateEnabled ? (
-            <ParticipateButton
-              onClick={() => {
-                setITO(asset);
-                setOpenParticipateModal(true);
-              }}
-            >
-              Participate
-            </ParticipateButton>
-          ) : (
-            renderViewAssetButton({ assetId, reference })
-          );
-        },
+        element: () => (
+          <ParticipateCell
+            asset={asset}
+            reference={reference}
+            setITO={setITO}
+            setOpenParticipateModal={setOpenParticipateModal}
+          />
+        ),
         span: 2,
       },
     ];
@@ -256,7 +282,6 @@ export const getITOTabletRowSections =
       endTime,
       whitelistStartTime,
       whitelistEndTime,
-      whitelistInfo,
     } = asset;
 
     const bestKLVRate = getBestKLVRate(packData);
@@ -349,25 +374,14 @@ export const getITOTabletRowSections =
         span: 1,
       },
       {
-        element: props => {
-          const { walletAddress } = useExtension();
-          const isParticipateEnabled =
-            !whitelistInfo ||
-            (walletAddress &&
-              whitelistInfo.some(info => info.address === walletAddress));
-          return isParticipateEnabled ? (
-            <ParticipateButton
-              onClick={() => {
-                setITO(asset);
-                setOpenParticipateModal(true);
-              }}
-            >
-              Participate
-            </ParticipateButton>
-          ) : (
-            renderViewAssetButton({ assetId, reference })
-          );
-        },
+        element: () => (
+          <ParticipateCell
+            asset={asset}
+            reference={reference}
+            setITO={setITO}
+            setOpenParticipateModal={setOpenParticipateModal}
+          />
+        ),
         span: 2,
       },
     ];

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -104,10 +104,12 @@ export const toAddressSectionElement = (
     </LinkWithDropdown>
   );
 };
-export const mobileAddressSectionElement = (
-  toAddress: string,
-  chars = 16,
-): React.ReactElement => {
+/** A component, not a render helper: it reads the mobile context, and row
+ *  cells are called as plain functions where a hook is illegal (#697). */
+export const MobileAddressSection: React.FC<{
+  toAddress: string;
+  chars?: number;
+}> = ({ toAddress, chars = 16 }) => {
   const { isMobile } = useMobile();
   if (isMobile) {
     return (
@@ -427,7 +429,7 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
               across both, against a 100px overflow at a 1100px viewport: the
               table scrolled sideways at 12 as well, and at 1280 it scrolls at
               neither. */}
-          {mobileAddressSectionElement(sender, 16)}
+          <MobileAddressSection toAddress={sender} chars={16} />
         </CenteredRow>
       ),
       span: 1,

--- a/src/services/__tests__/preserveBigDigits.test.ts
+++ b/src/services/__tests__/preserveBigDigits.test.ts
@@ -97,6 +97,26 @@ describe('api.get carries the exact digits through the parse boundary', () => {
     );
   });
 
+  it('rejects on a malformed body in a single attempt, as response.json() did', async () => {
+    // The parse runs in a returned, unawaited promise on purpose: rejection
+    // must bypass the request's catch (which resolves error shapes) and must
+    // not pay the retry loop. A proxy 504 HTML page is the realistic body.
+    const original = global.fetch;
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '<html>504 Gateway Time-out</html>',
+    });
+    global.fetch = fetchMock as never;
+
+    try {
+      await expect(api.get({ route: 'assets/list' })).rejects.toThrow();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      global.fetch = original;
+    }
+  });
+
   it('leaves a response verbatim without the opt-in, so raw views stay honest', async () => {
     // A CreateAsset transaction carries the same field names inside its
     // contract parameter; the Raw Tx card renders this object as-is.

--- a/src/services/__tests__/preserveBigDigits.test.ts
+++ b/src/services/__tests__/preserveBigDigits.test.ts
@@ -1,0 +1,91 @@
+import api, { preserveBigDigits } from '../api';
+
+describe('preserveBigDigits', () => {
+  it('injects an exact string twin for a 16-plus digit amount field', () => {
+    const parsed = JSON.parse(
+      preserveBigDigits('{"circulatingSupply":100000000000000001}'),
+    );
+
+    // The number itself parses bit-identically to before: still the rounded
+    // double. The twin carries what the wire actually said.
+    expect(parsed.circulatingSupply).toBe(100000000000000000);
+    expect(parsed.circulatingSupplyString).toBe('100000000000000001');
+  });
+
+  it('leaves 15-digit values alone: they fit a double exactly', () => {
+    const parsed = JSON.parse(
+      preserveBigDigits('{"maxSupply":999999999999999}'),
+    );
+
+    expect(parsed.maxSupply).toBe(999999999999999);
+    expect(parsed.maxSupplyString).toBeUndefined();
+  });
+
+  it('processes every occurrence across array items', () => {
+    const parsed = JSON.parse(
+      preserveBigDigits(
+        '{"assets":[{"maxSupply":10000000000000000},{"maxSupply":20000000000000000}]}',
+      ),
+    );
+
+    expect(parsed.assets[0].maxSupplyString).toBe('10000000000000000');
+    expect(parsed.assets[1].maxSupplyString).toBe('20000000000000000');
+  });
+
+  it('does not touch the same text inside a string value', () => {
+    // In valid JSON a quote inside a string is always escaped, so the anchor
+    // `[{,]"field"` cannot match there.
+    const raw =
+      '{"metadata":"{\\"maxSupply\\":10000000000000000}","maxSupply":5}';
+    const parsed = JSON.parse(preserveBigDigits(raw));
+
+    expect(parsed.metadata).toBe('{"maxSupply":10000000000000000}');
+    expect(parsed.maxSupplyString).toBeUndefined();
+  });
+
+  it('does not touch fractions, exponents or fields outside the allowlist', () => {
+    const raw =
+      '{"ratio":1234567890123456.5,"volume":1234567890123456789,"klvBalance":1e17}';
+    const parsed = JSON.parse(preserveBigDigits(raw));
+
+    expect(parsed.ratioString).toBeUndefined();
+    expect(parsed.volumeString).toBeUndefined();
+    expect(parsed.klvBalanceString).toBeUndefined();
+  });
+
+  it('keeps whitespace-formatted JSON working', () => {
+    const parsed = JSON.parse(
+      preserveBigDigits('{ "totalStaked" : 90000000000000000 }'),
+    );
+
+    expect(parsed.totalStaked).toBe(90000000000000000);
+    expect(parsed.totalStakedString).toBe('90000000000000000');
+  });
+
+  it('leaves broken JSON broken, so the parse still throws as before', () => {
+    expect(() => JSON.parse(preserveBigDigits('{"maxSupply":'))).toThrow();
+  });
+});
+
+describe('api.get carries the exact digits through the parse boundary', () => {
+  it('returns both the rounded number and the exact twin', async () => {
+    const original = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        '{"data":{"asset":{"assetId":"EMT-NO9T","circulatingSupply":100000000000000001}},"error":"","code":"successful"}',
+    }) as never;
+
+    try {
+      const result = await api.get({ route: 'assets/EMT-NO9T' });
+
+      expect(result.data.asset.circulatingSupply).toBe(100000000000000000);
+      expect(result.data.asset.circulatingSupplyString).toBe(
+        '100000000000000001',
+      );
+    } finally {
+      global.fetch = original;
+    }
+  });
+});

--- a/src/services/__tests__/preserveBigDigits.test.ts
+++ b/src/services/__tests__/preserveBigDigits.test.ts
@@ -68,24 +68,46 @@ describe('preserveBigDigits', () => {
 });
 
 describe('api.get carries the exact digits through the parse boundary', () => {
-  it('returns both the rounded number and the exact twin', async () => {
+  const withFetchText = async (
+    body: string,
+    props: Parameters<typeof api.get>[0],
+  ) => {
     const original = global.fetch;
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () =>
-        '{"data":{"asset":{"assetId":"EMT-NO9T","circulatingSupply":100000000000000001}},"error":"","code":"successful"}',
+      text: async () => body,
     }) as never;
-
     try {
-      const result = await api.get({ route: 'assets/EMT-NO9T' });
-
-      expect(result.data.asset.circulatingSupply).toBe(100000000000000000);
-      expect(result.data.asset.circulatingSupplyString).toBe(
-        '100000000000000001',
-      );
+      return await api.get(props);
     } finally {
       global.fetch = original;
     }
+  };
+
+  it('returns both the rounded number and the exact twin when asked', async () => {
+    const result = await withFetchText(
+      '{"data":{"asset":{"assetId":"EMT-NO9T","circulatingSupply":100000000000000001}},"error":"","code":"successful"}',
+      { route: 'assets/EMT-NO9T', preserveBigAmounts: true },
+    );
+
+    expect(result.data.asset.circulatingSupply).toBe(100000000000000000);
+    expect(result.data.asset.circulatingSupplyString).toBe(
+      '100000000000000001',
+    );
+  });
+
+  it('leaves a response verbatim without the opt-in, so raw views stay honest', async () => {
+    // A CreateAsset transaction carries the same field names inside its
+    // contract parameter; the Raw Tx card renders this object as-is.
+    const result = await withFetchText(
+      '{"data":{"transaction":{"contract":[{"parameter":{"initialSupply":2100000000000000000,"maxSupply":2100000000000000000}}]}},"error":"","code":"successful"}',
+      { route: 'transaction/abc' },
+    );
+
+    const parameter = result.data.transaction.contract[0].parameter;
+    expect(parameter.initialSupplyString).toBeUndefined();
+    expect(parameter.maxSupplyString).toBeUndefined();
+    expect(Object.keys(parameter)).toEqual(['initialSupply', 'maxSupply']);
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -57,6 +57,48 @@ const pagination = {
 };
 
 /**
+ * Amount fields that some surface displays exactly (tooltips, the asset
+ * overview figures). Only these get the preserved-digits treatment: the goal
+ * is the exact display path, not a general bigint payload.
+ */
+const BIG_AMOUNT_FIELDS = [
+  'circulatingSupply',
+  'netCirculatingSupply',
+  'voidedSupply',
+  'initialSupply',
+  'maxSupply',
+  'burnedValue',
+  'totalStaked',
+  'klvBalance',
+  'kdaBalance',
+] as const;
+
+/**
+ * `[{,]` anchors a real key (no suffix matches, and inside a JSON string a
+ * quote is always escaped, so `"maxSupply":` cannot occur there); 16 digits is
+ * where integers can pass Number.MAX_SAFE_INTEGER; the lookahead rejects
+ * fractions and exponents, which these chain integers never carry.
+ */
+const BIG_AMOUNT_PATTERN = new RegExp(
+  String.raw`([{,]\s*"(${BIG_AMOUNT_FIELDS.join('|')})"\s*:\s*)(\d{16,})(?=\s*[,}\]])`,
+  'g',
+);
+
+/**
+ * JSON.parse maps every number onto a double, exact only up to 2^53, and
+ * chain supplies routinely exceed that: the last digits were gone before any
+ * code ran (#679). This raw-text pass leaves the number token untouched, so
+ * everything numeric parses bit-identically to before, and injects an exact
+ * `<field>String` sibling for the display path to prefer.
+ */
+export const preserveBigDigits = (text: string): string =>
+  text.replace(
+    BIG_AMOUNT_PATTERN,
+    (_match, prefix: string, field: string, digits: string) =>
+      `${prefix}${digits},"${field}String":"${digits}"`,
+  );
+
+/**
  * Percent-encodes both sides of every pair.
  *
  * Next has already decoded `router.query` by the time a value reaches here, so
@@ -194,7 +236,9 @@ export const withoutBody = async (
         };
       }
 
-      return response.json();
+      // Through text so the exact digits survive the parse boundary (#679);
+      // a body that is not JSON still lands in the catch below, as before.
+      return JSON.parse(preserveBigDigits(await response.text()));
     } catch (error) {
       return {
         data: null,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -244,10 +244,15 @@ export const withoutBody = async (
         };
       }
 
-      // Through text so the exact digits survive the parse boundary (#679);
-      // a body that is not JSON still lands in the catch below, as before.
-      const text = await response.text();
-      return JSON.parse(preserveBigAmounts ? preserveBigDigits(text) : text);
+      // Through text so the exact digits survive the parse boundary (#679).
+      // Returned WITHOUT await, exactly like `return response.json()` was: a
+      // returned promise's rejection bypasses this try/catch, so a malformed
+      // body still rejects the call in one attempt instead of resolving as an
+      // error shape and paying the full retry loop.
+      return (async () => {
+        const text = await response.text();
+        return JSON.parse(preserveBigAmounts ? preserveBigDigits(text) : text);
+      })();
     } catch (error) {
       return {
         data: null,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -25,6 +25,13 @@ export interface IProps {
   service?: Service;
   requestMode?: RequestMode;
   tries?: number;
+  /**
+   * Opt-in for `preserveBigDigits` on this response. Off by default on
+   * purpose: the field names also occur inside transaction payloads, and the
+   * raw-JSON surfaces (the Raw Tx card, the JSON export) must show the wire
+   * verbatim. A consumer that reads `<field>String` twins asks for them here.
+   */
+  preserveBigAmounts?: boolean;
 }
 
 export interface IAssetInfoRequestProps {
@@ -199,7 +206,8 @@ export const withoutBody = async (
 ): Promise<any> => {
   const request = async () => {
     try {
-      const { route, query, service, apiVersion } = getProps(props);
+      const { route, query, service, apiVersion, preserveBigAmounts } =
+        getProps(props);
       const requestMode: RequestMode = props?.requestMode ?? 'cors';
 
       // No Content-Type here on purpose: this path carries no body, so the
@@ -238,7 +246,8 @@ export const withoutBody = async (
 
       // Through text so the exact digits survive the parse boundary (#679);
       // a body that is not JSON still lands in the catch below, as before.
-      return JSON.parse(preserveBigDigits(await response.text()));
+      const text = await response.text();
+      return JSON.parse(preserveBigAmounts ? preserveBigDigits(text) : text);
     } catch (error) {
       return {
         data: null,

--- a/src/services/requests/__tests__/requestShapes.test.ts
+++ b/src/services/requests/__tests__/requestShapes.test.ts
@@ -34,10 +34,12 @@ import {
   assetsRequest,
 } from '@/services/requests/account';
 import {
+  getAsset,
   getAssetByPartialSymbol,
   transactionCall,
 } from '@/services/requests/asset';
-import { requestAssets } from '@/services/requests/assets';
+import { requestAssets, requestAssetsQuery } from '@/services/requests/assets';
+import { requestAssetsPoolsQuery } from '@/services/requests/assetsPools';
 import { collectionListCall } from '@/services/requests/collection';
 import { requestAssetsList } from '@/services/requests/ito';
 import { getMarketplace } from '@/services/requests/marketplace';
@@ -225,5 +227,29 @@ describe('shapes that must not drift', () => {
       route: 'assets/list',
       query: { asset: 'KLV,KFI' },
     });
+  });
+});
+
+describe('preserved big amounts stay opt-in per request', () => {
+  it('the exact-display requests ask for the digit twins', async () => {
+    mockGet.mockResolvedValue({
+      error: '',
+      data: { assets: [], pools: [] },
+      pagination: { totalPages: 1 },
+    });
+
+    await requestAssetsQuery(1, 10, routerWith({}));
+    await getAsset('KLV');
+    await requestAssetsPoolsQuery(1, 10, routerWith({}));
+
+    expect(callArg(0)).toMatchObject({ preserveBigAmounts: true });
+    expect(callArg(1)).toMatchObject({ preserveBigAmounts: true });
+    expect(callArg(2)).toMatchObject({ preserveBigAmounts: true });
+  });
+
+  it('a transaction request does not, so the raw view stays verbatim', async () => {
+    await transactionCall(routerWith({ asset: 'KLV' }));
+
+    expect(callArg()).not.toHaveProperty('preserveBigAmounts');
   });
 });

--- a/src/services/requests/__tests__/requestShapes.test.ts
+++ b/src/services/requests/__tests__/requestShapes.test.ts
@@ -40,6 +40,7 @@ import {
 } from '@/services/requests/asset';
 import { requestAssets, requestAssetsQuery } from '@/services/requests/assets';
 import { requestAssetsPoolsQuery } from '@/services/requests/assetsPools';
+import getTransaction from '@/services/requests/transaction';
 import { collectionListCall } from '@/services/requests/collection';
 import { requestAssetsList } from '@/services/requests/ito';
 import { getMarketplace } from '@/services/requests/marketplace';
@@ -251,5 +252,11 @@ describe('preserved big amounts stay opt-in per request', () => {
     await transactionCall(routerWith({ asset: 'KLV' }));
 
     expect(callArg()).not.toHaveProperty('preserveBigAmounts');
+  });
+
+  it('nor does the by-hash request that feeds the Raw Tx card', async () => {
+    await getTransaction('abc123');
+
+    expect(callArg()).toEqual({ route: 'transaction/abc123' });
   });
 });

--- a/src/services/requests/__tests__/requestShapes.test.ts
+++ b/src/services/requests/__tests__/requestShapes.test.ts
@@ -249,7 +249,7 @@ describe('preserved big amounts stay opt-in per request', () => {
   });
 
   it('a transaction request does not, so the raw view stays verbatim', async () => {
-    await transactionCall(routerWith({ asset: 'KLV' }));
+    await transactionCall('KLV');
 
     expect(callArg()).not.toHaveProperty('preserveBigAmounts');
   });

--- a/src/services/requests/asset/index.ts
+++ b/src/services/requests/asset/index.ts
@@ -34,6 +34,8 @@ const parseURIs = (asset: IAsset) => {
 export const getAsset = async (assetId: string): Promise<IAssetResponse> =>
   api.get({
     route: `assets/${assetId}`,
+    // The overview shows the supply figures exactly (#679).
+    preserveBigAmounts: true,
   });
 
 export const getAssetByPartialSymbol = async (
@@ -79,6 +81,8 @@ export const assetCall = async (
     const assetId = router.query?.asset as string;
     const res = await api.get({
       route: `assets/${assetId}`,
+      // The overview shows the supply figures exactly (#679).
+      preserveBigAmounts: true,
     });
 
     if (res?.error === 'cannot find asset in database') {

--- a/src/services/requests/assets/index.ts
+++ b/src/services/requests/assets/index.ts
@@ -26,5 +26,7 @@ export const requestAssetsQuery = async (
   return api.get({
     route: `assets/list`,
     query: localQuery,
+    // The assets list shows exact supplies in its tooltips (#679).
+    preserveBigAmounts: true,
   });
 };

--- a/src/services/requests/assetsPools/index.ts
+++ b/src/services/requests/assetsPools/index.ts
@@ -55,6 +55,8 @@ export const requestAssetsPoolsQuery = async (
   const response = await api.get({
     route: `assets/pool/list`,
     query: localQuery,
+    // The reserve tooltips show the balances exactly (#679).
+    preserveBigAmounts: true,
   });
 
   // Keep the shape the return type promises even on the error path, so a

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { IChartData } from '@/configs/home';
 import { ISO2 } from '@/utils/country';
-import { Dispatch, PropsWithChildren, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { IBlock, IBlockResponse } from './blocks';
 import {
   Contract,
@@ -1100,7 +1100,14 @@ export interface TableRowElementProps {
   $smaller?: boolean;
 }
 export interface IRowSection {
-  element: React.FC<PropsWithChildren<TableRowElementProps>>;
+  /**
+   * A plain function the tables CALL, not a component type they mount: builders
+   * hand over a fresh arrow every render, and rendering that as `<Element />`
+   * gave every cell a new identity, so React remounted all of them on each
+   * re-render, dropping keyboard focus and cell state (#697). Consequence: no
+   * hooks inside; a cell needing hooks renders a real component instead.
+   */
+  element: (props: TableRowElementProps) => React.ReactNode;
   span: number;
   width?: number;
   maxWidth?: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -424,6 +424,8 @@ export interface IStaking {
   interestType: string;
   minEpochsToWithdraw: number;
   totalStaked: number;
+  /** Exact digit twin from the parse boundary, values past 2^53 (#679). */
+  totalStakedString?: string;
   apr:
     | {
         timestamp: number;
@@ -464,6 +466,14 @@ export interface IAsset {
   voidedSupply?: number;
   netCirculatingSupply?: number;
   maxSupply: number;
+  // Exact digit twins, injected at the parse boundary for values past 2^53
+  // (#679); present only when the wire value was 16 digits or more.
+  initialSupplyString?: string;
+  circulatingSupplyString?: string;
+  voidedSupplyString?: string;
+  netCirculatingSupplyString?: string;
+  maxSupplyString?: string;
+  burnedValueString?: string;
   royalties: IRoyalties;
   mintedValue: number;
   issueDate: number;
@@ -537,6 +547,9 @@ export interface IAssetPool {
   active: boolean;
   klvBalance: number;
   kdaBalance: number;
+  /** Exact digit twins from the parse boundary, values past 2^53 (#679). */
+  klvBalanceString?: string;
+  kdaBalanceString?: string;
   convertedFees: number;
   adminAddress: string;
   fRatioKLV: number;


### PR DESCRIPTION
Stacked on #703: same shared primitives, so this branches from that head. GitHub retargets this PR to `develop` automatically once #703 merges; nothing here should be reviewed as part of that diff.

## Summary

Five open issues on the shared list primitives, one commit per issue, plus an audit round. Together they make every filter dropdown keyboard operable, stop the shared tables from tearing down their cells on each re-render, make the validator badges reachable for keyboard, touch and screen readers, deduplicate the home block cells, and carry chain amounts above 2^53 exactly from the API parse boundary to every surface that promises an exact figure.

## Changes

**#697, table cells remounted on every re-render.** The shared `Table` (and `ITOTable`, `PrePageTooltip`) rendered each row section's `element` as a component type. Builders hand over fresh arrow functions every render, so every cell had a new identity each time and React unmounted and rebuilt it, dropping keyboard focus and any cell state (the copy-confirmation tick was the visible case). The tables now call `element(props)` and cells update in place; a changed item still remounts its row through the row key. The `IRowSection` type documents the new contract (note: React 19 typings still accept such a function as a JSX type, so the real guard is the regression tests), the one hook-bearing closure (the ITO participate cell) became a real component, and the transactions from-cell helper that reached a context hook one call deep became a component too. I re-measured the issue's own repro in a browser: the focused node now survives scrolling past the table top, where the issue measured `isConnected: false`.

**#698, the shared filter dropdown was mouse-only (WCAG 2.1.1).** The opener is now a real button carrying `aria-expanded` and `aria-haspopup="listbox"`; the option panel is a `listbox` with `option` children; the arrow keys walk the options through `aria-activedescendant` on the search input, Enter selects, Escape closes, and focus lands back on the opener after any close. The clear control is a labelled button. The value's colors, the pill's dimensions and the DOM order that the unit and e2e suites anchor on are unchanged: computed styles measured byte-identical before and after, in the light and the dark theme. Three call sites stopped keying their `Filter` on the current value, because that remount defeated the focus restore; the display keeps up through the component's existing sync effect.

**#699, validator list state only in a `title`, late badges unannounced.** Both account badges now use the focusable tooltip pattern the multi-contract badge established, and the full tooltip message rides inside each pill as visually hidden text, so a row reads as "Validator, Owns a registered validator node (Elected)" instead of hiding everything behind a hover-only `title`. The validator set lands on purpose well after the rows paint; a polite live region announces when the badges arrived and stays silent when the fetch failed, matching the absent badges. Shared tooltips also dismiss on Escape now (WCAG 1.4.13).

**#700, block row cells written three times.** The `/blocks` half of the duplication was already resolved by the blocks list rebuild; what remained were the three byte-identical cells inside the home block list, once per variant, plus a duplicated header array. The cells now live once, used by both builders, with a test pinning the two variants to the same rendered output.

**#679, chain amounts above 2^53 lose digits at JSON.parse.** A raw-text pass at the GET parse boundary injects an exact `<field>String` twin beside 16-plus-digit integer values, for an allowlist of amount fields and only on the requests that display them exactly (assets list, asset detail, pool list). The number token itself is untouched, so every numeric value parses bit-identically to before and arithmetic is unaffected; `exactAmount` accepts the digit strings directly, with a fixed-decimals mode for the asset overview figures. Verified against live data: EMT-NO9T's total supply now renders `1,000,000,000.00000001`, the final digit the issue documented as lost. The opt-in matters: the same field names occur inside transaction payloads, and the Raw Tx card and the JSON export keep showing the wire verbatim. The verbatim default is pinned at the parse boundary, and the request-shape suite pins that no transaction request opts in, including the by-hash one behind the Raw Tx card.

## Audit round

Before pushing I ran six parallel reviewers over the complete diff (security, scoped code review, frontend accessibility, TypeScript, performance, and an independent full-diff pass), fed with scanner output, branch coverage and a mechanical blast-radius map. All eleven actionable findings are fixed in the final commit; the three largest were the Raw Tx fabrication above, a Tab-out that left the dropdown orphaned open, and the clear button dropping keyboard focus to `body` by hiding itself. The remaining observations (the `Tooltip Component` prop creating fresh component types, rolling the badge pattern out to the other title-only badges, a keyboard-driven e2e spec) are follow-up issue material rather than part of this PR.

## Test plan

- Unit: full jest suite green, including new regression suites for the table in-place behavior (both directions), the filter keyboard model, the badges, the announcement region and the parse boundary. Every new guard was also run once against a deliberately broken state to prove the test fails when the guarded behavior is gone.
- E2e: full Cypress green twice, both against the local recipe and in the CI shape (testnet, no host override), after the audit fixes.
- Browser: keyboard walkthroughs (open, arrows, select, Escape, Tab-out, clear), badge focus and Escape dismissal, and the exact-supply figures, all verified live; computed styles compared before and after in both themes.
- Manual: on `/transactions`, Tab to a filter, Enter, arrows, Enter; on `/accounts`, Tab to a badge and read its tooltip; on the EMT-NO9T asset page, check the last digit of Total Supply; on any CreateAsset transaction, check the Raw Tx card carries no `*String` fields.

## Related issues

Closes #697
Closes #698
Closes #699
Closes #700
Closes #679



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible keyboard navigation, focus management, and configurable labels to filters.
  * Improved badge and tooltip accessibility, including screen-reader announcements and Escape-key dismissal.
  * Added validator badge loading translations in English and Portuguese-Brazilian.

* **Bug Fixes**
  * Preserved exact digits for large asset, staking, and pool amounts in displays and tooltips.
  * Improved table interactions by preserving cell focus and state during updates.
  * Standardized ITO participation and transaction address rendering across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->