### PR TITLE
fix(i18n): pass common translator for elapsed timestamps

### DIFF
--- a/src/components/BlocksList/MobileCard.tsx
+++ b/src/components/BlocksList/MobileCard.tsx
@@ -30,6 +30,7 @@ const BlocksMobileCard: React.FC<IBlocksMobileCardProps> = ({
   index,
 }) => {
   const { t } = useTranslation(['blocks']);
+  const { t: commonT } = useTranslation('common');
   const label = (key: BlockColumnKey): string => {
     const column = BLOCK_COLUMNS.find(c => c.key === key);
     return column ? t(column.i18nKey, { defaultValue: column.header }) : key;
@@ -49,9 +50,10 @@ const BlocksMobileCard: React.FC<IBlocksMobileCardProps> = ({
     blockRewards,
   } = item;
 
-  const elapsed = formatDate(timestamp, { showElapsedTime: true }).split(
-    ' (',
-  )[0];
+  const elapsed = formatDate(timestamp, {
+    showElapsedTime: true,
+    t: commonT,
+  }).split(' (')[0];
 
   return (
     <MobileListCard data-testid={`table-row-${index}`}>

--- a/src/components/BlocksList/__tests__/MobileCard.test.tsx
+++ b/src/components/BlocksList/__tests__/MobileCard.test.tsx
@@ -14,14 +14,15 @@ jest.mock('@/utils/parseValues', () => ({
   parseAddress: (value: string) => `${value.slice(0, 10)}...`,
 }));
 
-// Resolved against the shipped bundle, with i18next's plural resolution
+// Resolved against the shipped bundles, with i18next's plural resolution
 // mirrored: a `count` option first tries `<key>_one`/`<key>_other`, which is
 // exactly the mechanism the transaction count relies on.
 jest.mock('next-i18next', () => {
-  const bundle = jest.requireActual(
-    '../../../../public/locales/en/blocks.json',
-  );
-  const lookup = (path: string): unknown =>
+  const bundles: Record<string, unknown> = {
+    blocks: jest.requireActual('../../../../public/locales/en/blocks.json'),
+    common: jest.requireActual('../../../../public/locales/en/common.json'),
+  };
+  const lookup = (bundle: unknown, path: string): unknown =>
     path
       .split('.')
       .reduce<unknown>(
@@ -32,28 +33,32 @@ jest.mock('next-i18next', () => {
         bundle,
       );
   return {
-    useTranslation: () => ({
-      t: (
-        key: string,
-        options?: Record<string, unknown> & {
-          defaultValue?: string;
-          count?: number;
+    useTranslation: (ns: string | string[] = 'blocks') => {
+      const first = Array.isArray(ns) ? ns[0] : ns;
+      return {
+        t: (
+          key: string,
+          options?: Record<string, unknown> & {
+            defaultValue?: string;
+            count?: number;
+          },
+        ) => {
+          const [space, path] = key.includes(':') ? key.split(':') : [first, key];
+          const bundle = bundles[space];
+          let value: unknown;
+          if (typeof options?.count === 'number') {
+            value = lookup(bundle, `${path}_${options.count === 1 ? 'one' : 'other'}`);
+          }
+          if (typeof value !== 'string') value = lookup(bundle, path);
+          if (typeof value !== 'string') value = options?.defaultValue;
+          if (typeof value !== 'string')
+            throw new Error(`missing ${space} locale key: ${key}`);
+          return value.replace(/\{\{(\w+)\}\}/g, (whole, name) =>
+            options && name in options ? String(options[name]) : whole,
+          );
         },
-      ) => {
-        const path = key.includes(':') ? key.split(':')[1] : key;
-        let value: unknown;
-        if (typeof options?.count === 'number') {
-          value = lookup(`${path}_${options.count === 1 ? 'one' : 'other'}`);
-        }
-        if (typeof value !== 'string') value = lookup(path);
-        if (typeof value !== 'string') value = options?.defaultValue;
-        if (typeof value !== 'string')
-          throw new Error(`missing blocks locale key: ${key}`);
-        return value.replace(/\{\{(\w+)\}\}/g, (whole, name) =>
-          options && name in options ? String(options[name]) : whole,
-        );
-      },
-    }),
+      };
+    },
   };
 });
 
@@ -171,5 +176,12 @@ describe('BlocksMobileCard', () => {
 
     expect(screen.getByText(/Fee Rewards 0 KLV/)).toBeTruthy();
     expect(screen.getByText(/0 txs · 0 B/)).toBeTruthy();
+  });
+
+  it('translates the elapsed age from the common bundle', () => {
+    renderCard();
+
+    // The timestamp renders elapsed relative time followed by "ago" from the common bundle.
+    expect(screen.getByText(/ago/)).toBeTruthy();
   });
 });

--- a/src/components/BlocksList/__tests__/MobileCard.test.tsx
+++ b/src/components/BlocksList/__tests__/MobileCard.test.tsx
@@ -18,9 +18,18 @@ jest.mock('@/utils/parseValues', () => ({
 // mirrored: a `count` option first tries `<key>_one`/`<key>_other`, which is
 // exactly the mechanism the transaction count relies on.
 jest.mock('next-i18next', () => {
+  const commonActual = jest.requireActual(
+    '../../../../public/locales/en/common.json',
+  );
   const bundles: Record<string, unknown> = {
     blocks: jest.requireActual('../../../../public/locales/en/blocks.json'),
-    common: jest.requireActual('../../../../public/locales/en/common.json'),
+    common: {
+      ...commonActual,
+      Date: {
+        ...commonActual.Date,
+        Elapsed_Time: 'mock-ago',
+      },
+    },
   };
   const lookup = (bundle: unknown, path: string): unknown =>
     path
@@ -181,7 +190,7 @@ describe('BlocksMobileCard', () => {
   it('translates the elapsed age from the common bundle', () => {
     renderCard();
 
-    // The timestamp renders elapsed relative time followed by "ago" from the common bundle.
-    expect(screen.getByText(/ago/)).toBeTruthy();
+    // The timestamp renders elapsed relative time followed by the unique common bundle translation.
+    expect(screen.getByText(/mock-ago/)).toBeTruthy();
   });
 });

--- a/src/components/BlocksList/__tests__/rows.test.tsx
+++ b/src/components/BlocksList/__tests__/rows.test.tsx
@@ -86,8 +86,12 @@ const BLOCK = {
   blockRewards: 15000000,
 } as IBlock;
 
-const renderCell = (key: string, block: IBlock = BLOCK) => {
-  const sections = blockRowSections(block);
+const renderCell = (
+  key: string,
+  block: IBlock = BLOCK,
+  t?: Parameters<typeof blockRowSections>[2],
+) => {
+  const sections = blockRowSections(block, 'Epoch', t);
   const index = BLOCK_COLUMNS.findIndex(column => column.key === key);
   return render(
     <ThemeProvider theme={theme}>{sections[index].element({})}</ThemeProvider>,
@@ -183,5 +187,15 @@ describe('blockRowSections', () => {
     expect(
       screen.getByTitle('08/27/26 23:06:04 UTC · Epoch 6076'),
     ).toBeTruthy();
+  });
+
+  it('translates the elapsed age using the translator passed to blockRowSections', () => {
+    const t = jest.fn((key: string) =>
+      key === 'Date.Elapsed_Time' ? 'atrás' : key,
+    );
+    renderCell('age', BLOCK, t as unknown as Parameters<typeof blockRowSections>[2]);
+
+    expect(t).toHaveBeenCalledWith('Date.Elapsed_Time');
+    expect(screen.getByText(/atrás/)).toBeTruthy();
   });
 });

--- a/src/components/BlocksList/rows.tsx
+++ b/src/components/BlocksList/rows.tsx
@@ -12,6 +12,7 @@ import { IRowSection } from '@/types/index';
 import { formatDate, formatDateWithSeconds } from '@/utils/formatFunctions';
 import { bandwidthFeeReward } from '@/utils/fees';
 import { parseAddress } from '@/utils/parseValues';
+import { TFunction } from 'next-i18next';
 import React from 'react';
 import { BLOCK_COLUMNS, BlockColumnKey } from './columns';
 
@@ -35,6 +36,7 @@ export const COLUMN_LAYOUT: IRowSection[] = BLOCK_COLUMNS.map(column => ({
 export const blockRowSections = (
   block: IBlock | string,
   epochLabel = 'Epoch',
+  t?: TFunction,
 ): IRowSection[] => {
   // The header-string probe above. Handled explicitly so a future dereference
   // of the argument cannot take the page down while rendering its own header.
@@ -60,7 +62,7 @@ export const blockRowSections = (
   // tooltip is hover-only, so without this a keyboard user on desktop had no
   // way to reach the epoch at all.
   const fullDate = `${formatDateWithSeconds(timestamp)} · ${epochLabel} ${epoch}`;
-  const elapsed = formatDate(timestamp, { showElapsedTime: true }).split(
+  const elapsed = formatDate(timestamp, { showElapsedTime: true, t }).split(
     ' (',
   )[0];
 

--- a/src/components/TransactionsList/__tests__/MobileCard.test.tsx
+++ b/src/components/TransactionsList/__tests__/MobileCard.test.tsx
@@ -53,11 +53,20 @@ jest.mock('@/utils/parseValues', () => ({
 // the card asks for that nobody ever added fails the suite here instead of
 // rendering "transactions:Table.Type" at a reader.
 jest.mock('next-i18next', () => {
+  const commonActual = jest.requireActual(
+    '../../../../public/locales/en/common.json',
+  );
   const bundles: Record<string, unknown> = {
     transactions: jest.requireActual(
       '../../../../public/locales/en/transactions.json',
     ),
-    common: jest.requireActual('../../../../public/locales/en/common.json'),
+    common: {
+      ...commonActual,
+      Date: {
+        ...commonActual.Date,
+        Elapsed_Time: 'mock-ago',
+      },
+    },
   };
 
   const resolve = (bundle: unknown, path: string): unknown =>
@@ -314,5 +323,11 @@ describe('TransactionsMobileCard', () => {
     // timestamp to 0, so without them the card dates the row 01/01/70 and
     // ages it in years.
     expect(card.textContent).not.toMatch(/year|\/70/);
+  });
+
+  it('translates the elapsed age from the common bundle', () => {
+    renderCard(transfer());
+
+    expect(screen.getByText(/mock-ago/)).toBeTruthy();
   });
 });

--- a/src/pages/blocks/index.tsx
+++ b/src/pages/blocks/index.tsx
@@ -33,6 +33,7 @@ const Blocks: React.FC<PropsWithChildren> = () => {
   const router = useRouter();
   const header = useColumnHeaders(BLOCK_COLUMNS);
   const { t } = useTranslation(['blocks']);
+  const { t: commonT } = useTranslation('common');
   // Translated here and handed down: the row builder is no component, so
   // t() is out of its reach, and the mobile card already translates this key.
   const epochLabel = t('blocks:Table.Epoch', { defaultValue: 'Epoch' });
@@ -65,7 +66,7 @@ const Blocks: React.FC<PropsWithChildren> = () => {
     type: 'blocks',
     header,
     rowSections: (block: Parameters<typeof blockRowSections>[0]) =>
-      blockRowSections(block, epochLabel),
+      blockRowSections(block, epochLabel, commonT),
     dataName: 'blocks',
     request: (page: number, limit: number) =>
       blockListCall(page, limit, router.query),

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -66,7 +66,7 @@ import { getPrecision } from '@/utils/precisionFunctions';
 import { TXType } from '@klever/connect';
 import { GetServerSideProps } from 'next';
 import { MdOutlineDescription } from 'react-icons/md';
-import { useTranslation } from 'next-i18next';
+import { TFunction, useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import Link from 'next/link';
 import { NextRouter, useRouter } from 'next/router';
@@ -266,6 +266,7 @@ export const getCustomFields = (
 export const transactionRowSections = (
   props: ITransaction,
   routeState?: { pathname?: string; query?: ParsedUrlQuery },
+  t?: TFunction,
 ): IRowSection[] => {
   const {
     hash,
@@ -329,6 +330,7 @@ export const transactionRowSections = (
   // shows the first half, the tooltip the full date.
   const ageElapsed = formatDate(timestamp || Date.now(), {
     showElapsedTime: true,
+    t,
   }).split(' (')[0];
 
   const emptyCell = (
@@ -550,10 +552,12 @@ export const useTransactionRowSections = (): ((
   props: ITransaction,
 ) => IRowSection[]) => {
   const { pathname, query } = useRouter();
+  const { t: commonT } = useTranslation('common');
 
   return useCallback(
-    (props: ITransaction) => transactionRowSections(props, { pathname, query }),
-    [pathname, query],
+    (props: ITransaction) =>
+      transactionRowSections(props, { pathname, query }, commonT),
+    [pathname, query, commonT],
   );
 };
 


### PR DESCRIPTION
## What this fixes

Elapsed timestamps across the transactions list, blocks list, and blocks mobile card were hardcoded to English "ago" rather than using localized strings, because `formatDate` was called with `{ showElapsedTime: true }` without passing a translator `t`.

Additionally, as documented in #709, `formatDate` resolves `Date.Elapsed_Time` which lives under the `common` namespace. Binding only `transactions` or `blocks` causes raw translation keys to be rendered.

Closes #709

## Changes

- **`src/pages/transactions/index.tsx`**: Updated `transactionRowSections` to accept an optional translator `t`, forward it to `formatDate`, and pass `useTranslation('common')` via `useTransactionRowSections`.
- **`src/components/BlocksList/rows.tsx`**: Updated `blockRowSections` to accept an optional `t` parameter and pass it to `formatDate`.
- **`src/pages/blocks/index.tsx`**: Bound `useTranslation('common')` and passed `commonT` down to `blockRowSections`.
- **`src/components/BlocksList/MobileCard.tsx`**: Bound `common` namespace (`useTranslation('common')`) and passed `commonT` into `formatDate`.
- **Tests**:
  - Updated `src/components/BlocksList/__tests__/MobileCard.test.tsx` to mirror the namespace-faithful mock (supporting both `blocks` and `common`) and added a test asserting elapsed age translation.
  - Updated `src/components/BlocksList/__tests__/rows.test.tsx` to forward translator `t` and asserted that `blockRowSections` uses `t` to localize the elapsed time.

## Verification

- `yarn test src/components/BlocksList src/components/TransactionsList`: 14 test suites passed, 155 tests passed.
- `yarn lint`: 0 errors, 0 warnings (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Localized elapsed-time labels, including “ago,” across block and transaction listings.
  * Ensured elapsed-time translations are applied consistently in both mobile cards and table rows.

* **Tests**
  * Added coverage verifying localized elapsed-time text in block cards and rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->