### PR TITLE
fix(app): stop the per-navigation remount and land the shared list follow-ups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        run: yarn lint
+
       - name: Run tests
         run: yarn test --ci --coverage
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: ['develop', 'staging', 'master']
 
+# Checkout and setup-node need repository read; Codecov authenticates with its
+# own secret, so the default broader GITHUB_TOKEN grant buys nothing here.
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
-    supportFile: false,
+    supportFile: 'cypress/support/e2e.ts',
   },
   video: false,
   screenshotOnRunFailure: false,

--- a/cypress/e2e/filter_keyboard.cy.ts
+++ b/cypress/e2e/filter_keyboard.cy.ts
@@ -1,22 +1,19 @@
 /// <reference types="cypress" />
+/// <reference types="cypress-real-events" />
 
 /**
- * The shared filter dropdown, driven by keys only.
+ * The shared filter dropdown, driven by real keys.
  *
  * jsdom cannot move focus the way a browser does, which is exactly where the
  * review round on #704 found the defects this pins: a dropdown left orphaned
- * open, and a control that dropped focus to `body` by hiding itself. The unit
- * suite covers the state machine; this covers what only a real browser answers.
+ * open on Tab-out, and a control that dropped focus to `body` by hiding
+ * itself. The unit suite covers the state machine; this covers what only a
+ * real browser answers.
  *
- * Two things are deliberately NOT covered, both because Cypress 13 cannot do
- * them without a plugin this repo does not depend on:
- *
- * 1. A literal Tab traversal. There is no `cy.tab()`, so focus is placed with
- *    `.focus()` and the tab ORDER itself stays unverified.
- * 2. Enter on the opener. That button is a real <button>, so a browser turns
- *    Enter into a click itself; `.type('{enter}')` does not, because the
- *    activation is the browser's, not the app's. The opener is therefore
- *    activated with a click, and every key after it is a real key.
+ * Every key here is a real CDP key via cypress-real-events: Enter genuinely
+ * activates the opener the way a browser does, and Tab genuinely moves focus,
+ * so the tab order and the Tab-out close are asserted for real rather than
+ * simulated.
  */
 
 const OPENER =
@@ -88,10 +85,26 @@ describe('Shared filter dropdown, keyboard only', () => {
     cy.wait('@accountList');
   });
 
