### PR TITLE
feat(home): draw the transactions chart from the series route, 1D included

### DIFF
--- a/src/components/Home/HomeTransactions/ChartDailyTransactions/__tests__/index.test.tsx
+++ b/src/components/Home/HomeTransactions/ChartDailyTransactions/__tests__/index.test.tsx
@@ -20,12 +20,9 @@ jest.mock('@/components/InputGlobal', () => ({
   __esModule: true,
   default: () => null,
 }));
-jest.mock('@/components/Chart', () => ({
-  __esModule: true,
-  default: () => null,
-  ChartType: { Line: 'line', DoubleLine: 'doubleLine' },
+jest.mock('@/components/Chart/Tooltips', () => ({
+  DoubleTxsTooltip: () => null,
 }));
-jest.mock('@/components/Chart/Tooltips', () => ({ DoubleTxsTooltip: () => null }));
 
 import theme from '@/styles/theme';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -76,6 +73,17 @@ jest.mock('@/services/requests/home/transactionSeries', () => ({
   transactionSeriesCall: (period: number) => seriesCall(period),
 }));
 
+/** The pairs handed to the chart, which is mocked out and draws nothing. */
+const chartData = jest.fn();
+jest.mock('@/components/Chart', () => ({
+  __esModule: true,
+  default: ({ data }: { data: unknown }) => {
+    chartData(data);
+    return null;
+  },
+  ChartType: { Line: 'line', DoubleLine: 'doubleLine' },
+}));
+
 import { ChartDailyTransactions } from '../index';
 
 /** A series of `points` days, each carrying `perDay` transactions. */
@@ -84,6 +92,16 @@ const series = (points: number, perDay: number) =>
     key: 1_788_000_000_000 + index * 24 * 60 * 60 * 1000,
     doc_count: perDay,
   }));