-  it('opens and hands the options to a reader', () => {
+  it('does not trap: a real Tab moves focus off the closed opener', () => {
+    cy.get(OPENER).should('not.have.attr', 'tabindex', '-1');
+    cy.get(OPENER).focus();
+
+    cy.realPress('Tab');
+
+    // Somewhere real, not body: Tab genuinely left the opener forward.
+    cy.focused().should('exist');
+    cy.focused().should('not.have.attr', 'aria-haspopup');
+    // The Shift+Tab return leg is deliberately absent: under the Cypress
+    // runner it intermittently lands elsewhere while the same traversal in a
+    // plain browser returns to the opener (verified by hand). The Tab-out
+    // test below carries the traversal guarantee that matters.
+  });
+
+  it('opens with a real Enter and hands the options to a reader', () => {
     cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
 
-    cy.get(OPENER).focus().click();
+    cy.get(OPENER).focus();
+    cy.realPress('Enter');
 
     cy.get(OPENER).should('have.attr', 'aria-expanded', 'true');
     cy.get(LISTBOX).should('be.visible');
@@ -101,18 +114,19 @@ describe('Shared filter dropdown, keyboard only', () => {
   });
 
   it('walks the options with the arrow keys and selects with Enter', () => {
-    cy.get(OPENER).focus().click();
+    cy.get(OPENER).focus();
+    cy.realPress('Enter');
 
     cy.focused()
       .invoke('attr', 'aria-activedescendant')
       .then(first => {
-        cy.focused().type('{downarrow}');
+        cy.realPress('ArrowDown');
         cy.focused()
           .invoke('attr', 'aria-activedescendant')
           .should('not.eq', first);
       });
 
-    cy.focused().type('{enter}');
+    cy.realPress('Enter');
 
     cy.location('search').should('include', 'type=');
     cy.get(LISTBOX).should('not.exist');
@@ -124,15 +138,32 @@ describe('Shared filter dropdown, keyboard only', () => {
   // nothing and must still hand focus back.
   it('closes with Escape without selecting, and restores focus', () => {
     cy.location('search').then(search => {
-      cy.get(OPENER).focus().click();
+      cy.get(OPENER).focus();
+      cy.realPress('Enter');
       cy.get(LISTBOX).should('be.visible');
 
-      cy.focused().type('{esc}');
+      cy.realPress('Escape');
 
       cy.get(LISTBOX).should('not.exist');
       cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
       cy.focused().should('have.attr', 'aria-haspopup', 'listbox');
       cy.location('search').should('eq', search);
     });
+  });
+
+  // The defect the #704 review round actually found: focus left the widget
+  // and the panel stayed orphaned open behind it.
+  it('closes when a real Tab leaves the open dropdown', () => {
+    cy.get(OPENER).focus();
+    cy.realPress('Enter');
+    cy.get(LISTBOX).should('be.visible');
+
+    // Focus sits on the search input; two Tabs leave the widget for certain
+    // (one may park on an inside control such as the clear button).
+    cy.realPress('Tab');
+    cy.realPress('Tab');
+
+    cy.get(LISTBOX).should('not.exist');
+    cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
   });
 });

--- a/cypress/e2e/filter_keyboard.cy.ts
+++ b/cypress/e2e/filter_keyboard.cy.ts
@@ -1,0 +1,138 @@
+/// <reference types="cypress" />
+
+/**
+ * The shared filter dropdown, driven by keys only.
+ *
+ * jsdom cannot move focus the way a browser does, which is exactly where the
+ * review round on #704 found the defects this pins: a dropdown left orphaned
+ * open, and a control that dropped focus to `body` by hiding itself. The unit
+ * suite covers the state machine; this covers what only a real browser answers.
+ *
+ * Two things are deliberately NOT covered, both because Cypress 13 cannot do
+ * them without a plugin this repo does not depend on:
+ *
+ * 1. A literal Tab traversal. There is no `cy.tab()`, so focus is placed with
+ *    `.focus()` and the tab ORDER itself stays unverified.
+ * 2. Enter on the opener. That button is a real <button>, so a browser turns
+ *    Enter into a click itself; `.type('{enter}')` does not, because the
+ *    activation is the browser's, not the app's. The opener is therefore
+ *    activated with a click, and every key after it is a real key.
+ */
+
+const OPENER =
+  '[data-testid="filter-account-type"] button[aria-haspopup="listbox"]';
+const LISTBOX = '[role="listbox"]';
+const OPTION = '[role="option"]';
+
+const accounts = Array.from({ length: 5 }, (_, index) => ({
+  address: `klv1account${String(index + 1).padStart(2, '0')}${'q'.repeat(49)}`,
+  nonce: index,
+  balance: 1_000_000_000,
+  frozenBalance: 0,
+  allowance: 0,
+  permissions: [],
+  timestamp: 1_700_000_000 + index,
+  assets: {},
+}));
+
+const ok = (
+  data: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+) => ({
+  data,
+  error: '',
+  code: 'successful',
+  ...extra,
+});
+
+const stubAccountsApis = (): void => {
+  cy.intercept('GET', '**/v1.0/address/list/count/**', {
+    statusCode: 200,
+    body: ok({ number_by_day: [{ doc_count: accounts.length }] }),
+  }).as('accountCount');
+
+  cy.intercept('GET', '**/v1.0/validator/list*', {
+    statusCode: 200,
+    body: ok({ validators: [] }, { pagination: { totalRecords: 0 } }),
+  }).as('validatorList');
+
+  cy.intercept('GET', '**/v1.0/block/by-nonce/0*', {
+    statusCode: 200,
+    body: ok({ block: { nonce: 0, timestamp: 1_700_000_000_000 } }),
+  }).as('blockZero');
+
+  cy.intercept('GET', '**/v1.0/address/list*', {
+    statusCode: 200,
+    body: ok(
+      { accounts },
+      {
+        pagination: {
+          self: 1,
+          next: 1,
+          previous: 1,
+          perPage: 10,
+          totalPages: 1,
+          totalRecords: accounts.length,
+        },
+      },
+    ),
+  }).as('accountList');
+};
+
+describe('Shared filter dropdown, keyboard only', () => {
+  beforeEach(() => {
+    stubAccountsApis();
+    cy.visit('/accounts');
+    // The list must have arrived before anything is asserted about the filter,
+    // otherwise a passing assertion may only mean the page had not rendered.
+    cy.wait('@accountList');
+  });
+
+  it('opens and hands the options to a reader', () => {
+    cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
+
+    cy.get(OPENER).focus().click();
+
+    cy.get(OPENER).should('have.attr', 'aria-expanded', 'true');
+    cy.get(LISTBOX).should('be.visible');
+    cy.get(OPTION).should('have.length.greaterThan', 1);
+    // Arrow keys walk the list through the input, not through focus moves.
+    cy.focused().should('have.attr', 'aria-activedescendant');
+  });
+
+  it('walks the options with the arrow keys and selects with Enter', () => {
+    cy.get(OPENER).focus().click();
+
+    cy.focused()
+      .invoke('attr', 'aria-activedescendant')
+      .then(first => {
+        cy.focused().type('{downarrow}');
+        cy.focused()
+          .invoke('attr', 'aria-activedescendant')
+          .should('not.eq', first);
+      });
+
+    cy.focused().type('{enter}');
+
+    cy.location('search').should('include', 'type=');
+    cy.get(LISTBOX).should('not.exist');
+    // Focus must come back to the control the reader opened, not to body.
+    cy.focused().should('have.attr', 'aria-haspopup', 'listbox');
+  });
+
+  // The opposite of the test above: leaving without choosing must change
+  // nothing and must still hand focus back.
+  it('closes with Escape without selecting, and restores focus', () => {
+    cy.location('search').then(search => {
+      cy.get(OPENER).focus().click();
+      cy.get(LISTBOX).should('be.visible');
+
+      cy.focused().type('{esc}');
+
+      cy.get(LISTBOX).should('not.exist');
+      cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
+      cy.focused().should('have.attr', 'aria-haspopup', 'listbox');
+      cy.location('search').should('eq', search);
+    });
+  });
+});

--- a/cypress/e2e/filter_keyboard.cy.ts
+++ b/cypress/e2e/filter_keyboard.cy.ts
@@ -110,7 +110,13 @@ describe('Shared filter dropdown, keyboard only', () => {
     cy.get(LISTBOX).should('be.visible');
     cy.get(OPTION).should('have.length.greaterThan', 1);
     // Arrow keys walk the list through the input, not through focus moves.
-    cy.focused().should('have.attr', 'aria-activedescendant');
+    // Dereferenced, not just present: a dangling id would keep a reader
+    // silent while a has-attribute assertion stays green.
+    cy.focused()
+      .invoke('attr', 'aria-activedescendant')
+      .then(id => {
+        cy.get(`#${id}`).should('have.attr', 'role', 'option');
+      });
   });
 
   it('walks the options with the arrow keys and selects with Enter', () => {
@@ -130,7 +136,9 @@ describe('Shared filter dropdown, keyboard only', () => {
 
     cy.location('search').should('include', 'type=');
     cy.get(LISTBOX).should('not.exist');
-    // Focus must come back to the control the reader opened, not to body.
+    // Focus must come back to the control the reader opened, not to body,
+    // pinned to THIS filter's container rather than any opener on the page.
+    cy.focused().closest('[data-testid="filter-account-type"]').should('exist');
     cy.focused().should('have.attr', 'aria-haspopup', 'listbox');
   });
 
@@ -146,9 +154,32 @@ describe('Shared filter dropdown, keyboard only', () => {
 
       cy.get(LISTBOX).should('not.exist');
       cy.get(OPENER).should('have.attr', 'aria-expanded', 'false');
+      cy.focused()
+        .closest('[data-testid="filter-account-type"]')
+        .should('exist');
       cy.focused().should('have.attr', 'aria-haspopup', 'listbox');
       cy.location('search').should('eq', search);
     });
+  });
+
+  // The reopen announcement is what confirms an earlier selection took:
+  // the chosen option must read as selected and the cursor must start on it.
+  it('marks the chosen option as selected on reopen', () => {
+    cy.get(OPENER).focus();
+    cy.realPress('Enter');
+    cy.realPress('ArrowDown');
+    cy.realPress('Enter');
+    cy.location('search').should('include', 'type=');
+
+    cy.realPress('Enter');
+
+    cy.get(LISTBOX).should('be.visible');
+    cy.get(`${OPTION}[aria-selected="true"]`).should('have.length', 1);
+    cy.focused()
+      .invoke('attr', 'aria-activedescendant')
+      .then(id => {
+        cy.get(`#${id}`).should('have.attr', 'aria-selected', 'true');
+      });
   });
 
   // The defect the #704 review round actually found: focus left the widget

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,4 @@
+// Loads for every spec. cypress-real-events adds cy.realPress and friends:
+// real CDP input, so a Tab actually moves focus and an Enter actually
+// activates a button, which cy.type() cannot do.
+import 'cypress-real-events';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,35 @@
+import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
-import js from '@eslint/js';
 
-export default tseslint.config({
-  rules: {
-    'no-unused-vars': 'off',
-    'no-explicit-any': 'off',
-    'no-empty-interface': 'off',
-    'react-hooks/exhaustive-deps': 'off',
-    '@next/next/link-passhref': 'off',
+export default tseslint.config(
+  {
+    rules: {
+      'no-unused-vars': 'off',
+      'no-explicit-any': 'off',
+      'no-empty-interface': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+      '@next/next/link-passhref': 'off',
+    },
   },
-});
+  {
+    // Without `files` the config above matches nothing, so every rule in it was
+    // inert. This block is the one that actually applies to the source tree.
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      // Required, not decorative: the default parser reports 646 errors on this
+      // tree, starting at the first `interface`.
+      parser: tseslint.parser,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      // Registered so the inline disable comments across the tree name a rule
+      // that exists; without it each one is itself an error.
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'off',
+    },
+  },
+);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,35 +1,25 @@
 import reactHooks from 'eslint-plugin-react-hooks';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
-  {
-    rules: {
-      'no-unused-vars': 'off',
-      'no-explicit-any': 'off',
-      'no-empty-interface': 'off',
-      'react-hooks/exhaustive-deps': 'off',
-      '@next/next/link-passhref': 'off',
-    },
+// One config object, WITH `files`: a flat-config object without it applies to
+// every file another object makes lintable, which is how an earlier "inert"
+// rules block silently became global the moment this block arrived.
+export default tseslint.config({
+  files: ['src/**/*.{ts,tsx}'],
+  languageOptions: {
+    // Required, not decorative: the default parser reports 646 errors on this
+    // tree, starting at the first `interface`.
+    parser: tseslint.parser,
+    parserOptions: { ecmaFeatures: { jsx: true } },
   },
-  {
-    // Without `files` the config above matches nothing, so every rule in it was
-    // inert. This block is the one that actually applies to the source tree.
-    files: ['src/**/*.{ts,tsx}'],
-    languageOptions: {
-      // Required, not decorative: the default parser reports 646 errors on this
-      // tree, starting at the first `interface`.
-      parser: tseslint.parser,
-      parserOptions: { ecmaFeatures: { jsx: true } },
-    },
-    plugins: {
-      'react-hooks': reactHooks,
-      // Registered so the inline disable comments across the tree name a rule
-      // that exists; without it each one is itself an error.
-      '@typescript-eslint': tseslint.plugin,
-    },
-    rules: {
-      'react-hooks/rules-of-hooks': 'error',
-      'react-hooks/exhaustive-deps': 'off',
-    },
+  plugins: {
+    'react-hooks': reactHooks,
+    // Registered so the inline disable comments across the tree name a rule
+    // that exists; without it each one is itself an error.
+    '@typescript-eslint': tseslint.plugin,
   },
-);
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'off',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "bech32": "^2.0.0",
     "cypress": "^13.15.2",
+    "cypress-real-events": "^1.15.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.3.0",
     "eslint-config-prettier": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "svg-path-bounds": "1.0.2"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
     "@noble/hashes": "^1.3.3",
     "@sinonjs/fake-timers": "9.1.2",
     "@testing-library/jest-dom": "^6.4.0",
@@ -103,6 +102,7 @@
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.3.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-testing-library": "^6.2.0",
     "git-commit-msg-linter": "4.5.0",
     "husky": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "dev": "next dev",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings 0",
     "build": "next build",
     "start": "next start",
     "test": "jest",

--- a/src/__tests__/nextI18nextConfig.test.ts
+++ b/src/__tests__/nextI18nextConfig.test.ts
@@ -14,7 +14,7 @@ describe('next-i18next config', () => {
 
   const loadConfig = () => {
     jest.resetModules();
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+     
     return require(configPath);
   };
 

--- a/src/__tests__/nextI18nextConfig.test.ts
+++ b/src/__tests__/nextI18nextConfig.test.ts
@@ -14,7 +14,7 @@ describe('next-i18next config', () => {
 
   const loadConfig = () => {
     jest.resetModules();
-     
+
     return require(configPath);
   };
 

--- a/src/components/AssetsList/MobileCard.tsx
+++ b/src/components/AssetsList/MobileCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import CopyAction from '@/components/DataList/CopyAction';
 import ExplorerLink from '@/components/DataList/ExplorerLink';
 import {
@@ -73,24 +74,27 @@ const AssetsMobileCard: React.FC<IAssetsMobileCardProps> = ({
           verified={verified}
         />
         {assetType === 'NonFungible' && (
-          <BadgePill $variant="neutral" title={t(ASSET_BADGE_TOOLTIPS.nft)}>
+          <ExplainedBadge variant="neutral" msg={t(ASSET_BADGE_TOOLTIPS.nft)}>
             {t('assets:List.Nft')}
-          </BadgePill>
+          </ExplainedBadge>
         )}
         {assetType === 'SemiFungible' && (
-          <BadgePill $variant="neutral" title={t(ASSET_BADGE_TOOLTIPS.sft)}>
+          <ExplainedBadge variant="neutral" msg={t(ASSET_BADGE_TOOLTIPS.sft)}>
             {t('assets:List.Sft')}
-          </BadgePill>
+          </ExplainedBadge>
         )}
         {attributes?.isPaused && (
-          <BadgePill $variant="warning" title={t(ASSET_BADGE_TOOLTIPS.paused)}>
+          <ExplainedBadge
+            variant="warning"
+            msg={t(ASSET_BADGE_TOOLTIPS.paused)}
+          >
             {t('assets:List.Paused')}
-          </BadgePill>
+          </ExplainedBadge>
         )}
         {hasKdaPool && (
-          <BadgePill $variant="accent" title={t(ASSET_BADGE_TOOLTIPS.pool)}>
+          <ExplainedBadge variant="accent" msg={t(ASSET_BADGE_TOOLTIPS.pool)}>
             Fee Pool
-          </BadgePill>
+          </ExplainedBadge>
         )}
         <RowActions>
           <CopyAction
@@ -160,9 +164,9 @@ const AssetsMobileCard: React.FC<IAssetsMobileCardProps> = ({
             <RewardsUnit>{t('assets:List.Apr')}</RewardsUnit>
           )}
           {rewards.kind === 'fpr' && (
-            <BadgePill $variant="neutral" title={t(FPR_TOOLTIP)}>
+            <ExplainedBadge variant="neutral" msg={t(FPR_TOOLTIP)}>
               FPR
-            </BadgePill>
+            </ExplainedBadge>
           )}
           {rewards.kind === 'none' && t('assets:List.RewardsUnavailable')}
         </MobileMetaItem>

--- a/src/components/AssetsPools/MobileCard.tsx
+++ b/src/components/AssetsPools/MobileCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'next-i18next';
 import React from 'react';
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import CopyAction from '@/components/DataList/CopyAction';
 import ExplorerLink from '@/components/DataList/ExplorerLink';
 import { exactAmount } from '@/components/DataList/format';
@@ -52,9 +53,9 @@ const PoolsMobileCard: React.FC<IPoolsMobileCardProps> = ({
           verified={assetVerified}
         />
         {!active && (
-          <BadgePill $variant="warning" title={t(POOL_DISABLED_TOOLTIP)}>
+          <ExplainedBadge variant="warning" msg={t(POOL_DISABLED_TOOLTIP)}>
             {t('assets:Pools.Disabled')}
-          </BadgePill>
+          </ExplainedBadge>
         )}
         <RowActions>
           <CopyAction

--- a/src/components/AssetsPools/index.tsx
+++ b/src/components/AssetsPools/index.tsx
@@ -1,3 +1,4 @@
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import CopyAction from '@/components/DataList/CopyAction';
 import ExplorerLink from '@/components/DataList/ExplorerLink';
 import { exactAmount } from '@/components/DataList/format';
@@ -147,9 +148,9 @@ const AssetsPools: React.FC<PropsWithChildren> = () => {
               verified={assetVerified}
             />
             {!active && (
-              <BadgePill $variant="warning" title={t(POOL_DISABLED_TOOLTIP)}>
+              <ExplainedBadge variant="warning" msg={t(POOL_DISABLED_TOOLTIP)}>
                 {t('assets:Pools.Disabled')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             <RowActions>
               <CopyAction

--- a/src/components/DataList/ExplainedBadge.tsx
+++ b/src/components/DataList/ExplainedBadge.tsx
@@ -1,0 +1,37 @@
+import {
+  BadgePill,
+  BadgeVariant,
+  VisuallyHidden,
+} from '@/components/DataList/styles';
+import Tooltip from '@/components/Tooltip';
+import React, { PropsWithChildren } from 'react';
+
+export interface IExplainedBadgeProps {
+  /** The full explanation. Shown on hover or focus, and read out as part of
+   *  the pill, so it must be a sentence rather than a label. */
+  msg: string;
+  variant: BadgeVariant;
+}
+
+/**
+ * A badge whose explanation is reachable by keyboard, touch and screen reader.
+ *
+ * A bare `title` opens on neither keyboard nor touch and readers expose it
+ * inconsistently (#699). The tooltip mounts only while hovered or focused, so
+ * the message also rides inside the pill as hidden text: a reader in browse
+ * mode would otherwise never meet it at all.
+ */
+const ExplainedBadge: React.FC<PropsWithChildren<IExplainedBadgeProps>> = ({
+  msg,
+  variant,
+  children,
+}) => (
+  <Tooltip msg={msg} focusable>
+    <BadgePill $variant={variant}>
+      {children}
+      <VisuallyHidden>{`, ${msg}`}</VisuallyHidden>
+    </BadgePill>
+  </Tooltip>
+);
+
+export default ExplainedBadge;

--- a/src/components/DataList/__tests__/ExplainedBadge.test.tsx
+++ b/src/components/DataList/__tests__/ExplainedBadge.test.tsx
@@ -1,0 +1,101 @@
+import theme from '@/styles/theme';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('@/assets/help', () => ({
+  IconHelp: () => null,
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import ExplainedBadge from '../ExplainedBadge';
+
+const MSG = 'This asset has a KDA fee pool.';
+
+const renderBadge = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <ExplainedBadge variant="accent" msg={MSG}>
+        Fee Pool
+      </ExplainedBadge>
+    </ThemeProvider>,
+  );
+
+describe('ExplainedBadge', () => {
+  it('shows the label', () => {
+    const { container } = renderBadge();
+    expect(container.textContent).toContain('Fee Pool');
+  });
+
+  it('reaches the keyboard, where a title attribute never did', () => {
+    const { container } = renderBadge();
+    const trigger = container.querySelector(
+      '[data-tooltip-anchor]',
+    ) as HTMLElement;
+
+    expect(trigger).not.toBeNull();
+    expect(trigger.tabIndex).toBe(0);
+  });
+
+  it('carries the whole explanation as text, not only in a tooltip', () => {
+    const { container } = renderBadge();
+    // The tooltip mounts only while hovered or focused, so a reader in browse
+    // mode meets the message only through this copy.
+    expect(container.textContent).toContain(MSG);
+  });
+
+  // The opposite of the two above: the explanation must not be painted next to
+  // the label, which is what makes it safe to carry inline.
+  it('does not show the explanation visually', () => {
+    const { container } = renderBadge();
+    const hidden = container.querySelector('[class*="VisuallyHidden"]');
+
+    expect(hidden).not.toBeNull();
+    expect(hidden?.textContent).toContain(MSG);
+    // The visible label must not have absorbed it.
+    const label = container.querySelector('[class*="BadgePill"]');
+    expect(label?.firstChild?.textContent).toBe('Fee Pool');
+  });
+
+  it('does not leave the explanation in a title attribute', () => {
+    const { container } = renderBadge();
+    expect(container.querySelector('[title]')).toBeNull();
+  });
+});

--- a/src/components/DataList/styles.ts
+++ b/src/components/DataList/styles.ts
@@ -86,6 +86,9 @@ export const focusRing = css`
 `;
 
 export const VisuallyHidden = styled.span`
+  /* Readers get the rendered text: inheriting the badge's uppercase handed
+     them whole sentences in caps, which VoiceOver spells out. */
+  text-transform: none;
   position: absolute;
   width: 1px;
   height: 1px;

--- a/src/components/NonFungileITO/index.tsx
+++ b/src/components/NonFungileITO/index.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { useExtension } from '@/contexts/extension';
 import { Transaction } from '@klever/connect';
 import { useTranslation } from 'next-i18next';

--- a/src/components/Tabs/Holders/MobileCard.tsx
+++ b/src/components/Tabs/Holders/MobileCard.tsx
@@ -5,6 +5,7 @@ import { IAsset, IBalance } from '@/types';
 import { formatAmount } from '@/utils/formatFunctions';
 import { parseAddress } from '@/utils/parseValues';
 import { useTranslation } from 'next-i18next';
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import CopyAction from '@/components/DataList/CopyAction';
 import {
   AddressLink,
@@ -73,12 +74,17 @@ const HoldersMobileCard: React.FC<IHoldersMobileCardProps> = ({
           {parseAddress(address, 12)}
         </AddressLink>
         {isVoid && (
-          <BadgePill $variant="void">{t('assets:Overview.Void')}</BadgePill>
+          <ExplainedBadge variant="void" msg={t('assets:Holders.VoidTooltip')}>
+            {t('assets:Overview.Void')}
+          </ExplainedBadge>
         )}
         {isContract && (
-          <BadgePill $variant="contract">
+          <ExplainedBadge
+            variant="contract"
+            msg={t('assets:Holders.ContractTooltip')}
+          >
             {t('assets:Holders.Contract')}
-          </BadgePill>
+          </ExplainedBadge>
         )}
         <RowActions>
           <CopyAction

--- a/src/components/Tabs/Holders/index.tsx
+++ b/src/components/Tabs/Holders/index.tsx
@@ -1,4 +1,5 @@
 import { isValidContractAddress } from '@klever/connect';
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import Filter, { IFilter } from '@/components/Filter';
 import Table, { ITable } from '@/components/Table';
 import api from '@/services/api';
@@ -164,20 +165,20 @@ const Holders: React.FC<IHolders> = ({ asset }) => {
               {parseAddress(address, 20)}
             </AddressLink>
             {isVoid && (
-              <BadgePill
-                $variant="void"
-                title={t('assets:Holders.VoidTooltip')}
+              <ExplainedBadge
+                variant="void"
+                msg={t('assets:Holders.VoidTooltip')}
               >
                 {t('assets:Overview.Void')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             {isContract && (
-              <BadgePill
-                $variant="contract"
-                title={t('assets:Holders.ContractTooltip')}
+              <ExplainedBadge
+                variant="contract"
+                msg={t('assets:Holders.ContractTooltip')}
               >
                 {t('assets:Holders.Contract')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             <RowActions>
               <CopyAction

--- a/src/components/Tabs/Transactions/index.tsx
+++ b/src/components/Tabs/Transactions/index.tsx
@@ -4,7 +4,7 @@ import TransactionsFilters from '@/components/TransactionsFilters';
 import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
 import { TransactionsTableWrapper } from '@/components/TransactionsList/styles';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
-import { transactionRowSections } from '@/pages/transactions';
+import { useTransactionRowSections } from '@/pages/transactions';
 import { IInnerTableProps } from '@/types/index';
 import React from 'react';
 
@@ -19,10 +19,11 @@ const Transactions: React.FC<PropsWithChildren<ITransactionsProps>> = props => {
   // account. It was the only one of the four call sites that did, which is
   // why the other three rendered a heading short.
   const header = useTransactionHeaders();
+  const rowSections = useTransactionRowSections();
 
   const tableProps: ITable = {
     ...transactionTableProps,
-    rowSections: transactionRowSections,
+    rowSections,
     header,
     type: 'transactions',
     Filters: TransactionsFilters,

--- a/src/components/Tooltip/__tests__/index.test.tsx
+++ b/src/components/Tooltip/__tests__/index.test.tsx
@@ -7,6 +7,12 @@ import { ThemeProvider } from 'styled-components';
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+// The bare `<Tooltip msg=... />` path renders this SVG import, which Jest
+// resolves to an object rather than a component.
+jest.mock('@/assets/help', () => ({
+  IconHelp: () => null,
+}));
+
 jest.mock('react-dom', () => {
   const actual = jest.requireActual('react-dom');
   const client = jest.requireActual('react-dom/client');
@@ -102,5 +108,50 @@ describe('Tooltip hover dismissal', () => {
     ).toBe(removesBefore);
 
     removeSpy.mockRestore();
+  });
+});
+
+describe('Tooltip trigger and anchor', () => {
+  const wrap = (ui: React.ReactNode) => (
+    <ThemeProvider theme={theme}>{ui}</ThemeProvider>
+  );
+
+  it('renders children as the trigger', () => {
+    const { container } = render(
+      wrap(
+        <Tooltip msg="explanation">
+          <span data-testid="own-trigger">icon</span>
+        </Tooltip>,
+      ),
+    );
+
+    expect(container.querySelector('[data-testid="own-trigger"]')).not.toBeNull();
+  });
+
+  // The opposite of the test above: without a trigger the built-in help icon
+  // still stands in, which is what every bare `<Tooltip msg=... />` relies on.
+  it('falls back to the built-in icon when given neither children nor Component', () => {
+    const { container } = render(wrap(<Tooltip msg="explanation" />));
+
+    expect(container.querySelector('[data-testid="own-trigger"]')).toBeNull();
+    expect(container.querySelector('.button-tooltip')).not.toBeNull();
+  });
+
+  it('gives each instance its own anchor, so one does not bind the others', () => {
+    const { container } = render(
+      wrap(
+        <>
+          <Tooltip msg="first" />
+          <Tooltip msg="second" />
+        </>,
+      ),
+    );
+
+    const anchors = [...container.querySelectorAll('[data-tooltip-anchor]')].map(
+      node => node.getAttribute('data-tooltip-anchor'),
+    );
+
+    expect(anchors).toHaveLength(2);
+    expect(new Set(anchors).size).toBe(2);
   });
 });

--- a/src/components/Tooltip/__tests__/index.test.tsx
+++ b/src/components/Tooltip/__tests__/index.test.tsx
@@ -13,6 +13,13 @@ jest.mock('@/assets/help', () => ({
   IconHelp: () => null,
 }));
 
+// react-tooltip renders null in jsdom (no real anchor/portal), which made the
+// shown and suppressed states indistinguishable to any DOM assertion. The mock
+// leaves a marker so the render condition itself becomes testable.
+jest.mock('react-tooltip', () => ({
+  Tooltip: () => <div data-testid="tip-body" />,
+}));
+
 jest.mock('react-dom', () => {
   const actual = jest.requireActual('react-dom');
   const client = jest.requireActual('react-dom/client');
@@ -135,6 +142,33 @@ describe('Tooltip trigger and anchor', () => {
 
     expect(container.querySelector('[data-testid="own-trigger"]')).toBeNull();
     expect(container.querySelector('.button-tooltip')).not.toBeNull();
+  });
+
+  // The changed condition's third arm: a trigger with a message under the
+  // threshold suppresses the tooltip entirely.
+
+  it('renders the tooltip when the message clears minMsgLength', () => {
+    const { container } = render(
+      wrap(
+        <Tooltip msg="long enough" minMsgLength={5}>
+          <span>icon</span>
+        </Tooltip>,
+      ),
+    );
+
+    expect(container.querySelector('[data-testid="tip-body"]')).not.toBeNull();
+  });
+
+  it('renders no tooltip when the message is under minMsgLength', () => {
+    const { container } = render(
+      wrap(
+        <Tooltip msg="ok" minMsgLength={5}>
+          <span>icon</span>
+        </Tooltip>,
+      ),
+    );
+
+    expect(container.querySelector('[data-testid="tip-body"]')).toBeNull();
   });
 
   it('gives each instance its own anchor, so one does not bind the others', () => {

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,11 +1,16 @@
 import { PropsWithChildren } from 'react';
 import { IconHelp } from '@/assets/help';
 import { ICustomStyles } from '@/types/index';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import { StyledTooltip, ToolTipSpan } from './styles';
 
 interface ITooltipProps {
   msg: string;
+  /**
+   * @deprecated Pass the trigger as children instead. Call sites hand over a
+   * fresh arrow per render, which is a fresh component type, so React remounts
+   * the trigger on every render.
+   */
   Component?: React.FC<PropsWithChildren>;
   customStyles?: ICustomStyles;
   minMsgLength?: number;
@@ -22,12 +27,17 @@ interface ITooltipProps {
 const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
   msg,
   Component,
+  children,
   customStyles,
   minMsgLength = 0,
   maxVw,
   focusable = false,
 }) => {
   const [displayMessage, setDisplayMessage] = useState(false);
+  // Every instance used to anchor on the shared `.button-tooltip` class, so
+  // each one bound every trigger on the page. This scopes it to its own.
+  const anchorId = useId();
+  const trigger = children ?? (Component ? <Component /> : null);
   const parsedMsgs = msg.split('\n');
 
   // WCAG 1.4.13: content shown on hover or focus must be dismissible without
@@ -46,6 +56,7 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
   return (
     <ToolTipSpan
       className="button-tooltip"
+      data-tooltip-anchor={anchorId}
       onMouseOver={() => setDisplayMessage(true)}
       onMouseLeave={() => setDisplayMessage(false)}
       // The focused-trigger path: same dismissal, plus it stops propagation
@@ -64,16 +75,10 @@ const Tooltip: React.FC<PropsWithChildren<ITooltipProps>> = ({
       })}
       maxVw={maxVw}
     >
-      {Component ? (
-        <div>
-          <Component />
-        </div>
-      ) : (
-        <IconHelp>button</IconHelp>
-      )}
-      {((Component && msg.length > minMsgLength) || !Component) && (
+      {trigger ? <div>{trigger}</div> : <IconHelp>button</IconHelp>}
+      {((trigger && msg.length > minMsgLength) || !trigger) && (
         <StyledTooltip
-          anchorSelect=".button-tooltip"
+          anchorSelect={`[data-tooltip-anchor="${anchorId}"]`}
           displayMsg={displayMessage}
           place={customStyles?.place || 'top'}
           delayShow={customStyles?.delayShow || 300}

--- a/src/components/TransactionContractComponents/index.tsx
+++ b/src/components/TransactionContractComponents/index.tsx
@@ -1439,6 +1439,12 @@ export const Claim: React.FC<PropsWithChildren<IIndexedContract>> = ({
   const claimReceipts = findReceipts(filteredReceipts, 17) as
     | IClaimReceipt[]
     | undefined;
+  // Resolved for every receipt at once, at component level. Called inside the
+  // map below it added two hook slots per element, so two claims with a
+  // different receipt count rendered a different number of hooks.
+  const claimPrecisions = usePrecision(
+    (claimReceipts ?? []).map(receipt => receipt?.assetIdReceived || 'KLV'),
+  );
 
   return (
     <>
@@ -1470,12 +1476,11 @@ export const Claim: React.FC<PropsWithChildren<IIndexedContract>> = ({
               </span>
               <FrozenContainer>
                 {claimReceipts.map((claimReceipt, index) => {
-                  const precision = usePrecision(
-                    claimReceipt?.assetIdReceived || 'KLV',
-                  );
+                  const assetId = claimReceipt?.assetIdReceived || 'KLV';
+                  const precision = claimPrecisions[assetId.split('/')[0]] ?? 0;
 
                   return (
-                    <div>
+                    <div key={`${assetId}-${index}`}>
                       {toLocaleFixed(
                         claimReceipt?.amount / 10 ** precision,
                         precision,
@@ -2698,6 +2703,12 @@ export const SmartContract: React.FC<PropsWithChildren<IIndexedContract>> = ({
     parameter?.address ||
     '';
 
+  // Same reason as the claim receipts above: one call at component level, not
+  // one per call value, so the hook count does not track the array length.
+  const callValuePrecisions = usePrecision(
+    (parameter?.callValue || []).map(value => String(value?.asset || 'KLV')),
+  );
+
   return (
     <>
       <Row>
@@ -2727,9 +2738,9 @@ export const SmartContract: React.FC<PropsWithChildren<IIndexedContract>> = ({
             <BalanceContainer>
               <NetworkParamsContainer>
                 {parameter?.callValue?.map(value => {
-                  const assetPrecision = usePrecision(
-                    String(value?.asset || 'KLV'),
-                  );
+                  const assetId = String(value?.asset || 'KLV');
+                  const assetPrecision =
+                    callValuePrecisions[assetId.split('/')[0]] ?? 0;
                   return Object.entries(value).map(([key, val]) => {
                     const formattedValue =
                       key === 'value'

--- a/src/components/TransactionDetails/TokenOperations.tsx
+++ b/src/components/TransactionDetails/TokenOperations.tsx
@@ -68,7 +68,7 @@ const copyStyle = {
 const TokenOperations: React.FC<Props> = ({ receipts }) => {
   const [expanded, setExpanded] = useState(false);
 
-  const operations = (receipts || []).filter((r: any) =>
+  const operations = (receipts ?? []).filter((r: any) =>
     ['Transfer'].includes(r.typeString),
   );
 

--- a/src/components/TransactionDetails/TokenOperations.tsx
+++ b/src/components/TransactionDetails/TokenOperations.tsx
@@ -68,13 +68,9 @@ const copyStyle = {
 const TokenOperations: React.FC<Props> = ({ receipts }) => {
   const [expanded, setExpanded] = useState(false);
 
-  if (!receipts || receipts.length === 0) return null;
-
-  const operations = receipts.filter((r: any) =>
+  const operations = (receipts || []).filter((r: any) =>
     ['Transfer'].includes(r.typeString),
   );
-
-  if (!operations.length) return null;
 
   const assetIdsToSearch = Array.from(
     new Set(
@@ -88,7 +84,11 @@ const TokenOperations: React.FC<Props> = ({ receipts }) => {
     ),
   );
 
+  // Above the early return on purpose: a transaction with no transfer receipts
+  // used to return before this line, so the hook count depended on the data.
   const precisions = usePrecision(assetIdsToSearch as string[]);
+
+  if (!operations.length) return null;
 
   const visible = expanded ? operations : operations.slice(0, 2);
 

--- a/src/components/TransactionForms/CustomForms/utils/index.ts
+++ b/src/components/TransactionForms/CustomForms/utils/index.ts
@@ -3,7 +3,6 @@ import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 import { cleanEmptyValues } from '../../FormInput';
 import { Pack, PackInfo, WhitelistInfo } from './types';
 
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export const parseSplitRoyalties = (data: any): void => {
   if (!data.royalties) {
     return;

--- a/src/components/TransactionsList/rowDetails.ts
+++ b/src/components/TransactionsList/rowDetails.ts
@@ -109,7 +109,6 @@ const FUNCTION_NAME_LIMIT = 40;
 const readFunctionName = (data?: string[]): string =>
   hexToString(data?.[0] || '')
     .split('@')[0]
-    // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
     .slice(0, FUNCTION_NAME_LIMIT);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback } from 'react';
+import { PropsWithChildren } from 'react';
 import ContextProviders from '@/components/ContextProviders';
 import { appWithTranslation, SSRConfig } from 'next-i18next';
 import App from 'next/app';
@@ -67,17 +67,6 @@ const MyApp = ({ Component, pageProps, initialDarkTheme }: AppProps) => {
 
   const isTargetDate = currentDate >= startDate && currentDate <= endDate;
 
-  const RenderedComponent: React.FC = useCallback(() => {
-    if (isTargetDate) {
-      return <Maintenance />;
-    }
-    return (
-      <LayoutWrapper>
-        <Component {...pageProps} />
-      </LayoutWrapper>
-    );
-  }, [isTargetDate, pageProps]);
-
   return (
     <>
       <Head>
@@ -88,7 +77,16 @@ const MyApp = ({ Component, pageProps, initialDarkTheme }: AppProps) => {
       </Head>
       <InternalThemeProvider initialDarkTheme={initialDarkTheme}>
         <ContextProviders>
-          <RenderedComponent />
+          {/* Rendered inline, not through a component built per render: a new
+              function identity is a new component type, so React tore down the
+              whole tree (layout, page and footers) on every navigation. */}
+          {isTargetDate ? (
+            <Maintenance />
+          ) : (
+            <LayoutWrapper>
+              <Component {...pageProps} />
+            </LayoutWrapper>
+          )}
           <GlobalStyle />
           <NProgress />
         </ContextProviders>

--- a/src/pages/api/__tests__/asset-info.test.ts
+++ b/src/pages/api/__tests__/asset-info.test.ts
@@ -13,7 +13,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 process.env.DEFAULT_KLEVERSCAN_API_URL = 'https://info.example.com';
 process.env.DEFAULT_KLEVERSCAN_API_KEY = 'test-key';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+ 
 const handler = require('../asset-info').default as (
   req: NextApiRequest,
   res: NextApiResponse,

--- a/src/pages/api/__tests__/asset-info.test.ts
+++ b/src/pages/api/__tests__/asset-info.test.ts
@@ -13,7 +13,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 process.env.DEFAULT_KLEVERSCAN_API_URL = 'https://info.example.com';
 process.env.DEFAULT_KLEVERSCAN_API_KEY = 'test-key';
 
- 
+
 const handler = require('../asset-info').default as (
   req: NextApiRequest,
   res: NextApiResponse,

--- a/src/pages/asset/[asset].tsx
+++ b/src/pages/asset/[asset].tsx
@@ -82,7 +82,9 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
       setQueryAndRouter(initialQueryState, router);
       setSelectedTab((router.query.tab as string) || getTableHeaders()[0]);
     }
-  }, [router.isReady]);
+    // Also keyed on the asset: the page persists across asset-to-asset
+    // navigation now, and a kept Holders tab does not exist on an SFT.
+  }, [router.isReady, router.query.asset]);
 
   const requestTransactions = async (page: number, limit: number) => {
     const newQuery = {
@@ -158,6 +160,7 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
     <AssetPageContainer>
       <AssetSummary asset={asset} ITO={ITO} />
       <AssetTabs
+        key={String(router.query.asset)}
         asset={asset}
         ITO={ITO}
         assetPool={assetPool}

--- a/src/pages/asset/[asset].tsx
+++ b/src/pages/asset/[asset].tsx
@@ -27,7 +27,7 @@ import React, {
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import nextI18nextConfig from '../../../next-i18next.config';
-import { transactionRowSections } from '../transactions';
+import { useTransactionRowSections } from '../transactions';
 
 const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
   const router = useRouter();
@@ -108,10 +108,12 @@ const Asset: React.FC<PropsWithChildren<IAssetPage>> = ({}) => {
     };
   };
 
+  const rowSections = useTransactionRowSections();
+
   const tableProps: ITable = {
     type: 'transactions',
     header: transactionHeaders,
-    rowSections: transactionRowSections,
+    rowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
     Filters: TransactionsFilters,

--- a/src/pages/asset/[asset]/[nonce].tsx
+++ b/src/pages/asset/[asset]/[nonce].tsx
@@ -6,7 +6,7 @@ import { ITable } from '@/components/Table';
 import TransactionsMobileCard from '@/components/TransactionsList/MobileCard';
 import { useTransactionHeaders } from '@/components/TransactionsList/useTransactionHeaders';
 import TransactionsFilters from '@/components/TransactionsFilters';
-import { transactionRowSections } from '@/pages/transactions';
+import { useTransactionRowSections } from '@/pages/transactions';
 import api from '@/services/api';
 import { requestNonceDetails } from '@/services/requests/asset/nonce';
 import { Container, Header, SpacedContainer } from '@/styles/common';
@@ -59,10 +59,12 @@ const AssetNonce: React.FC<PropsWithChildren> = () => {
     };
   };
 
+  const rowSections = useTransactionRowSections();
+
   const tableProps: ITable = {
     type: 'transactions',
     header: transactionHeaders,
-    rowSections: transactionRowSections,
+    rowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactions(page, limit),
     Filters: TransactionsFilters,

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -1,4 +1,5 @@
 import { Assets as Icon } from '@/assets/title-icons';
+import ExplainedBadge from '@/components/DataList/ExplainedBadge';
 import AssetsPools from '@/components/AssetsPools';
 import {
   APR_CONFIGURED_TOOLTIP,
@@ -220,27 +221,36 @@ const Assets: React.FC<PropsWithChildren> = () => {
               verified={verified}
             />
             {assetType === 'NonFungible' && (
-              <BadgePill $variant="neutral" title={t(ASSET_BADGE_TOOLTIPS.nft)}>
+              <ExplainedBadge
+                variant="neutral"
+                msg={t(ASSET_BADGE_TOOLTIPS.nft)}
+              >
                 {t('assets:List.Nft')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             {assetType === 'SemiFungible' && (
-              <BadgePill $variant="neutral" title={t(ASSET_BADGE_TOOLTIPS.sft)}>
+              <ExplainedBadge
+                variant="neutral"
+                msg={t(ASSET_BADGE_TOOLTIPS.sft)}
+              >
                 {t('assets:List.Sft')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             {attributes?.isPaused && (
-              <BadgePill
-                $variant="warning"
-                title={t(ASSET_BADGE_TOOLTIPS.paused)}
+              <ExplainedBadge
+                variant="warning"
+                msg={t(ASSET_BADGE_TOOLTIPS.paused)}
               >
                 {t('assets:List.Paused')}
-              </BadgePill>
+              </ExplainedBadge>
             )}
             {hasKdaPool && (
-              <BadgePill $variant="accent" title={t(ASSET_BADGE_TOOLTIPS.pool)}>
+              <ExplainedBadge
+                variant="accent"
+                msg={t(ASSET_BADGE_TOOLTIPS.pool)}
+              >
                 Fee Pool
-              </BadgePill>
+              </ExplainedBadge>
             )}
             <RowActions>
               <CopyAction
@@ -357,9 +367,9 @@ const Assets: React.FC<PropsWithChildren> = () => {
               </RewardsMuted>
             )}
             {rewards.kind === 'fpr' && (
-              <BadgePill $variant="neutral" title={t(FPR_TOOLTIP)}>
+              <ExplainedBadge variant="neutral" msg={t(FPR_TOOLTIP)}>
                 FPR
-              </BadgePill>
+              </ExplainedBadge>
             )}
             {rewards.kind === 'none' && (
               <RewardsMuted>{t('assets:List.NotAvailable')}</RewardsMuted>

--- a/src/pages/block/[block].tsx
+++ b/src/pages/block/[block].tsx
@@ -79,7 +79,10 @@ const Block: React.FC<PropsWithChildren<IBlockPage>> = ({ block }) => {
     setSelectedTab((router.query.tab as string) || tableHeaders[0]);
     setSelectedCard((router.query.card as string) || cardHeaders[0]);
     setQueryAndRouter({ ...router.query }, router);
-  }, [router.isReady]);
+    // Also keyed on the block: prev/next keeps the page mounted now, and the
+    // shared Tabs highlight resets on the query change while this state did
+    // not, splitting the highlight from the rendered content.
+  }, [router.isReady, router.query.block]);
 
   const BlockNavigation: React.FC<PropsWithChildren> = () => {
     return (

--- a/src/pages/marketplace/[marketplace].tsx
+++ b/src/pages/marketplace/[marketplace].tsx
@@ -70,7 +70,8 @@ const MarketplaceDetails: React.FC<
     serversideMarketplaceResponse.data.assets;
 
   const { data: buyCardsData, isFetching: buyCardsLoading } = useQuery({
-    queryKey: ['buycard', page],
+    // Same reason as the proposal key: the marketplace id decides the result.
+    queryKey: ['buycard', serversideMarketplace.id, page],
     queryFn: () => getBuyCards(serversideMarketplace.id, page),
     enabled: router?.isReady,
   });

--- a/src/pages/proposal/[number].tsx
+++ b/src/pages/proposal/[number].tsx
@@ -164,7 +164,9 @@ const ProposalDetails: React.FC<PropsWithChildren> = () => {
     queryFn: () => dataOverviewCall(),
   });
   const { data: proposal } = useQuery<IParsedProposal | undefined>({
-    queryKey: ['proposalsCall'],
+    // The proposal number belongs in the key: without it, navigating from one
+    // proposal to another reuses the first one's cached record.
+    queryKey: ['proposalsCall', router.query?.number],
     queryFn: () => dataProposalCall(router),
     enabled: !!router.isReady,
   });

--- a/src/pages/smart-contract/[address].tsx
+++ b/src/pages/smart-contract/[address].tsx
@@ -215,6 +215,7 @@ const SmartContractInvoke: React.FC = () => {
           return <EmptyState>Loading contract data...</EmptyState>;
         return contractInfo ? (
           <ContractSourceTab
+            key={contractAddress}
             contractAddress={contractAddress}
             contractInfo={contractInfo}
           />

--- a/src/pages/transaction/[hash].tsx
+++ b/src/pages/transaction/[hash].tsx
@@ -128,7 +128,6 @@ const Transaction: React.FC<PropsWithChildren<ITransactionPage>> = props => {
   // two transactions, so empty deps kept the previous transaction's precision.
   useEffect(() => {
     getPrecisionTransaction();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [kdaFee?.kda]);
 
   const overviewProps = {

--- a/src/pages/transaction/[hash].tsx
+++ b/src/pages/transaction/[hash].tsx
@@ -117,17 +117,21 @@ const Transaction: React.FC<PropsWithChildren<ITransactionPage>> = props => {
   );
   const StatusIcon = getStatusIcon(status);
 
-  const getPrecisionTransaction = async () => {
-    if (kdaFee) {
-      const precision = await getPrecision(kdaFee.kda);
-      setPrecisionTransaction(precision);
-    }
-  };
-
   // Keyed on the fee asset, not on mount: the page no longer remounts between
   // two transactions, so empty deps kept the previous transaction's precision.
+  // The active flag mirrors usePrecision: a slower earlier lookup must not
+  // overwrite the current transaction's answer.
   useEffect(() => {
+    if (!kdaFee) return;
+    let active = true;
+    const getPrecisionTransaction = async () => {
+      const precision = await getPrecision(kdaFee.kda);
+      if (active) setPrecisionTransaction(precision);
+    };
     getPrecisionTransaction();
+    return () => {
+      active = false;
+    };
   }, [kdaFee?.kda]);
 
   const overviewProps = {

--- a/src/pages/transaction/[hash].tsx
+++ b/src/pages/transaction/[hash].tsx
@@ -124,9 +124,12 @@ const Transaction: React.FC<PropsWithChildren<ITransactionPage>> = props => {
     }
   };
 
+  // Keyed on the fee asset, not on mount: the page no longer remounts between
+  // two transactions, so empty deps kept the previous transaction's precision.
   useEffect(() => {
     getPrecisionTransaction();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [kdaFee?.kda]);
 
   const overviewProps = {
     hash,

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -74,7 +74,8 @@ import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from 'next/link';
 import { NextRouter, useRouter } from 'next/router';
-import React, { PropsWithChildren } from 'react';
+import type { ParsedUrlQuery } from 'querystring';
+import React, { PropsWithChildren, useCallback } from 'react';
 import nextI18nextConfig from '../../../next-i18next.config';
 
 interface IRequestTxQuery {
@@ -273,7 +274,10 @@ export const getCustomFields = (
   return filteredSectionsResult;
 };
 
-export const transactionRowSections = (props: ITransaction): IRowSection[] => {
+export const transactionRowSections = (
+  props: ITransaction,
+  routeState?: { pathname?: string; query?: ParsedUrlQuery },
+): IRowSection[] => {
   const {
     hash,
     blockNum,
@@ -287,7 +291,6 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
     precision,
     data,
   } = props;
-  const router = useRouter();
 
   const contractType = contractTypes(contract);
   // The counterparty, the second type badge and the contract-mark tooltip,
@@ -303,8 +306,8 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
 
   const inOrOut = valueDirection({
     account:
-      typeof router?.query?.account === 'string'
-        ? router.query.account
+      typeof routeState?.query?.account === 'string'
+        ? routeState.query.account
         : undefined,
     sender,
     contractType,
@@ -542,8 +545,24 @@ export const transactionRowSections = (props: ITransaction): IRowSection[] => {
 
   // Ordered by the column list rather than assembled here, so the cells and
   // the headings above them come from the same decision.
-  return getTransactionColumns({ showInOut: showsInOut(router) }).map(
+  return getTransactionColumns({ showInOut: showsInOut(routeState ?? {}) }).map(
     column => sectionByColumn[column.key],
+  );
+};
+
+/**
+ * Companion to `useTransactionHeaders`: the account that decides the In/Out
+ * direction comes from the URL, and a row builder is called by the table
+ * rather than mounted, so it cannot read a hook itself.
+ */
+export const useTransactionRowSections = (): ((
+  props: ITransaction,
+) => IRowSection[]) => {
+  const { pathname, query } = useRouter();
+
+  return useCallback(
+    (props: ITransaction) => transactionRowSections(props, { pathname, query }),
+    [pathname, query],
   );
 };
 
@@ -551,11 +570,12 @@ const Transactions: React.FC<PropsWithChildren> = () => {
   const router = useRouter();
   const { t } = useTranslation(['common', 'transactions']);
   const header = useTransactionHeaders();
+  const rowSections = useTransactionRowSections();
 
   const tableProps: ITable = {
     type: 'transactions',
     header,
-    rowSections: transactionRowSections,
+    rowSections,
     dataName: 'transactions',
     request: (page, limit) => requestTransactionsDefault(page, limit, router),
     Filters: TransactionsFilters,

--- a/src/pages/validator/[hash].tsx
+++ b/src/pages/validator/[hash].tsx
@@ -92,18 +92,27 @@ const Validator: React.FC<PropsWithChildren<IValidatorPage>> = () => {
   const { extensionInstalled, walletAddress } = useExtension();
 
   useEffect(() => {
-    if (router.isReady) {
-      const requestValidator = async () => {
-        const res = await api.get({
-          route: `validator/${encodeURIComponent(String(router.query.hash))}`,
-        });
-        if (!res.error || res.error === '') {
-          setValidator(res.data.validator);
-        }
-      };
-      requestValidator();
-    }
-  }, [router.isReady]);
+    if (!router.isReady) return;
+    let active = true;
+    // Keyed on the hash: the page no longer remounts between validators, so a
+    // mount-only fetch kept showing the previous record under the new URL.
+    // The reset gives the incoming validator its loading state, not A's data.
+    setValidator(null);
+    setImgError(false);
+    const requestValidator = async () => {
+      const res = await api.get({
+        route: `validator/${encodeURIComponent(String(router.query.hash))}`,
+      });
+      if (!active) return;
+      if (!res.error || res.error === '') {
+        setValidator(res.data.validator);
+      }
+    };
+    requestValidator();
+    return () => {
+      active = false;
+    };
+  }, [router.isReady, router.query.hash]);
 
   const handleLogoError = () => {
     setImgError(true);

--- a/src/utils/contractValidator/__tests__/abiVersions.test.ts
+++ b/src/utils/contractValidator/__tests__/abiVersions.test.ts
@@ -1,9 +1,9 @@
 import { TextDecoder, TextEncoder } from 'util';
 
 // jsdom doesn't expose these globally; the util (and this test) use them.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 (global as any).TextEncoder = (global as any).TextEncoder || TextEncoder;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 (global as any).TextDecoder = (global as any).TextDecoder || TextDecoder;
 
 import { readBuildVersionsFromZip } from '../abiVersions';
@@ -97,7 +97,7 @@ function fileFrom(bytes: Uint8Array): File {
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength,
   );
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+   
   return { arrayBuffer: async () => ab } as any as File;
 }
 

--- a/src/utils/contractValidator/__tests__/abiVersions.test.ts
+++ b/src/utils/contractValidator/__tests__/abiVersions.test.ts
@@ -1,9 +1,9 @@
 import { TextDecoder, TextEncoder } from 'util';
 
 // jsdom doesn't expose these globally; the util (and this test) use them.
- 
+
 (global as any).TextEncoder = (global as any).TextEncoder || TextEncoder;
- 
+
 (global as any).TextDecoder = (global as any).TextDecoder || TextDecoder;
 
 import { readBuildVersionsFromZip } from '../abiVersions';
@@ -97,7 +97,7 @@ function fileFrom(bytes: Uint8Array): File {
     bytes.byteOffset,
     bytes.byteOffset + bytes.byteLength,
   );
-   
+
   return { arrayBuffer: async () => ab } as any as File;
 }
 

--- a/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
+++ b/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
@@ -119,6 +119,25 @@ describe('usePackInfoPrecisions', () => {
     expect(mockGetPrecision).toHaveBeenCalledWith([]);
   });
 
+  // The reset guard: pending or failed, the old packs' precisions must not
+  // sit under the new packs.
+  it('clears the previous answer while a new lookup is unresolved', async () => {
+    mockGetPrecision
+      .mockResolvedValueOnce({ KLV: 6 })
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    render(<Harness initial={packsFor('KLV')} />);
+    await flush();
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":6}');
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    expect(screen.getByTestId('out').textContent).toBe('{"DVK-34ZH":0}');
+  });
+
   it('lets a newer answer stand when an older one resolves late', async () => {
     let resolveFirst: (v: unknown) => void = () => undefined;
     mockGetPrecision

--- a/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
+++ b/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
@@ -138,6 +138,26 @@ describe('usePackInfoPrecisions', () => {
     expect(screen.getByTestId('out').textContent).toBe('{"DVK-34ZH":0}');
   });
 
+  it('keeps the zero map and stays quiet when the lookup rejects', async () => {
+    const unhandled: unknown[] = [];
+    const track = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', track);
+
+    mockGetPrecision.mockRejectedValueOnce(new Error('api down'));
+    render(<Harness initial={packsFor('KLV')} />);
+    await flush();
+    // Two macrotask ticks: node reports an unhandled rejection only after
+    // the microtask queue has drained past it.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    process.off('unhandledRejection', track);
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":0}');
+    expect(unhandled).toHaveLength(0);
+  });
+
   it('lets a newer answer stand when an older one resolves late', async () => {
     let resolveFirst: (v: unknown) => void = () => undefined;
     mockGetPrecision

--- a/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
+++ b/src/utils/hooks/__tests__/usePackInfoPrecisions.test.tsx
@@ -1,0 +1,148 @@
+import { act, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Factory mock, never loading the real module: precisionFunctions reaches an
+// ESM chain Jest cannot transform.
+const mockGetPrecision = jest.fn();
+jest.mock('@/utils/precisionFunctions', () => ({
+  getPrecision: (...args: unknown[]) => mockGetPrecision(...args),
+}));
+
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import type { IPackInfo } from '@/types/contracts';
+import { usePackInfoPrecisions } from '../index';
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const packsFor = (...keys: string[]): IPackInfo[] =>
+  keys.map(key => ({ key, packs: [] }));
+
+/** Mirrors the ITO detail components: the packInfo prop changes when the
+ *  reader navigates from one transaction to another without a remount. */
+const Harness: React.FC<{ initial: IPackInfo[] }> = ({ initial }) => {
+  const [packInfo, setPackInfo] = useState(initial);
+  const [precisions] = usePackInfoPrecisions(packInfo);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setPackInfo(packsFor('DVK-34ZH'))}>
+        swap
+      </button>
+      <span data-testid="out">{JSON.stringify(precisions)}</span>
+    </div>
+  );
+};
+
+describe('usePackInfoPrecisions', () => {
+  beforeEach(() => {
+    mockGetPrecision.mockReset();
+  });
+
+  it('resolves the precisions for the mount-time packs', async () => {
+    mockGetPrecision.mockResolvedValue({ KLV: 6 });
+
+    render(<Harness initial={packsFor('KLV')} />);
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledWith(['KLV']);
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":6}');
+  });
+
+  // The defect being pinned: the ids were frozen inside the useState
+  // initializer, so a later packInfo never reached the effect.
+  it('re-resolves when the packs change', async () => {
+    mockGetPrecision
+      .mockResolvedValueOnce({ KLV: 6 })
+      .mockResolvedValueOnce({ 'DVK-34ZH': 4 });
+
+    render(<Harness initial={packsFor('KLV')} />);
+    await flush();
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledTimes(2);
+    expect(mockGetPrecision).toHaveBeenLastCalledWith(['DVK-34ZH']);
+    expect(screen.getByTestId('out').textContent).toBe('{"DVK-34ZH":4}');
+  });
+
+  it('asks nothing for an empty pack list', async () => {
+    mockGetPrecision.mockResolvedValue({});
+
+    render(<Harness initial={[]} />);
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledWith([]);
+  });
+
+  it('lets a newer answer stand when an older one resolves late', async () => {
+    let resolveFirst: (v: unknown) => void = () => undefined;
+    mockGetPrecision
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ 'DVK-34ZH': 4 });
+
+    render(<Harness initial={packsFor('KLV')} />);
+    await flush();
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    await act(async () => {
+      resolveFirst({ KLV: 6 });
+    });
+    await flush();
+
+    expect(screen.getByTestId('out').textContent).toBe('{"DVK-34ZH":4}');
+  });
+});

--- a/src/utils/hooks/__tests__/usePrecision.test.tsx
+++ b/src/utils/hooks/__tests__/usePrecision.test.tsx
@@ -155,7 +155,31 @@ describe('usePrecision', () => {
     });
     await flush();
 
-    expect(screen.getByTestId('out').textContent).toBe('0');
+    // A zero MAP, not the number 0: consumers index the array overload's
+    // result, and 10 ** undefined renders NaN.
+    expect(screen.getByTestId('out').textContent).toBe('{"KFI":0}');
+  });
+
+  // The failure path: a rejected lookup settles on the reset value and must
+  // not surface as an unhandled rejection.
+  it('keeps the zero map and stays quiet when the lookup rejects', async () => {
+    const unhandled: unknown[] = [];
+    const track = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', track);
+
+    mockGetPrecision.mockRejectedValueOnce(new Error('api down'));
+    render(<Harness initial={['KLV']} />);
+    await flush();
+    // Two macrotask ticks: node reports an unhandled rejection only after
+    // the microtask queue has drained past it.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    process.off('unhandledRejection', track);
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":0}');
+    expect(unhandled).toHaveLength(0);
   });
 
   it('lets a newer answer stand when an older one resolves late', async () => {

--- a/src/utils/hooks/__tests__/usePrecision.test.tsx
+++ b/src/utils/hooks/__tests__/usePrecision.test.tsx
@@ -139,6 +139,25 @@ describe('usePrecision', () => {
     expect(mockGetPrecision).toHaveBeenCalledTimes(1);
   });
 
+  // The reset guard: a pending or failed lookup must not leave the previous
+  // asset's precision under the new one.
+  it('clears the previous answer while a new lookup is unresolved', async () => {
+    mockGetPrecision
+      .mockResolvedValueOnce({ KLV: 6 })
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    render(<Harness initial={['KLV']} />);
+    await flush();
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":6}');
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    expect(screen.getByTestId('out').textContent).toBe('0');
+  });
+
   it('lets a newer answer stand when an older one resolves late', async () => {
     let resolveFirst: (v: unknown) => void = () => undefined;
     mockGetPrecision

--- a/src/utils/hooks/__tests__/usePrecision.test.tsx
+++ b/src/utils/hooks/__tests__/usePrecision.test.tsx
@@ -1,0 +1,153 @@
+import { act, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Factory mock, never loading the real module: precisionFunctions reaches
+// @/pages/transactions and from there an ESM chain Jest cannot transform.
+const mockGetPrecision = jest.fn();
+jest.mock('@/utils/precisionFunctions', () => ({
+  getPrecision: (...args: unknown[]) => mockGetPrecision(...args),
+}));
+
+// Same shim every component suite in this repo carries: this
+// testing-library version drives the removed ReactDOM.render API.
+jest.mock('react-dom', () => {
+  const actual = jest.requireActual('react-dom');
+  const client = jest.requireActual('react-dom/client');
+  const ReactLib = jest.requireActual('react');
+  const roots = new Map<
+    Element,
+    { render: (ui: React.ReactNode) => void; unmount: () => void }
+  >();
+
+  return {
+    ...actual,
+    render: (ui: React.ReactNode, container: Element) => {
+      let root = roots.get(container);
+      if (!root) {
+        root = client.createRoot(container);
+        roots.set(container, root);
+      }
+      ReactLib.act(() => {
+        root.render(ui);
+      });
+      return root;
+    },
+    unmountComponentAtNode: (container: Element) => {
+      const root = roots.get(container);
+      if (!root) return false;
+      ReactLib.act(() => {
+        root.unmount();
+      });
+      roots.delete(container);
+      return true;
+    },
+  };
+});
+
+import { usePrecision } from '../index';
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+/** Renders one asset list and can swap it, the way a detail page does when the
+ *  reader navigates from one record to another without the page remounting. */
+const Harness: React.FC<{ initial: string[] }> = ({ initial }) => {
+  const [ids, setIds] = useState(initial);
+  const precisions = usePrecision(ids);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIds(['KFI'])}>
+        swap
+      </button>
+      <button type="button" onClick={() => setIds([...ids])}>
+        rebuild
+      </button>
+      <span data-testid="out">{JSON.stringify(precisions)}</span>
+    </div>
+  );
+};
+
+describe('usePrecision', () => {
+  beforeEach(() => {
+    mockGetPrecision.mockReset();
+  });
+
+  it('resolves the precisions for the ids it was given', async () => {
+    mockGetPrecision.mockResolvedValue({ KLV: 6 });
+
+    render(<Harness initial={['KLV']} />);
+    await flush();
+
+    expect(screen.getByTestId('out').textContent).toBe('{"KLV":6}');
+  });
+
+  it('re-resolves when the asset ids change', async () => {
+    mockGetPrecision
+      .mockResolvedValueOnce({ KLV: 6 })
+      .mockResolvedValueOnce({ KFI: 8 });
+
+    render(<Harness initial={['KLV']} />);
+    await flush();
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('out').textContent).toBe('{"KFI":8}');
+  });
+
+  // The opposite of the test above: the fix keys on the ids, not on the array
+  // identity, so a caller rebuilding its list inline must not refetch forever.
+  it('does not re-resolve when the same ids arrive in a new array', async () => {
+    mockGetPrecision.mockResolvedValue({ KLV: 6 });
+
+    render(<Harness initial={['KLV']} />);
+    await flush();
+
+    await act(async () => {
+      screen.getByText('rebuild').click();
+    });
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a newer answer stand when an older one resolves late', async () => {
+    let resolveFirst: (v: unknown) => void = () => undefined;
+    mockGetPrecision
+      .mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ KFI: 8 });
+
+    render(<Harness initial={['KLV']} />);
+    await flush();
+
+    await act(async () => {
+      screen.getByText('swap').click();
+    });
+    await flush();
+
+    // The first request only now comes back, with the superseded asset.
+    await act(async () => {
+      resolveFirst({ KLV: 6 });
+    });
+    await flush();
+
+    expect(screen.getByTestId('out').textContent).toBe('{"KFI":8}');
+  });
+});

--- a/src/utils/hooks/__tests__/usePrecision.test.tsx
+++ b/src/utils/hooks/__tests__/usePrecision.test.tsx
@@ -76,9 +76,25 @@ const Harness: React.FC<{ initial: string[] }> = ({ initial }) => {
   );
 };
 
+const SingleHarness: React.FC = () => {
+  const precision = usePrecision('KLV');
+  return <span data-testid="single">{String(precision)}</span>;
+};
+
 describe('usePrecision', () => {
   beforeEach(() => {
     mockGetPrecision.mockReset();
+  });
+
+  // The other arm of the input type: a single id resolves to a number.
+  it('resolves a single string id to a number', async () => {
+    mockGetPrecision.mockResolvedValue(6);
+
+    render(<SingleHarness />);
+    await flush();
+
+    expect(mockGetPrecision).toHaveBeenCalledWith('KLV');
+    expect(screen.getByTestId('single').textContent).toBe('6');
   });
 
   it('resolves the precisions for the ids it was given', async () => {

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -47,12 +47,23 @@ export function usePrecision(
   const [precision, setPrecision] = useState<
     number | { [assetId: string]: number }
   >(0);
+  // Keyed on the ids themselves, not the array identity: callers build the list
+  // inline, so a reference dep would refetch every render. Empty deps used to be
+  // harmless only because the app remounted on every navigation.
+  const assetKey = Array.isArray(assetIds) ? assetIds.join(',') : assetIds;
   useEffect(() => {
+    let active = true;
     const precisionCall = async () => {
-      setPrecision(await getPrecision(assetIds));
+      const resolved = await getPrecision(assetIds);
+      // A slower earlier request must not overwrite a newer one's answer.
+      if (active) setPrecision(resolved);
     };
     precisionCall();
-  }, []);
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assetKey]);
   if (typeof precision === 'number') {
     return precision as number;
   } else {

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -52,6 +52,10 @@ export function usePrecision(
   const assetKey = Array.isArray(assetIds) ? assetIds.join(',') : assetIds;
   useEffect(() => {
     let active = true;
+    // Back to the initial value first: on a rejected lookup, and during the
+    // window before the new one resolves, the previous asset's precision must
+    // not scale the new asset's amounts.
+    setPrecision(0);
     const precisionCall = async () => {
       const resolved = await getPrecision(assetIds);
       // A slower earlier request must not overwrite a newer one's answer.
@@ -215,8 +219,11 @@ export const usePackInfoPrecisions = (
   const assetKey = packInfo.map(pack => pack.key).join(',');
   useEffect(() => {
     let active = true;
+    const ids = assetKey === '' ? [] : assetKey.split(',');
+    // Same reset as usePrecision: a rejected or still-pending lookup must not
+    // leave the previous packs' precisions under the new packs.
+    setPacksPrecision(Object.fromEntries(ids.map(id => [id, 0])));
     const getPacksPrecision = async () => {
-      const ids = assetKey === '' ? [] : assetKey.split(',');
       const precisions = await getPrecision(ids);
       if (active) setPacksPrecision(precisions);
     };

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-types */
 import Skeleton from '@/components/Skeleton';
 import api from '@/services/api';
 import { IAssetsResponse, IValidatorResponse } from '@/types';
@@ -62,7 +61,6 @@ export function usePrecision(
     return () => {
       active = false;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetKey]);
   if (typeof precision === 'number') {
     return precision as number;

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -205,27 +205,26 @@ type PackInfoHookResult = [
 export const usePackInfoPrecisions = (
   packInfo: IPackInfo[],
 ): PackInfoHookResult => {
-  const assetIds: string[] = [];
-  const getInitialPrecisions = () => {
-    const initialPrecisions: { [key: string]: number } = {};
-    for (let index = 0; index < packInfo.length; index++) {
-      assetIds.push(packInfo[index].key);
-      initialPrecisions[packInfo[index].key] = 0;
-    }
-    return initialPrecisions;
-  };
-
-  const [packsPrecision, setPacksPrecision] = useState<PacksPrecision>(
-    getInitialPrecisions(),
+  const [packsPrecision, setPacksPrecision] = useState<PacksPrecision>(() =>
+    Object.fromEntries(packInfo.map(pack => [pack.key, 0])),
   );
 
+  // Same treatment as usePrecision above: the ids used to be collected inside
+  // the useState initializer, so they were frozen at mount and the effect
+  // never saw a later packInfo.
+  const assetKey = packInfo.map(pack => pack.key).join(',');
   useEffect(() => {
+    let active = true;
     const getPacksPrecision = async () => {
-      const precisions = await getPrecision(assetIds);
-      setPacksPrecision(precisions);
+      const ids = assetKey === '' ? [] : assetKey.split(',');
+      const precisions = await getPrecision(ids);
+      if (active) setPacksPrecision(precisions);
     };
     getPacksPrecision();
-  }, []);
+    return () => {
+      active = false;
+    };
+  }, [assetKey]);
 
   return [packsPrecision, setPacksPrecision];
 };

--- a/src/utils/hooks/index.tsx
+++ b/src/utils/hooks/index.tsx
@@ -52,16 +52,24 @@ export function usePrecision(
   const assetKey = Array.isArray(assetIds) ? assetIds.join(',') : assetIds;
   useEffect(() => {
     let active = true;
-    // Back to the initial value first: on a rejected lookup, and during the
+    // Back to the initial shape first: on a rejected lookup, and during the
     // window before the new one resolves, the previous asset's precision must
-    // not scale the new asset's amounts.
-    setPrecision(0);
+    // not scale the new asset's amounts. The array overload resets to a map
+    // of zeros, keyed like getPrecision keys its result, because consumers
+    // index it and 10 ** undefined renders NaN.
+    setPrecision(
+      Array.isArray(assetIds)
+        ? Object.fromEntries(assetIds.map(id => [id.split('/')[0], 0]))
+        : 0,
+    );
     const precisionCall = async () => {
       const resolved = await getPrecision(assetIds);
       // A slower earlier request must not overwrite a newer one's answer.
       if (active) setPrecision(resolved);
     };
-    precisionCall();
+    // The reset above IS the failure fallback; without this catch every
+    // failed lookup is an unhandled rejection.
+    precisionCall().catch(() => undefined);
     return () => {
       active = false;
     };
@@ -227,7 +235,8 @@ export const usePackInfoPrecisions = (
       const precisions = await getPrecision(ids);
       if (active) setPacksPrecision(precisions);
     };
-    getPacksPrecision();
+    // Same reason as usePrecision: the zero map above is the fallback.
+    getPacksPrecision().catch(() => undefined);
     return () => {
       active = false;
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4160,6 +4160,11 @@ csstype@^3.0.10, csstype@^3.2.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+cypress-real-events@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.15.0.tgz#b84ed97455238139ac3d0c8f803991b30f22fc8a"
+  integrity sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==
+
 cypress@*, cypress@^13.15.2:
   version "13.17.0"
   resolved "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1392,7 +1392,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.39.2", "@eslint/js@^9.39.2":
+"@eslint/js@9.39.2":
   version "9.39.2"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz"
   integrity sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==
@@ -5044,6 +5044,17 @@ eslint-plugin-react-hooks@^7.0.0:
   version "7.0.1"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz"
   integrity sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==
+  dependencies:
+    "@babel/core" "^7.24.4"
+    "@babel/parser" "^7.24.4"
+    hermes-parser "^0.25.1"
+    zod "^3.25.0 || ^4.0.0"
+    zod-validation-error "^3.5.0 || ^4.0.0"
+
+eslint-plugin-react-hooks@^7.0.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz#e6742cad75d970c0a3f30d7d3fa80a4784f55927"
+  integrity sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==
   dependencies:
     "@babel/core" "^7.24.4"
     "@babel/parser" "^7.24.4"


### PR DESCRIPTION
## What

The four remaining follow-ups from #705, plus the defect that inventorying them uncovered: the app remounted its entire tree on every navigation.

**The remount.** `_app` built the page tree inside a `useCallback` and rendered it as a component, so every `pageProps` change was a new component type and React tore down layout, page and footers on each client-side navigation. Measured by tagging DOM nodes and navigating: all three replaced before, all three surviving after. This is the same bug class #697 fixed for table cells, sitting at the application root.

**The hook bugs it hid (issue item 1).** With the remount gone, three `usePrecision` call sites become live crashes: called once per array element in the Claim and SmartContract detail components, and after early returns in TokenOperations, the hook count tracked the data. Verified in a browser before fixing: with the remount fix in and the hook fix out, navigating from a one-receipt claim to a four-receipt claim blanks the page with "Rendered more hooks than during the previous render". On chain data the receipt count genuinely varies (98 of 100 sampled claims carry one claim receipt, 2 carry four). The two changes therefore land together, and the same persistence audit fixed what else relied on remounting: `usePrecision` now re-resolves when its ids change (with a stale-response guard), the transaction page keys its fee-precision effect on the fee asset, and the proposal and marketplace pages carry their route param in the react-query key so record B no longer serves record A's cache.

**The lint gate (item 1, tooling half).** The flat eslint config matched nothing, so every rule in it was inert. It now has a real `files` block with a TypeScript parser and `react-hooks/rules-of-hooks` as an error, a `lint` script, and a CI step that runs it. The fourth violation, `useRouter` inside `transactionRowSections`, is gone: row builders are called by the table, not mounted, so the route state now comes in through `useTransactionRowSections`, mirroring `useTransactionHeaders`. Proven enforceable: putting a hook behind an early return makes `yarn lint` exit non-zero naming the file and rule.

**Tooltip (item 2, re-scoped).** Every tooltip instance anchored on the same `.button-tooltip` selector, so each one bound every trigger on the page and hovering one ran the handlers of all. Each instance now anchors on its own generated id; hovering one of six on the accounts page shows exactly one. Tooltip also accepts `children` as the trigger, which three call sites already passed and had silently discarded; the `Component` prop keeps working and is marked deprecated instead of rewriting 103 call sites in one go.

**Badges (item 3).** The 14 remaining title-only badges, plus two on the holders mobile card that had no explanation at all, now use one shared `ExplainedBadge`: a focusable tooltip with the full message riding inside the pill as visually hidden text. Measured on the assets page: zero focusable before, all of them after, no `title` left, pill dimensions unchanged.

**Keyboard e2e (item 4).** A Cypress spec drives the shared filter with real CDP keys via `cypress-real-events`: Enter opens through the app's own handler, arrows walk `aria-activedescendant`, Enter selects and the URL updates, Escape closes without selecting, focus returns to the opener both ways, and a real Tab out of the open dropdown closes it, which is exactly the orphaned-open defect the #704 review round found. Each guard was run once in a broken state: removing the blur handler fails exactly the Tab-out test, removing the opener's activation fails exactly the four open-dependent tests.

Item 5 (Spotlight) is deliberately not here: the frontend and the updated proxy go live together, so the missing-route state cannot occur in production; a failure there genuinely means search is down.

## Audit round

Before pushing I ran seven parallel reviewers over the complete diff (security, scoped code review, frontend, TypeScript, performance, accessibility, and an independent full-diff pass), fed with scanner output, branch coverage and a mechanical blast-radius map. Their converging theme: the branch had swept react-query keys and `usePrecision` for the new no-remount reality, but not the other two ways this codebase assumed remount-per-navigation, mount-only fetch effects and `useState` seeded from props. Everything actionable is fixed in the final commit; the largest were the validator detail page serving the previous validator under the new URL (reproduced live before the fix, verified gone after), the frozen `usePackInfoPrecisions` sibling of the hook bug this branch already fixed, tab and card state leaking between blocks, assets and contracts, and the visually hidden badge copy reaching screen readers in all caps through an inherited text-transform. The eslint gate also hardened itself along the way: the config's leftover first block was not inert under flat-config semantics and is gone, and `eslint-plugin-react-hooks` is now a declared dependency instead of resolving through another package's hoisting.

## Tests

Unit suite green including the new regression suites; every new guard was also run once against a deliberately broken state to prove it fails when the guarded behavior is gone, in both directions where a guard has two. Full Cypress green in the CI shape. Typecheck, lint and production build clean. Browser verification: the remount measurement, the deliberate hook crash and its fix, tooltip hover isolation, badge focusability, and the full keyboard walk.

## Related issues

Closes #705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, keyboard-accessible explanations for status badges and labels.
  * Improved tooltip behavior, accessibility, and support for multiple tooltips.
  * Enhanced keyboard navigation and selection in account filters.

* **Bug Fixes**
  * Fixed stale data and state when switching assets, blocks, proposals, marketplaces, validators, and transactions.
  * Improved precision updates and handling of missing transaction data.
  * Corrected tab state when navigating between different asset types.

* **Tests**
  * Expanded coverage for tooltips, badges, keyboard interactions, navigation, and precision updates.
  * Added lint checks to the test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->