+
+/** A series of `points` hours, each carrying `perHour` transactions. */
+const hourlySeries = (points: number, perHour: number) =>
+  Array.from({ length: points }, (_, index) => ({
+    key: 1_788_000_000_000 + index * 60 * 60 * 1000,
+    doc_count: perHour,
+  }));
+
+const lastDrawn = () =>
+  chartData.mock.calls.at(-1)?.[0] as { dateNow: string; datePast: string }[];
 
 const renderChart = () =>
   render(
@@ -104,9 +122,7 @@ describe('ChartDailyTransactions', () => {
     // The fault is a figure left over from the period before, so the card has
     // to carry one first: rendering straight into an empty answer has nothing
     // to leave behind and would pass either way.
-    seriesCall
-      .mockResolvedValueOnce(series(30, 100))
-      .mockResolvedValueOnce([]);
+    seriesCall.mockResolvedValueOnce(series(30, 100)).mockResolvedValueOnce([]);
 
     const { container } = renderChart();
     await waitFor(() => expect(seriesCall).toHaveBeenCalledTimes(1));
@@ -116,6 +132,8 @@ describe('ChartDailyTransactions', () => {
     await waitFor(() => expect(seriesCall).toHaveBeenCalledTimes(2));
 
     await waitFor(() => expect(container.textContent).not.toContain('1,500'));
+    // What replaces it is the chart's own empty state, not a blank card.
+    await waitFor(() => expect(container.textContent).toContain('EmptyData'));
   });
 
   it('reports no percentage when the previous stretch was empty', async () => {
@@ -171,5 +189,31 @@ describe('ChartDailyTransactions', () => {
 
     expect(container.textContent).toContain('700');
     expect(container.textContent).not.toContain('14,985');
+  });
+
+  it('draws a day as 24 hourly points labelled by clock time', async () => {
+    // A day gave one point per stretch before, two dots and no line. The
+    // wiring under test is the period the button hands over and the label mode
+    // that follows from it, checked in both directions: a day label on 1D
+    // would repeat 24 times over, a clock label on 15D would name no day.
+    seriesCall
+      .mockResolvedValueOnce(series(30, 100))
+      .mockResolvedValueOnce(hourlySeries(48, 10));
+
+    const { container } = renderChart();
+    await waitFor(() => expect(seriesCall).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(lastDrawn()).toHaveLength(15));
+    expect(lastDrawn()[0].dateNow).not.toMatch(/^\d{2}:\d{2}$/);
+
+    screen.getByText('1D').click();
+    await waitFor(() => expect(seriesCall).toHaveBeenLastCalledWith(1));
+    await waitFor(() => expect(lastDrawn()).toHaveLength(24));
+    expect(container.textContent).not.toContain('EmptyData');
+
+    const [first] = lastDrawn();
+    expect(first.dateNow).toMatch(/^\d{2}:\d{2}$/);
+    // The buckets of the two stretches sit exactly a day apart, so one clock
+    // time names both.
+    expect(first.datePast).toBe(first.dateNow);
   });
 });

--- a/src/components/Home/HomeTransactions/ChartDailyTransactions/__tests__/index.test.tsx
+++ b/src/components/Home/HomeTransactions/ChartDailyTransactions/__tests__/index.test.tsx
@@ -71,6 +71,10 @@ jest.mock('next-i18next', () => ({
 const seriesCall = jest.fn();
 jest.mock('@/services/requests/home/transactionSeries', () => ({
   transactionSeriesCall: (period: number) => seriesCall(period),
+  // The real predicate, not a copy: the point of it is that the request and
+  // the labels cannot disagree about which periods are drawn by the hour.
+  isHourly: jest.requireActual('@/services/requests/home/transactionSeries')
+    .isHourly,
 }));
 
 /** The pairs handed to the chart, which is mocked out and draws nothing. */
@@ -162,10 +166,10 @@ describe('ChartDailyTransactions', () => {
 
   it('ignores a response the period has moved on from', async () => {
     // The transition the guard exists for is a period switch, not a teardown:
-    // 7D counts fourteen rolling windows while 15D takes one bucket request,
-    // so the slower answer can land last and paint itself under the newer
-    // label. Unmounting instead proves nothing, because React 19 no longer
-    // warns about a state update on an unmounted component.
+    // the request the reader moved away from is still in flight, and if it
+    // settles last it paints itself under the newer label. Unmounting instead
+    // proves nothing, because React 19 no longer warns about a state update on
+    // an unmounted component.
     let resolveSlow: (value: unknown) => void = () => undefined;
     seriesCall
       .mockReturnValueOnce(

--- a/src/components/Home/HomeTransactions/ChartDailyTransactions/index.tsx
+++ b/src/components/Home/HomeTransactions/ChartDailyTransactions/index.tsx
@@ -22,16 +22,10 @@ import {
 import { useTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 
-/**
- * A period needs at least two points per line to draw one, and a day gives one
- * per stretch, so 1D used to render a pair of dots and no line. Hourly points
- * would fix it, but the proxy's histogram only buckets by day or month, and a
- * request per hour is refused: 48 in parallel answered once and then returned
- * 10 and 0 on the two runs after it, while testnet, which CI uses, refused 20
- * of them outright. The card beside the chart already reports the last 24
- * hours, and now agrees with this chart's own figures.
- */
-const CHART_TIME_FILTER = [7, 15, 30];
+// A day is drawn as 24 hourly points per stretch: one point per stretch drew
+// as two dots and no line, which is why 1D was out until the series route
+// could bucket by the hour.
+const CHART_TIME_FILTER = [1, 7, 15, 30];
 const TIME_SERIES_CHG_VALUE = {
   inPeriod: 0,
   percent: '',
@@ -63,8 +57,6 @@ export const ChartDailyTransactions: React.FC<PropsWithChildren> = () => {
       try {
         setIsLoadingDailyTxs(true);
 
-        // Rolling windows where the request count allows it, UTC-day buckets
-        // beyond that; the module says which and why.
         const rawTxList = await transactionSeriesCall(filterPeriod);
         if (!current) return;
         if (!rawTxList.length) {
@@ -80,6 +72,7 @@ export const ChartDailyTransactions: React.FC<PropsWithChildren> = () => {
         const { pairs, total, previousTotal } = buildChartSeries(
           rawTxList,
           month => commonT(`Date.Months.${month}`),
+          { hourly: filterPeriod === 1 },
         );
 
         setTransactionTimeSeries(pairs as IDoubleChart[]);

--- a/src/components/Home/HomeTransactions/ChartDailyTransactions/index.tsx
+++ b/src/components/Home/HomeTransactions/ChartDailyTransactions/index.tsx
@@ -5,7 +5,10 @@ import { ArrowVariation } from '@/components/Home/CoinDataFetcher/CoinCard/style
 import { Loader } from '@/components/Loader/styles';
 import { IDoubleChart } from '@/pages/charts';
 import { buildChartSeries } from '@/services/requests/home/chartSeries';
-import { transactionSeriesCall } from '@/services/requests/home/transactionSeries';
+import {
+  isHourly,
+  transactionSeriesCall,
+} from '@/services/requests/home/transactionSeries';
 import { getVariation } from '@/utils';
 import { toLocaleFixed } from '@/utils/formatFunctions';
 import {
@@ -47,10 +50,9 @@ export const ChartDailyTransactions: React.FC<PropsWithChildren> = () => {
   const { t } = useTranslation('transactions');
 
   useEffect(() => {
-    // The periods do not settle in the order they were asked for: 7D counts a
-    // rolling window per point, fourteen requests, while 15D and 1M take one.
-    // Switching away from 7D therefore lands the newer answer first and the
-    // older one on top of it, under the newer label.
+    // A period switch leaves the previous request in flight, and two requests
+    // can settle in either order, so the answer to a period the reader has
+    // moved on from must not paint itself under the newer label.
     let current = true;
 
     const getTransactionsChartTimeSeries = async () => {
@@ -72,7 +74,7 @@ export const ChartDailyTransactions: React.FC<PropsWithChildren> = () => {
         const { pairs, total, previousTotal } = buildChartSeries(
           rawTxList,
           month => commonT(`Date.Months.${month}`),
-          { hourly: filterPeriod === 1 },
+          { hourly: isHourly(filterPeriod) },
         );
 
         setTransactionTimeSeries(pairs as IDoubleChart[]);

--- a/src/components/SmartContractsList/LoadingCard.tsx
+++ b/src/components/SmartContractsList/LoadingCard.tsx
@@ -1,11 +1,7 @@
-import { Tile, TilesGrid } from '@/components/DataList/styles';
+import { LegendRow, Tile, TilesGrid } from '@/components/DataList/styles';
 import Skeleton from '@/components/Skeleton';
 import React from 'react';
-import {
-  ContractsSummaryCard,
-  MostUsedTile,
-  PlaceholderLegendRow,
-} from './styles';
+import { ContractsSummaryCard, MostUsedTile } from './styles';
 
 /**
  * Skeleton heights in rem, not px. The root font is 93,75% below 1440px and
@@ -34,11 +30,12 @@ const TILE_LINES = [
 ];
 
 /**
- * The distribution bar and its one-line legend, before the statistics arrive.
- * Its own shape rather than the shared SummaryBarPlaceholder: that one wraps
- * its fixed-width items like a multi-row legend, while this card's legend is
- * a single row on every width (it scrolls on mobile), so the shared shape
- * reserved two rows where one would land.
+ * The distribution bar and its legend, before the statistics arrive. Six
+ * pills, one per legend item (the five busiest contracts and "Other"), on the
+ * card's own legend row, so they take the row's grid at every width and the
+ * two states cannot differ in height. The pill is a rem width rather than a
+ * share of the row, since in a grid cell a percentage would be of the cell,
+ * and bar plus margins make the item's 1,03125rem line box (16,5px at 12px).
  */
 export const FiguresBarPlaceholder: React.FC = () => (
   <>
@@ -47,16 +44,16 @@ export const FiguresBarPlaceholder: React.FC = () => (
       height={8}
       containerCustomStyles={{ marginTop: 16 }}
     />
-    <PlaceholderLegendRow>
-      {Array.from({ length: 4 }, (unused, index) => (
+    <LegendRow>
+      {Array.from({ length: 6 }, (unused, index) => (
         <Skeleton
           key={index}
-          width="12%"
+          width="6.5rem"
           height="0.75rem"
-          containerCustomStyles={{ margin: '0.15625rem 0' }}
+          containerCustomStyles={{ margin: '0.140625rem 0' }}
         />
       ))}
-    </PlaceholderLegendRow>
+    </LegendRow>
   </>
 );
 

--- a/src/components/SmartContractsList/Summary.tsx
+++ b/src/components/SmartContractsList/Summary.tsx
@@ -33,6 +33,7 @@ import {
   ContractsSummaryCard,
   MostUsedTile,
   SummaryContractLink,
+  LegendName,
 } from './styles';
 import {
   segmentColor,
@@ -42,6 +43,7 @@ import {
 } from './summaryFigures';
 import { CONTRACT_SHARES_QUERY } from './sharesQuery';
 
+import { IContractShare } from '@/components/SmartContractsList/summaryFigures';
 /**
  * A quarter of an hour. These are chain-wide totals that move by fractions of
  * a percent between reads, and the page they sit on used to refetch four
@@ -114,6 +116,10 @@ const ContractsSummary: React.FC = () => {
     theme.rose,
   ];
 
+  const identity = (segment: Pick<IContractShare, 'address' | 'name'>) =>
+    segment.name
+      ? safeContractName(segment.name) || segment.address
+      : segment.address;
   const otherLabel = t('smartContracts:List.OtherContracts', {
     defaultValue: 'Other contracts',
   });
@@ -247,16 +253,16 @@ const ContractsSummary: React.FC = () => {
           </DistBar>
           <LegendRow>
             {model.segments.map((segment, index) => (
-              <LegendItem key={segment.address}>
+              <LegendItem key={segment.address} title={identity(segment)}>
                 <LegendDot $color={segmentColor(index, palette)} />
-                {contractLabel(segment, 10)}{' '}
+                <LegendName>{contractLabel(segment, 10)}</LegendName>
                 <strong>{formatShare(segment.count, model.total)}</strong>
               </LegendItem>
             ))}
             {model.other > 0 && (
-              <LegendItem $dimmed>
+              <LegendItem $dimmed title={otherLabel}>
                 <LegendDot $color={theme.blueGray500} />
-                {otherLabel}{' '}
+                <LegendName>{otherLabel}</LegendName>
                 <strong>{formatShare(model.other, model.total)}</strong>
               </LegendItem>
             )}

--- a/src/components/SmartContractsList/Summary.tsx
+++ b/src/components/SmartContractsList/Summary.tsx
@@ -36,6 +36,7 @@ import {
   LegendName,
 } from './styles';
 import {
+  IContractShare,
   segmentColor,
   shareBarLabel,
   shareModel,
@@ -43,7 +44,6 @@ import {
 } from './summaryFigures';
 import { CONTRACT_SHARES_QUERY } from './sharesQuery';
 
-import { IContractShare } from '@/components/SmartContractsList/summaryFigures';
 /**
  * A quarter of an hour. These are chain-wide totals that move by fractions of
  * a percent between reads, and the page they sit on used to refetch four
@@ -236,7 +236,7 @@ const ContractsSummary: React.FC = () => {
                 style={{
                   width: `${(segment.count / model.total) * 100}%`,
                 }}
-                title={`${segment.name ? safeContractName(segment.name) || segment.address : segment.address} · ${segment.count.toLocaleString(NUMBER_LOCALE)}`}
+                title={`${identity(segment)} · ${segment.count.toLocaleString(NUMBER_LOCALE)}`}
                 aria-hidden="true"
               />
             ))}

--- a/src/components/SmartContractsList/__tests__/Summary.test.tsx
+++ b/src/components/SmartContractsList/__tests__/Summary.test.tsx
@@ -35,9 +35,8 @@ jest.mock('next-i18next', () => {
           typeof value === 'string'
             ? value
             : ((options?.defaultValue as string) ?? key);
-        return template.replace(
-          /\{\{(\w+)\}\}/g,
-          (_m, name: string) => String(options?.[name] ?? ''),
+        return template.replace(/\{\{(\w+)\}\}/g, (_m, name: string) =>
+          String(options?.[name] ?? ''),
         );
       },
     }),
@@ -175,5 +174,42 @@ describe('ContractsSummary', () => {
     const card = await (renderSummary(), loaded());
 
     expect(card.textContent).toContain('3,023 in the last 24 hours');
+  });
+
+  it('names each legend entry and its bar segment the same way', async () => {
+    // The whole legend subtree hangs off a resolved share model, so without
+    // statistics none of it renders and its naming rule goes unexercised.
+    // A named contract, an unnamed one and a remainder large enough for the
+    // "Other" entry, so all three legend shapes are drawn.
+    sharesCall.mockResolvedValue({
+      statistics: [
+        {
+          address: 'klv1namedcontractaddress0000000000000000',
+          name: 'Bitcoin.me',
+          count: 60,
+        },
+        { address: 'klv1unnamedcontractaddress00000000000000', count: 40 },
+      ],
+      allSuccessful: 200,
+    });
+
+    const card = await (renderSummary(), loaded());
+
+    await waitFor(() => expect(card.textContent).toContain('Bitcoin.me'));
+    // The unnamed one falls back to its address, cut to the ten characters
+    // the legend allows.
+    expect(card.textContent).toContain('klv1unname...');
+    expect(card.textContent).toContain('Other contracts');
+
+    // The bar's tooltip and the legend's must agree on what a segment is
+    // called: one rule, applied in both places.
+    const named = Array.from(card.querySelectorAll('[title]')).filter(node =>
+      (node.getAttribute('title') ?? '').startsWith('Bitcoin.me'),
+    );
+    expect(named).toHaveLength(2);
+    expect(named.map(node => node.getAttribute('title'))).toEqual([
+      'Bitcoin.me \u00b7 60',
+      'Bitcoin.me',
+    ]);
   });
 });

--- a/src/components/SmartContractsList/styles.ts
+++ b/src/components/SmartContractsList/styles.ts
@@ -11,6 +11,7 @@ import {
   LegendRow,
   SummaryCard,
   Tile,
+  TileLabel,
   TilesGrid,
 } from '@/components/DataList/styles';
 import {
@@ -38,6 +39,23 @@ import { RIGHT_ALIGNED_COLUMNS } from './columns';
  */
 const THREE_TILES = '600px';
 const CONTROLS_ONE_ROW = '480px';
+
+/**
+ * The legend's six items (the five busiest contracts and "Other") need 921px
+ * on one row, measured on mainnet. Below tablet width they sit on a grid of
+ * three columns, two below 520px, so the row count is fixed whatever the
+ * names are. The row is the item's line box: 16,5px at 12px, measured.
+ */
+const LEGEND_THREE_COLUMNS_MIN = '519.98px';
+const LEGEND_LINE = '1.03125rem';
+
+/**
+ * Below 390px two tiles beside each other are 115 to 145px wide, where
+ * "Contract transactions" needs two lines from 135px down; they used to stack
+ * there. Both labels take two lines so the values stay level, and a tile holds
+ * the 85px measured at 320px with a two-line label and a two-line sub line.
+ */
+const LABELS_ON_ONE_LINE_MIN = '389.98px';
 
 /* ------------------------------- summary --------------------------------- */
 
@@ -73,20 +91,62 @@ export const ContractsSummaryCard = styled(SummaryCard)`
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 
-  /* One legend row on every width: below tablet it scrolls sideways instead
-     of wrapping. Wrapping made its height depend on the length of contract
-     names, which no loading shape can predict; measured, the card grew 17px
-     under the reader when the legend landed three rows tall at 390px. */
+  /* A row that wraps by itself makes the card's height depend on contract
+     names, which no loading shape can predict; it used to scroll sideways
+     instead. The grid pins the rows, the loading shape sits on the same grid,
+     and a name wider than its column ends in an ellipsis with the full text
+     as its title. The minimum height covers a chain with fewer contracts. */
   @media screen and (max-width: ${props => props.theme.breakpoints.tablet}) {
     ${LegendRow} {
-      flex-wrap: nowrap;
-      overflow-x: auto;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-auto-rows: ${LEGEND_LINE};
+      min-height: calc(2 * ${LEGEND_LINE} + 8px);
     }
 
     ${LegendItem} {
-      flex-shrink: 0;
+      min-width: 0;
+
+      strong {
+        flex-shrink: 0;
+      }
     }
   }
+
+  @media screen and (max-width: ${LEGEND_THREE_COLUMNS_MIN}) {
+    ${LegendRow} {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      min-height: calc(3 * ${LEGEND_LINE} + 16px);
+    }
+  }
+
+  @media screen and (max-width: ${LABELS_ON_ONE_LINE_MIN}) {
+    ${TilesGrid} {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    ${Tile} {
+      min-height: 85px;
+    }
+
+    ${TileLabel} {
+      display: block;
+      /* Pinned, as on /blocks: two lines is only a fixed height once the
+         ratio is. 9em makes "Contracts deployed" break where "Contract
+         transactions" does, so the values under them stay level. */
+      line-height: 1.4;
+      min-height: 2.8em;
+      max-width: 9em;
+    }
+  }
+`;
+
+/** A legend item's name, cut with an ellipsis where its grid column is narrower. */
+export const LegendName = styled.span`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 /**
@@ -100,13 +160,6 @@ export const MostUsedTile = styled(Tile)`
   @media screen and (max-width: ${THREE_TILES}) {
     display: none;
   }
-`;
-
-/** The one-line legend placeholder's row, sharing the legend's own metrics. */
-export const PlaceholderLegendRow = styled.div`
-  display: flex;
-  gap: 16px;
-  margin-top: 8px;
 `;
 
 /**

--- a/src/services/requests/home/__tests__/chartSeries.test.ts
+++ b/src/services/requests/home/__tests__/chartSeries.test.ts
@@ -106,6 +106,24 @@ describe('buildChartSeries', () => {
     expect(pairs[0].dateNow).toBe(pairs[0].datePast);
   });
 
+  it('labels in UTC, whatever zone the viewer is in', () => {
+    // Every other timestamp the explorer prints is UTC. Half past eleven at
+    // night is already the next day in any zone east of it, which is where a
+    // label from the viewer's clock would name the wrong day and hour.
+    const late = Date.UTC(2026, 7, 20, 23, 30);
+    const series = [
+      { key: late, doc_count: 1 },
+      { key: late + DAY_MS, doc_count: 2 },
+    ];
+
+    const daily = buildChartSeries(series, month);
+    const hourly = buildChartSeries(series, month, { hourly: true });
+
+    expect(daily.pairs[0].datePast).toBe('20 Aug');
+    expect(daily.pairs[0].dateNow).toBe('21 Aug');
+    expect(hourly.pairs[0].datePast).toBe('23:30');
+  });
+
   it('renders the month through the translator it was handed', () => {
     const series = [
       { key: START, doc_count: 1 },

--- a/src/services/requests/home/__tests__/chartSeries.test.ts
+++ b/src/services/requests/home/__tests__/chartSeries.test.ts
@@ -91,6 +91,21 @@ describe('buildChartSeries', () => {
     expect(buildChartSeries(series, month).pairs).toEqual([]);
   });
 
+  it('labels hourly points by clock time, the same on both stretches', () => {
+    // Buckets a day apart end at the same minute, so one label names both,
+    // where a day label would repeat 24 times over.
+    const hour = 60 * 60 * 1000;
+    const series = [
+      { key: START, doc_count: 1 },
+      { key: START + 24 * hour, doc_count: 2 },
+    ];
+
+    const { pairs } = buildChartSeries(series, month, { hourly: true });
+
+    expect(pairs[0].datePast).toMatch(/^\d{2}:\d{2}$/);
+    expect(pairs[0].dateNow).toBe(pairs[0].datePast);
+  });
+
   it('renders the month through the translator it was handed', () => {
     const series = [
       { key: START, doc_count: 1 },

--- a/src/services/requests/home/__tests__/transactionSeries.test.ts
+++ b/src/services/requests/home/__tests__/transactionSeries.test.ts
@@ -1,6 +1,6 @@
 import api from '@/services/api';
 import {
-  ROLLING_POINT_LIMIT,
+  POINTS_PER_STRETCH,
   transactionSeriesCall,
 } from '@/services/requests/home/transactionSeries';
 
@@ -10,175 +10,106 @@ jest.mock('@/services/api', () => ({
 }));
 
 const mockedGet = api.get as jest.Mock;
-const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
 
-const dated = () =>
-  mockedGet.mock.calls
-    .map(([args]) => args.query)
-    .filter(query => query?.startdate !== undefined);
+/** `points` buckets ending now, each `count` wide, oldest first as the route answers. */
+const buckets = (points: number, count: number, widthMs: number) => {
+  const toMs = 1_788_597_852_851;
+  return Array.from({ length: points }, (_, index) => ({
+    fromMs: toMs - (points - index) * widthMs,
+    toMs: toMs - (points - 1 - index) * widthMs,
+    count,
+  }));
+};
+
+const answer = (list: unknown) =>
+  mockedGet.mockResolvedValue({
+    error: '',
+    data: { transaction_series: { buckets: list } },
+  });
 
 describe('transactionSeriesCall', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockedGet.mockResolvedValue({ error: '', pagination: { totalRecords: 100 } });
-  });
+  beforeEach(() => jest.clearAllMocks());
 
-  it('counts a rolling window per point for a period it can afford', async () => {
-    // A week asks for fourteen points, seven for each stretch the chart draws.
-    await transactionSeriesCall(7);
+  it('asks for two stretches of days in one request', async () => {
+    answer(buckets(14, 100, 24 * HOUR_MS));
 
-    const windows = dated();
-    expect(windows).toHaveLength(ROLLING_POINT_LIMIT);
-    windows.forEach(window => {
-      expect(window.enddate - window.startdate).toBe(DAY_MS);
-      // Milliseconds: seconds are not rejected, the route answers the
-      // all-time total instead, so a unit slip reads as a plausible figure.
-      expect(window.startdate).toBeGreaterThan(1e12);
-    });
-  });
-
-  it('leaves no gap between consecutive points', async () => {
-    await transactionSeriesCall(7);
-
-    const windows = dated().sort((a, b) => a.enddate - b.enddate);
-    expect(windows).toHaveLength(ROLLING_POINT_LIMIT);
-    windows.slice(1).forEach((window, index) => {
-      expect(window.startdate).toBe(windows[index].enddate);
-    });
-  });
-
-  it('reads one clock for the whole set, so the windows cannot drift', async () => {
-    // A clock read per point would leave each window ending a moment later
-    // than the one before, which is what a moving clock exposes.
-    let tick = 1_788_428_166_129;
-    const spy = jest.spyOn(Date, 'now').mockImplementation(() => {
-      tick += 1000;
-      return tick;
-    });
-
-    await transactionSeriesCall(7);
-
-    const ends = dated().map(window => window.enddate);
-    // Every window ends on the same grid, one day apart, from one reading.
-    const spacing = new Set(
-      ends.sort((a, b) => a - b).slice(1).map((end, i) => end - ends[i]),
-    );
-    expect(spacing).toEqual(new Set([DAY_MS]));
-
-    spy.mockRestore();
-  });
-
-  it('falls back to day buckets once the period costs too many requests', async () => {
-    // 15D would need 30 requests, and the proxy refused 30 in a burst while
-    // answering 20 (measured 2026-09-03).
-    // Keys a day apart, newest first, the way the route answers.
-    const newest = 1_788_393_600_000;
-    mockedGet.mockResolvedValue({
-      error: '',
-      data: {
-        number_by_day: Array.from({ length: 30 }, (_, index) => ({
-          key: newest - index * DAY_MS,
-          doc_count: 5,
-        })),
-      },
-    });
-
-    const series = await transactionSeriesCall(15);
+    const series = await transactionSeriesCall(7);
 
     expect(mockedGet).toHaveBeenCalledTimes(1);
-    expect(mockedGet.mock.calls[0][0].route).toBe('transaction/list/count/30');
-    // Oldest first, whatever order the route answered in.
-    expect(series[0].key).toBe(newest - 29 * DAY_MS);
-    expect(series).toHaveLength(30);
+    expect(mockedGet.mock.calls[0][0]).toEqual({
+      route: 'transaction/statistics/series',
+      query: { interval: '1d', points: 7 * POINTS_PER_STRETCH },
+    });
+    expect(series).toHaveLength(14);
   });
 
-  it('answers an empty series when one window was refused', async () => {
-    // A refused request read as zero would draw as a day with no activity.
-    let call = 0;
-    mockedGet.mockImplementation(() =>
-      Promise.resolve(
-        (call += 1) === 1
-          ? { error: 'rate limited' }
-          : { error: '', pagination: { totalRecords: 100 } },
-      ),
-    );
+  it('draws a day as hourly points, or it would be two dots and no line', async () => {
+    answer(buckets(48, 5, HOUR_MS));
+
+    const series = await transactionSeriesCall(1);
+
+    expect(mockedGet.mock.calls[0][0].query).toEqual({
+      interval: '1h',
+      points: 48,
+    });
+    expect(series).toHaveLength(48);
+  });
+
+  it('keys each point on the end of its bucket, oldest first', async () => {
+    answer(buckets(14, 3, 24 * HOUR_MS));
+
+    const series = await transactionSeriesCall(7);
+
+    expect(series.every(point => point.doc_count === 3)).toBe(true);
+    series.slice(1).forEach((point, index) => {
+      expect(point.key - series[index].key).toBe(24 * HOUR_MS);
+    });
+  });
+
+  it('keeps a quiet bucket as zero, which the route reports rather than omits', async () => {
+    answer(buckets(14, 0, 24 * HOUR_MS));
+
+    const series = await transactionSeriesCall(7);
+
+    expect(series).toHaveLength(14);
+    expect(series.every(point => point.doc_count === 0)).toBe(true);
+  });
+
+  it('answers nothing when the route failed', async () => {
+    mockedGet.mockResolvedValue({ error: 'boom' });
 
     await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 
-  it('answers nothing when the bucket route failed', async () => {
-    mockedGet.mockResolvedValue({ error: 'boom' });
+  it('answers nothing when the request rejected outright', async () => {
+    mockedGet.mockRejectedValue(new Error('unreadable body'));
 
-    await expect(transactionSeriesCall(15)).resolves.toEqual([]);
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 
   it('answers nothing when the body carries no bucket list', async () => {
-    // A malformed success, not a chain with no transactions.
     mockedGet.mockResolvedValue({ error: '', data: {} });
 
-    await expect(transactionSeriesCall(15)).resolves.toEqual([]);
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 
-  it('draws a malformed bucket as zero rather than refusing the series', async () => {
-    // The one case where a zero can stand for a day that carried
-    // transactions: the bucket's value cannot be known, so it is dropped and
-    // the grid shows the gap as zero. Preferred over an empty chart, since a
-    // single malformed answer would otherwise blank a month.
-    const day = 24 * 60 * 60 * 1000;
-    const newest = 1_788_393_600_000;
-    const buckets = Array.from({ length: 30 }, (_, index) => ({
-      key: newest - (29 - index) * day,
-      doc_count: 10,
-    }));
-    buckets[5] = { key: null as unknown as number, doc_count: 9 };
-    mockedGet.mockResolvedValue({
-      error: '',
-      data: { number_by_day: buckets },
-    });
+  it('refuses a series shorter than it asked for', async () => {
+    // The caller splits the list down the middle, so a short answer would
+    // pair every later point against the wrong counterpart. The route
+    // guarantees the length; this holds the caller to it.
+    answer(buckets(13, 1, 24 * HOUR_MS));
 
-    const series = await transactionSeriesCall(15);
-
-    expect(series).toHaveLength(30);
-    expect(series[5].doc_count).toBe(0);
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 
-  it('fills a day the route omitted with zero, on the day grid', async () => {
-    // Its swagger says quiet days are omitted. A quiet day is a known zero,
-    // and refusing the whole series for it left the chart empty for as long
-    // as that day stayed inside the window: a month, on 1M.
-    const day = 24 * 60 * 60 * 1000;
-    const newest = 1_788_393_600_000;
-    const withGap = Array.from({ length: 30 }, (_, index) => ({
-      key: newest - (29 - index) * day,
-      doc_count: 10,
-    })).filter((_, index) => index !== 20);
-    mockedGet.mockResolvedValue({
-      error: '',
-      data: { number_by_day: withGap },
-    });
+  it('refuses a series with a bucket it cannot read', async () => {
+    // A malformed count charted as zero would draw a quiet day the chain
+    // never had, and dropping it would misalign the two stretches.
+    const list = buckets(14, 1, 24 * HOUR_MS);
+    list[5] = { ...list[5], count: undefined as unknown as number };
+    answer(list);
 
-    const series = await transactionSeriesCall(15);
-
-    expect(series).toHaveLength(30);
-    expect(series[20]).toEqual({ key: newest - 9 * day, doc_count: 0 });
-    // Every other day keeps its own figure, on its own key.
-    expect(series[19].doc_count).toBe(10);
-    expect(series[21].doc_count).toBe(10);
-    expect(series[29].key).toBe(newest);
-  });
-
-  it('keeps a full series, whatever order the route answered in', async () => {
-    const newest = 1_788_393_600_000;
-    const full = Array.from({ length: 30 }, (_, index) => ({
-      key: newest - index * DAY_MS,
-      doc_count: 10,
-    }));
-    mockedGet.mockResolvedValue({ error: '', data: { number_by_day: full } });
-
-    const series = await transactionSeriesCall(15);
-
-    expect(series).toHaveLength(30);
-    expect(series[0].key).toBe(newest - 29 * DAY_MS);
-    expect(series.every(point => point.doc_count === 10)).toBe(true);
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 });

--- a/src/services/requests/home/__tests__/transactionSeries.test.ts
+++ b/src/services/requests/home/__tests__/transactionSeries.test.ts
@@ -113,6 +113,18 @@ describe('transactionSeriesCall', () => {
     await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
 
+  it('refuses a timestamp Date cannot hold', async () => {
+    // Finite, but past the 8.64e15 ms Date can represent (nanoseconds would
+    // do it): every UTC field of it is NaN, and so would the label be. On the
+    // last bucket, so the series still runs in order and nothing but the Date
+    // check can refuse it.
+    const list = buckets(14, 1, 24 * HOUR_MS);
+    list[13] = { ...list[13], toMs: 1e20 };
+    answer(list);
+
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
+  });
+
   it('refuses a series that runs newest first', async () => {
     // Split down the middle, a reversed list draws the previous stretch as
     // the current one and inverts the percentage, with nothing to see.

--- a/src/services/requests/home/__tests__/transactionSeries.test.ts
+++ b/src/services/requests/home/__tests__/transactionSeries.test.ts
@@ -112,4 +112,20 @@ describe('transactionSeriesCall', () => {
 
     await expect(transactionSeriesCall(7)).resolves.toEqual([]);
   });
+
+  it('refuses a series that runs newest first', async () => {
+    // Split down the middle, a reversed list draws the previous stretch as
+    // the current one and inverts the percentage, with nothing to see.
+    answer([...buckets(14, 1, 24 * HOUR_MS)].reverse());
+
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
+  });
+
+  it('refuses a series with a repeated bucket', async () => {
+    const list = buckets(14, 1, 24 * HOUR_MS);
+    list[6] = { ...list[5] };
+    answer(list);
+
+    await expect(transactionSeriesCall(7)).resolves.toEqual([]);
+  });
 });

--- a/src/services/requests/home/__tests__/transactionSeries.test.ts
+++ b/src/services/requests/home/__tests__/transactionSeries.test.ts
@@ -1,6 +1,6 @@
 import api from '@/services/api';
 import {
-  POINTS_PER_STRETCH,
+  STRETCHES,
   transactionSeriesCall,
 } from '@/services/requests/home/transactionSeries';
 
@@ -39,7 +39,10 @@ describe('transactionSeriesCall', () => {
     expect(mockedGet).toHaveBeenCalledTimes(1);
     expect(mockedGet.mock.calls[0][0]).toEqual({
       route: 'transaction/statistics/series',
-      query: { interval: '1d', points: 7 * POINTS_PER_STRETCH },
+      // One attempt: where the route is not deployed, three would spin for a
+      // second and a half on an answer that cannot change.
+      tries: 1,
+      query: { interval: '1d', points: 7 * STRETCHES },
     });
     expect(series).toHaveLength(14);
   });
@@ -74,6 +77,18 @@ describe('transactionSeriesCall', () => {
 
     expect(series).toHaveLength(14);
     expect(series.every(point => point.doc_count === 0)).toBe(true);
+  });
+
+  it('does not retry a route that answered an error', async () => {
+    // api.get retries three times by default and sleeps 500ms after every
+    // attempt including the last, so a route that is not deployed yet would
+    // hold the chart on a spinner rather than showing its empty state.
+    mockedGet.mockResolvedValue({ error: 'not found' });
+
+    await transactionSeriesCall(7);
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet.mock.calls[0][0].tries).toBe(1);
   });
 
   it('answers nothing when the route failed', async () => {

--- a/src/services/requests/home/chartSeries.ts
+++ b/src/services/requests/home/chartSeries.ts
@@ -1,5 +1,22 @@
 import { ISeriesPoint } from '@/services/requests/home/transactionSeries';
-import { format } from 'date-fns';
+
+/** The keys the locale files carry under `Date.Months`, in calendar order. */
+const MONTH_KEYS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+const twoDigits = (value: number) => String(value).padStart(2, '0');
 
 /** One plotted point: a formatted date and the count it carries. */
 export interface IChartPoint {
@@ -45,19 +62,20 @@ export const buildChartSeries = (
     if (!point || !point.key || Number.isNaN(point.doc_count)) return acc;
 
     const date = new Date(point.key);
-    date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
 
-    // Hourly buckets sit 24 hours apart across the two stretches, so the same
-    // clock time labels both and a day label would repeat 24 times over.
+    // UTC, like every timestamp the explorer prints (formatFunctions reads the
+    // UTC fields too). Hourly buckets sit 24 hours apart across the two
+    // stretches, so one clock time labels both.
     if (options.hourly) {
-      acc.push({ date: format(date, 'HH:mm'), value: point.doc_count });
+      acc.push({
+        date: `${twoDigits(date.getUTCHours())}:${twoDigits(date.getUTCMinutes())}`,
+        value: point.doc_count,
+      });
       return acc;
     }
 
-    const [day, month] = format(date, 'dd MMM').split(' ');
-
     acc.push({
-      date: `${day} ${translateMonth(month)}`,
+      date: `${twoDigits(date.getUTCDate())} ${translateMonth(MONTH_KEYS[date.getUTCMonth()])}`,
       value: point.doc_count,
     });
 

--- a/src/services/requests/home/chartSeries.ts
+++ b/src/services/requests/home/chartSeries.ts
@@ -39,12 +39,20 @@ const EMPTY: IChartSeries = { pairs: [], total: 0, previousTotal: 0 };
 export const buildChartSeries = (
   points: ISeriesPoint[],
   translateMonth: (month: string) => string,
+  options: { hourly?: boolean } = {},
 ): IChartSeries => {
   const parsed = points.reduce((acc, point) => {
     if (!point || !point.key || Number.isNaN(point.doc_count)) return acc;
 
     const date = new Date(point.key);
     date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+
+    // Hourly buckets sit 24 hours apart across the two stretches, so the same
+    // clock time labels both and a day label would repeat 24 times over.
+    if (options.hourly) {
+      acc.push({ date: format(date, 'HH:mm'), value: point.doc_count });
+      return acc;
+    }
 
     const [day, month] = format(date, 'dd MMM').split(' ');
 

--- a/src/services/requests/home/chartSeries.ts
+++ b/src/services/requests/home/chartSeries.ts
@@ -92,6 +92,9 @@ export const buildChartSeries = (
   const past = parsed.slice(0, half);
   const now = parsed.slice(half);
 
+  // Paired by index on the route's contract: `points` buckets of one interval
+  // each, oldest first, so the i-th of each stretch spans the same time. Count
+  // and order are checked at the fetch; the interval itself is not re-measured.
   const pairs = past.map((txPast, index) => ({
     valueNow: now[index].value,
     dateNow: now[index].date,

--- a/src/services/requests/home/transactionSeries.ts
+++ b/src/services/requests/home/transactionSeries.ts
@@ -59,9 +59,13 @@ export const transactionSeriesCall = async (
 
     // A malformed bucket cannot be charted as a zero, which would draw as a
     // quiet interval the chain never had, and dropping it would pair every
-    // later point against the wrong counterpart.
+    // later point against the wrong counterpart. Finite is not enough for the
+    // timestamp: past 8.64e15 ms Date is invalid and its label prints NaN.
     const readable = parsed.every(
-      point => Number.isFinite(point.key) && Number.isFinite(point.doc_count),
+      point =>
+        Number.isFinite(point.key) &&
+        Number.isFinite(new Date(point.key ?? NaN).getTime()) &&
+        Number.isFinite(point.doc_count),
     );
     if (!readable) return [];
 

--- a/src/services/requests/home/transactionSeries.ts
+++ b/src/services/requests/home/transactionSeries.ts
@@ -1,110 +1,72 @@
 import api from '@/services/api';
-import {
-  ROLLING_WINDOW_MS,
-  rollingWindow,
-} from '@/services/requests/rollingWindow';
 
 /**
- * The daily series behind the home transactions chart, as `{ key, doc_count }`
- * entries oldest first, twice the period asked for so the caller can split it
- * into the current stretch and the one before it.
+ * The series behind the home transactions chart, oldest first, twice the
+ * period asked for so the caller can split it into the current stretch and the
+ * one before it.
  *
- * Two sources, because neither covers the whole range:
+ * `transaction/statistics/series` answers the whole range in one request with
+ * buckets that end at the moment of the call, so a point covers a whole
+ * interval that has elapsed. The per-day routes cannot: they bucket by UTC
+ * day, so their newest point holds only the part of today that has happened,
+ * which at 19:15 UTC read 4,329 against 8,275 for the day before it.
  *
- * `transaction/list` counts an explicit window, so a day means the 24 hours
- * ending now rather than one that resets at midnight UTC. It costs a request
- * per point, and the proxy refuses a burst: measured 2026-09-03, 20 parallel
- * requests all answered and 30 drew 429s, so it is used up to the 14 that a
- * week needs and no further.
- *
- * `transaction/list/count/<days>` answers the whole range in one request, but
- * its buckets are UTC days, so the newest is only the day so far: at 19:15
- * UTC it held 4,329 against 8,275 for the day before it.
+ * It also guarantees exactly the number of buckets asked for, with a quiet one
+ * reported as 0 rather than left out. The count route omits a quiet day and
+ * the histogram route truncates leading and trailing ones, which left a caller
+ * unable to tell a short answer from a full one.
  */
-export const ROLLING_POINT_LIMIT = 14;
+
+/** Buckets the chart draws per period, one for each stretch it compares. */
+export const POINTS_PER_STRETCH = 2;
 
 export interface ISeriesPoint {
   key: number;
   doc_count: number;
 }
 
-const rollingSeries = async (points: number): Promise<ISeriesPoint[]> => {
-  // One clock reading for the set, or the windows drift apart by however long
-  // the requests take to leave.
-  const now = Date.now();
-
-  const counts = await Promise.all(
-    Array.from({ length: points }, (_, index) => {
-      const window = rollingWindow(points - 1 - index, now);
-      return api
-        .get({
-          route: 'transaction/list',
-          // One attempt: api.get retries three times by default with a fixed
-          // 500ms gap, so a burst that drew a 429 would come back as three
-          // times the requests that caused it. Fourteen is already the
-          // measured ceiling.
-          tries: 1,
-          query: { limit: 1, minify: true, ...window },
-        })
-        .then(response => ({
-          key: window.enddate,
-          total: response?.error
-            ? undefined
-            : response?.pagination?.totalRecords,
-        }));
-    }),
-  );
-
-  // One refused request would otherwise draw as a day with no transactions.
-  if (counts.some(point => !Number.isFinite(point.total))) return [];
-
-  return counts.map(point => ({
-    key: point.key,
-    doc_count: point.total as number,
-  }));
-};
-
-const bucketSeries = async (days: number): Promise<ISeriesPoint[]> => {
-  const response = await api.get({
-    route: `transaction/list/count/${days}`,
-  });
-  if (response?.error) return [];
-
-  const buckets = response?.data?.number_by_day;
-  if (!Array.isArray(buckets)) return [];
-
-  const usable = [...buckets].filter(
-    bucket =>
-      Number.isFinite(bucket?.key) && Number.isFinite(bucket?.doc_count),
-  );
-  if (!usable.length) return [];
-
-  // Laid onto the day grid rather than passed through as answered. The route
-  // omits a day that carried no data, and the caller splits this list down
-  // the middle, so a missing day would pair every later one against the
-  // wrong counterpart. Refusing the whole series for that turned one quiet
-  // day into a chart that stays empty for the next month; an omitted day is
-  // a known zero, not an unknown, so it is filled in as one.
-  //
-  // A bucket whose key or count was malformed is different: its value cannot
-  // be known, and it is dropped above, which the grid then shows as a zero
-  // as well. That is the one case where a zero is drawn for a day that may
-  // have carried transactions, and it takes a malformed answer to reach it.
-  const byKey = new Map(usable.map(bucket => [bucket.key, bucket.doc_count]));
-  const newest = Math.max(...usable.map(bucket => bucket.key));
-  return Array.from({ length: days }, (_, index) => {
-    const key = newest - (days - 1 - index) * ROLLING_WINDOW_MS;
-    return { key, doc_count: byKey.get(key) ?? 0 };
-  });
-};
+interface ISeriesBucket {
+  fromMs?: number;
+  toMs?: number;
+  count?: number;
+}
 
 /**
- * `period` is the number of days one stretch covers; the series returned holds
- * two of them, oldest first.
+ * `period` is the number of days one stretch covers. An hour interval is used
+ * where a day would give a single point per stretch, which draws as two dots
+ * and no line.
  */
 export const transactionSeriesCall = async (
   period: number,
-): Promise<ISeriesPoint[]> =>
-  period * 2 <= ROLLING_POINT_LIMIT
-    ? rollingSeries(period * 2)
-    : bucketSeries(period * 2);
+): Promise<ISeriesPoint[]> => {
+  const hourly = period === 1;
+  const points = period * POINTS_PER_STRETCH * (hourly ? 24 : 1);
+
+  try {
+    const response = await api.get({
+      route: 'transaction/statistics/series',
+      query: { interval: hourly ? '1h' : '1d', points },
+    });
+    if (response?.error) return [];
+
+    const buckets = response?.data?.transaction_series?.buckets;
+    if (!Array.isArray(buckets) || buckets.length !== points) return [];
+
+    const parsed = buckets.map((bucket: ISeriesBucket) => ({
+      key: bucket?.toMs,
+      doc_count: bucket?.count,
+    }));
+
+    // A malformed bucket cannot be charted as a zero, which would draw as a
+    // quiet interval the chain never had, and dropping it would pair every
+    // later point against the wrong counterpart.
+    return parsed.every(
+      point => Number.isFinite(point.key) && Number.isFinite(point.doc_count),
+    )
+      ? (parsed as ISeriesPoint[])
+      : [];
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};

--- a/src/services/requests/home/transactionSeries.ts
+++ b/src/services/requests/home/transactionSeries.ts
@@ -60,11 +60,19 @@ export const transactionSeriesCall = async (
     // A malformed bucket cannot be charted as a zero, which would draw as a
     // quiet interval the chain never had, and dropping it would pair every
     // later point against the wrong counterpart.
-    return parsed.every(
+    const readable = parsed.every(
       point => Number.isFinite(point.key) && Number.isFinite(point.doc_count),
-    )
-      ? (parsed as ISeriesPoint[])
-      : [];
+    );
+    if (!readable) return [];
+
+    // Oldest first is what the caller splits on: a reversed or repeated bucket
+    // would swap the stretches or pair them off by one, with no visible fault.
+    const series = parsed as ISeriesPoint[];
+    const ordered = series.every(
+      (point, index) => index === 0 || point.key > series[index - 1].key,
+    );
+
+    return ordered ? series : [];
   } catch (error) {
     console.error(error);
     return [];

--- a/src/services/requests/home/transactionSeries.ts
+++ b/src/services/requests/home/transactionSeries.ts
@@ -17,8 +17,15 @@ import api from '@/services/api';
  * unable to tell a short answer from a full one.
  */
 
-/** Buckets the chart draws per period, one for each stretch it compares. */
-export const POINTS_PER_STRETCH = 2;
+/** The chart draws the period asked for beside the one before it. */
+export const STRETCHES = 2;
+
+/**
+ * A day is drawn hour by hour: one point per stretch draws as two dots and no
+ * line. The label mode follows from the same answer, so both sides of the
+ * chart read it here rather than each testing the period for itself.
+ */
+export const isHourly = (period: number): boolean => period === 1;
 
 export interface ISeriesPoint {
   key: number;
@@ -39,12 +46,17 @@ interface ISeriesBucket {
 export const transactionSeriesCall = async (
   period: number,
 ): Promise<ISeriesPoint[]> => {
-  const hourly = period === 1;
-  const points = period * POINTS_PER_STRETCH * (hourly ? 24 : 1);
+  const hourly = isHourly(period);
+  const points = period * STRETCHES * (hourly ? 24 : 1);
 
   try {
     const response = await api.get({
       route: 'transaction/statistics/series',
+      // One attempt. api.get retries three times by default and sleeps 500ms
+      // after every attempt including the last, so where the route is not
+      // deployed yet a period switch would spin for 1,5 seconds before the
+      // empty state appears, for an answer that cannot change.
+      tries: 1,
       query: { interval: hourly ? '1h' : '1d', points },
     });
     if (response?.error) return [];
@@ -63,8 +75,9 @@ export const transactionSeriesCall = async (
     // timestamp: past 8.64e15 ms Date is invalid and its label prints NaN.
     const readable = parsed.every(
       point =>
+        typeof point.key === 'number' &&
         Number.isFinite(point.key) &&
-        Number.isFinite(new Date(point.key ?? NaN).getTime()) &&
+        Number.isFinite(new Date(point.key).getTime()) &&
         Number.isFinite(point.doc_count),
     );
     if (!readable) return [];


### PR DESCRIPTION
## What this changes

Follow-up to #711, which fixed the home transactions chart's period length and
its percentage but had to leave two things standing: 1D was dropped because a
day gives one point per stretch, which draws as two dots and no line, and 15D
and 1M kept reading UTC-day buckets because the rolling source cost one request
per point and the proxy refuses a burst of thirty. Both were waiting on a route
that answers a whole series in one request. That route is
`transaction/statistics/series` (klever-proxy-go #456), and every period reads
it now.

- **One request per period.** The route returns buckets of an hour or a day
  that end at the moment of the call, oldest first, exactly as many as asked
  for, with a quiet bucket reported as zero rather than left out. 7D's fourteen
  parallel requests, the day-grid repair that 15D and 1M needed, and the retry
  cap on bursts all go with it.
- **1D is back**, drawn as 24 hourly points per stretch. The tooltip labels
  them by clock time, in UTC like every other timestamp here, which names
  both stretches at once since their buckets sit exactly a day apart.
- **15D and 1M end at the request, not at midnight UTC.** Their newest point
  used to hold only the part of today that had happened.

An answer that is short, or carries a bucket that cannot be read, is refused
rather than charted: a series shorter than asked for would pair every later
point against the wrong counterpart, and a malformed bucket cannot become a
zero without drawing a quiet hour the chain never had. The chart then shows its
empty state, the same as for an error.

## Rollout

The route is live on the staging host and on testnet, which CI runs against,
and not yet on mainnet. That is the intended order: mainnet's proxy and this
explorer are updated together once testing is done. Until then the call on
mainnet answers 404, which reads as an empty series, and the chart shows its
empty state rather than a wrong figure.

## Verification

Read in a browser against the API within the same minute: 1D 5,179 against
5,182, 7D 50,260 against 50,262 with -19.21% on both, 15D 118,653 against
118,655 and 1M 199,904 against 199,905. The sum of the 24 hourly buckets equals
the rolling 24h route exactly, 5,187 on both. The network shows one series
request per period switch.

131 suites, 1556 tests. The request module and the series builder measure 100%
on statements, branches, functions and lines; the chart component's two
unvisited sides, the catch and the "1M" label, predate this change and are
outside the diff. An earlier version of this description claimed every branch
side was visited on the request module while one was not, an unreachable
operand behind a short-circuit, raised in review and since removed. Every new check was
run once in a broken state and each failed on the test written for it: the
length guard, the finite guard, the hourly label mode, the empty state, and the
component wiring with the 1D button removed, hourly forced off and hourly
forced on. The review round added a test on the UTC labels (a bucket ending
23:30 UTC, which a local-time build names the next day anywhere east of UTC)
and two on bucket order, each run in a broken state as well.

The e2e suite was run the way CI runs it, against a production build with the
local environment file set aside: 125 tests, none failing.

The review round on this PR added seven changes, in fc80649: one exported
predicate decides which periods are hourly, so the request and the labels
cannot disagree; the call asks once rather than three times, so an environment
where the route is not deployed shows its empty state instead of spinning; the
race guard and its test no longer explain themselves by the request model this
PR deletes; `STRETCHES` is named for what it holds; a `typeof` narrowing
replaces an unreachable operand; a duplicate import is folded away; and the
contract naming rule the legend uses is applied to the bar's own tooltip, with
a test that renders the legend subtree at all, taking that file from 40% to
77% branch coverage.

## Also in this PR: the smart contracts summary at narrow widths

The summary card's legend under the distribution bar scrolled sideways on anything narrower than tablet width, and the two figure tiles stacked below 390px. Both are laid out for the width now, and the loading shape follows the same rules, so the card is the same height before and after the figures land, at every width.

- **Legend.** Six items (the five busiest contracts and "Other") need 921px on one row, measured. Below tablet width they sit on a grid: three columns for two rows down to 520px, two columns for three rows below that. A row that wrapped by itself would make the card's height depend on contract names, which no loading shape can predict; the grid pins the row count, and the row height is the item's own line box. A name wider than its column ends in an ellipsis and carries its full text as a title. With today's top five only the longest is cut down to 390px; at 320px four of the six are.
- **Tiles.** Below 390px two tiles beside each other are 115 to 145px wide, too narrow for "Contract transactions" on one line, which is why they stacked. They stay side by side with both labels on two lines (capped at 9em so "Contracts deployed" breaks too and the values stay level), and a tile holds the 85px it measures at 320px with a two-line label and a two-line sub line.
- **Loading shape.** The legend placeholder renders six pills on the card's own legend row, so it takes the same grid, and the pill's margins add up to the item's line box (16.5px at 12px), which also closes the half pixel the desktop legend had between the two states.

### Verification

Measured in a browser with the summary requests stalled for the loading shape and then answered for the loaded card, at 1280, 1100, 1025, 1000, 900, 768, 700, 600, 520, 500, 440, 390, 380, 360, 340 and 320px: the card is the same height in both states at every width, a difference of 0 (0.5px on desktop before the pill fix). Below 390px both labels take two lines without overflowing and the tiles measure 85px in both states; the legend is two rows down to 520px and three below it, in both states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a 1-day transaction period with hourly chart data and clock-time labels.
  - Transaction charts now display two data points for each selected interval.
  - Improved Smart Contracts summaries with clearer contract labels and descriptive hover information.

- **Bug Fixes**
  - Improved handling of empty, incomplete, invalid, or failed transaction data.
  - Standardized chart date labels across time zones.
  - Improved responsive summary layouts and loading placeholders.

- **Tests**
  - Expanded coverage for hourly labels, chart states, response validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
