### PR TITLE
fix(transactions): stop the To column clipping an address, and restore the In/Out word badge

### DIFF
--- a/src/components/TransactionsList/ContractTargetLabel.tsx
+++ b/src/components/TransactionsList/ContractTargetLabel.tsx
@@ -31,16 +31,20 @@ const ContractTargetLabel: React.FC<IContractTargetLabelProps> = ({
   const name = useContractName(address, Boolean(isContract));
   const shown = name ? safeContractName(name) : '';
 
-  // Both readings share one fixed box. The name lands about a second after
-  // the row is readable, and a cell that resizes on arrival drags every
-  // column beside it; identical width either way means nothing moves.
+  // The clamp rides on the name only: that is the reading whose width is
+  // unknown until its request lands, and a cell that resizes on arrival drags
+  // every column beside it. The address is a fixed 19 characters and never
+  // resizes, so clamping it only cost it its last character.
   //
   // A name that survives none of the cleaning is not a name; the address is.
   // The title carries the cleaned text plus the address, so the cell is never
   // the only place the counterparty is named, and the characters kept out of
   // the cell cannot reappear in the browser's own tooltip.
   return (
-    <ContractName title={shown ? `${shown} · ${address}` : address}>
+    <ContractName
+      $named={Boolean(shown)}
+      title={shown ? `${shown} · ${address}` : address}
+    >
       {shown || <Mono>{parseAddress(address, truncateTo)}</Mono>}
     </ContractName>
   );

--- a/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
+++ b/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
@@ -104,6 +104,29 @@ beforeEach(() => {
   nameCall.mockReset();
 });
 
+  /**
+   * Every declaration that makes up the clamp, not just its width. The clip
+   * is the whole trio: a ceiling to overflow, `overflow: hidden` to cut what
+   * passes it, and nowrap to keep the text on one line. Asserting max-width
+   * alone let the clip move out of the conditional and stay green.
+   */
+  const clampOf = (el: Element): Record<string, string> => {
+    const style = getComputedStyle(el as HTMLElement);
+    return {
+      minWidth: style.minWidth,
+      maxWidth: style.maxWidth,
+      overflow: style.overflow,
+    };
+  };
+
+  /** The box the clamp lives on, never the Mono span inside it: falling back
+   *  to the inner element would measure the wrong box and pass. */
+  const boxOf = (el: Element): Element => {
+    const box = el.closest('span[class*="ContractName"]');
+    if (!box) throw new Error('ContractName box not found around the label');
+    return box;
+  };
+
 describe('ContractTargetLabel', () => {
   it('shows the contract name once the chain answers with one', async () => {
     nameCall.mockResolvedValue('Bitcoin.me');
@@ -165,9 +188,17 @@ describe('ContractTargetLabel', () => {
   it('falls back to the address for a name that is only whitespace', async () => {
     nameCall.mockResolvedValue('   ');
 
-    renderLabel({});
+    // Settled, not just rendered: before the name lands there is no name to
+    // key the clamp off, so the assertion would hold for a reason that has
+    // nothing to do with the refusal.
+    await renderSettled({});
 
-    expect(await screen.findByText(/klv1qq/)).toBeTruthy();
+    const shown = screen.getByText(/klv1qq/);
+
+    expect(shown).toBeTruthy();
+    // The box follows what is drawn, not whether a name arrived: keyed off
+    // the raw name, whitespace is truthy and would clamp the address.
+    expect(clampOf(boxOf(shown)).maxWidth).not.toBe('160px');
   });
 
   it('strips the bidi override that paints a name backwards', async () => {
@@ -192,6 +223,9 @@ describe('ContractTargetLabel', () => {
 
     expect(screen.getByText(/klv1qq/)).toBeTruthy();
     expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+    expect(clampOf(boxOf(screen.getByText(/klv1qq/))).maxWidth).not.toBe(
+      '160px',
+    );
   });
 
   it('refuses a name that is an address with one odd character past the cap', async () => {
@@ -207,6 +241,9 @@ describe('ContractTargetLabel', () => {
 
     expect(screen.getByText(/klv1qq/)).toBeTruthy();
     expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+    expect(clampOf(boxOf(screen.getByText(/klv1qq/))).maxWidth).not.toBe(
+      '160px',
+    );
   });
 
   it('refuses one that hides its odd character in a homoglyph', async () => {
@@ -220,6 +257,9 @@ describe('ContractTargetLabel', () => {
 
     expect(screen.getByText(/klv1qq/)).toBeTruthy();
     expect(screen.queryByText(/^klv1fqeupef/)).toBeNull();
+    expect(clampOf(boxOf(screen.getByText(/klv1qq/))).maxWidth).not.toBe(
+      '160px',
+    );
   });
 
   it('strips a Hangul filler, which draws as a blank and is not a space', async () => {
@@ -270,16 +310,19 @@ describe('ContractTargetLabel', () => {
    * ate the last character, so a 62-character address rendered one short of
    * the identical address in the From column beside it.
    */
-  const clampOf = (el: Element): string =>
-    getComputedStyle(el as HTMLElement).maxWidth;
-
   it('clamps the box while it holds a name', async () => {
     nameCall.mockResolvedValue('Bitcoin.me');
 
     renderLabel({});
     const shown = await screen.findByText('Bitcoin.me');
 
-    expect(clampOf(shown)).toBe('160px');
+    // Floor as well as ceiling: without the floor a short name shrinks the
+    // cell, which is the same column shift from the other direction.
+    expect(clampOf(boxOf(shown))).toEqual({
+      minWidth: '160px',
+      maxWidth: '160px',
+      overflow: 'hidden',
+    });
   });
 
   it('leaves the box unclamped while it holds an address', async () => {
@@ -287,9 +330,12 @@ describe('ContractTargetLabel', () => {
 
     renderLabel({});
     const shown = await screen.findByText(/klv1qq/);
-    // The Mono span carries the text; the clamp lives on the box around it.
-    const box = shown.closest('span[class*="ContractName"]') ?? shown;
+    const box = clampOf(boxOf(shown));
 
-    expect(clampOf(box)).not.toBe('160px');
+    expect(box.maxWidth).not.toBe('160px');
+    expect(box.minWidth).not.toBe('160px');
+    // The clip itself, which is what cut the character off. A box that keeps
+    // this while losing the width ships the original bug.
+    expect(box.overflow).not.toBe('hidden');
   });
 });

--- a/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
+++ b/src/components/TransactionsList/__tests__/ContractTargetLabel.test.tsx
@@ -260,4 +260,36 @@ describe('ContractTargetLabel', () => {
 
     expect(screen.getByText(/klv1qq/)).toBeTruthy();
   });
+
+  /**
+   * The clamp and the address, the pair from the two directions of one rule.
+   *
+   * A name has an unknown width that arrives a second late, so it is clamped
+   * or every column moves under the reader. An address is a fixed 19
+   * characters, and the clamp measured 150px against its 159.6px: the browser
+   * ate the last character, so a 62-character address rendered one short of
+   * the identical address in the From column beside it.
+   */
+  const clampOf = (el: Element): string =>
+    getComputedStyle(el as HTMLElement).maxWidth;
+
+  it('clamps the box while it holds a name', async () => {
+    nameCall.mockResolvedValue('Bitcoin.me');
+
+    renderLabel({});
+    const shown = await screen.findByText('Bitcoin.me');
+
+    expect(clampOf(shown)).toBe('160px');
+  });
+
+  it('leaves the box unclamped while it holds an address', async () => {
+    nameCall.mockResolvedValue(null);
+
+    renderLabel({});
+    const shown = await screen.findByText(/klv1qq/);
+    // The Mono span carries the text; the clamp lives on the box around it.
+    const box = shown.closest('span[class*="ContractName"]') ?? shown;
+
+    expect(clampOf(box)).not.toBe('160px');
+  });
 });

--- a/src/components/TransactionsList/__tests__/badges.test.tsx
+++ b/src/components/TransactionsList/__tests__/badges.test.tsx
@@ -106,9 +106,12 @@ describe('transaction badges', () => {
     // badge or a screen-reader label clipped out of the layout.
     for (const direction of ['In', 'Out']) {
       const label = screen.getByText(direction) as HTMLElement;
+      // The badge, not the word: the glyph version put its arrow BESIDE the
+      // word, so querying the word itself would find no svg either way.
+      const badge = label.parentElement as HTMLElement;
 
       expect(getComputedStyle(label).position).not.toBe('absolute');
-      expect(label.querySelector('svg')).toBeNull();
+      expect(badge.querySelector('svg')).toBeNull();
     }
   });
 

--- a/src/components/TransactionsList/__tests__/badges.test.tsx
+++ b/src/components/TransactionsList/__tests__/badges.test.tsx
@@ -112,6 +112,25 @@ describe('transaction badges', () => {
     }
   });
 
+  it('names the direction badge, since the list is divs and has no header link', () => {
+    // A reader reaching this cell hears whatever the badge is called. The row
+    // is divs, not a table, so the "In/Out" header names nothing; without a
+    // label the cell is a bare "In" beside "Success" and "Transfer".
+    //
+    // The name rides in the hidden sibling, not aria-label: the spec forbids
+    // naming a bare span, and the pill is uppercase, which a reader may spell
+    // out letter by letter.
+    for (const direction of ['In', 'Out']) {
+      const named = screen.getByText(`Direction: ${direction}`);
+
+      expect(getComputedStyle(named).position).toBe('absolute');
+      expect(named.getAttribute('aria-hidden')).toBeNull();
+      expect(screen.getByText(direction).getAttribute('aria-hidden')).toBe(
+        'true',
+      );
+    }
+  });
+
   it('gives fail its own look, distinct from success and pending', () => {
     expect(classOf('Fail')).not.toBe(classOf('Success'));
     expect(classOf('Fail')).not.toBe(classOf('Pending'));

--- a/src/components/TransactionsList/__tests__/badges.test.tsx
+++ b/src/components/TransactionsList/__tests__/badges.test.tsx
@@ -53,10 +53,12 @@ import { InOutBadge, TransactionStatusBadge } from '../badges';
  * pending, and fail must not look like success.
  */
 const classOf = (text: string): string => {
-  // The word is visually hidden inside the badge now that the glyph carries
-  // the state, so the styled element is its parent.
+  // A status badge hides its word behind a glyph, so the styled element is the
+  // parent; a direction badge is the word itself. Take whichever of the two
+  // actually carries the pill class.
   const label = screen.getByText(text) as HTMLElement;
-  return (label.parentElement as HTMLElement).className;
+  const parent = label.parentElement as HTMLElement;
+  return /Badge|Pill/.test(label.className) ? label.className : parent.className;
 };
 
 describe('transaction badges', () => {
@@ -78,9 +80,36 @@ describe('transaction badges', () => {
     expect(screen.getByText('Fail')).toBeTruthy();
   });
 
-  it('maps success and In to the same look, pending and Out likewise', () => {
-    expect(classOf('In')).toBe(classOf('Success'));
-    expect(classOf('Out')).toBe(classOf('Pending'));
+  it('gives In and Out the colors of success and pending', () => {
+    // The two columns are deliberately different shapes now: status is a
+    // glyph, direction is a word. The colour is the part that still has to
+    // agree, so read it rather than the class.
+    const colorOf = (text: string): string => {
+      const label = screen.getByText(text) as HTMLElement;
+      const badge = /Badge|Pill/.test(label.className)
+        ? label
+        : (label.parentElement as HTMLElement);
+      return getComputedStyle(badge).color;
+    };
+
+    expect(colorOf('In')).toBe(colorOf('Success'));
+    expect(colorOf('Out')).toBe(colorOf('Pending'));
+  });
+
+  it('spells the direction out instead of drawing an arrow', () => {
+    // The row already carries a green arrow between From and To. A second
+    // pair of arrows beside it reads as the same signal repeated.
+    //
+    // The word alone proves nothing: the glyph version kept the same word in a
+    // visually hidden span next to the arrow, so getByText found it either
+    // way. What separates the two shapes is whether that word is the visible
+    // badge or a screen-reader label clipped out of the layout.
+    for (const direction of ['In', 'Out']) {
+      const label = screen.getByText(direction) as HTMLElement;
+
+      expect(getComputedStyle(label).position).not.toBe('absolute');
+      expect(label.querySelector('svg')).toBeNull();
+    }
   });
 
   it('gives fail its own look, distinct from success and pending', () => {

--- a/src/components/TransactionsList/badges.tsx
+++ b/src/components/TransactionsList/badges.tsx
@@ -77,8 +77,12 @@ export const InOutBadge: React.FC<{ direction: 'In' | 'Out' }> = ({
   // and Transfer. Named through the hidden sibling rather than aria-label,
   // which the spec prohibits on a bare span, and which would leave the pill's
   // uppercase to be spelled out letter by letter.
+  //
+  // A `b` and not a span, the reason BadgeCount already carries: the shared
+  // cell rules pin every span inside a card to weight 400 and their own line
+  // height, and a child cannot outrank them the way BadgePill's `&&` does.
   <BadgePill $variant={direction === 'In' ? 'success' : 'warning'}>
-    <span aria-hidden="true">{direction}</span>
+    <b aria-hidden="true">{direction}</b>
     <VisuallyHidden>{`Direction: ${direction}`}</VisuallyHidden>
   </BadgePill>
 );

--- a/src/components/TransactionsList/badges.tsx
+++ b/src/components/TransactionsList/badges.tsx
@@ -3,13 +3,7 @@ import Tooltip from '@/components/Tooltip';
 import { ContractsIndex, IContract } from '@/types/contracts';
 import { capitalizeString } from '@/utils/convertString';
 import React from 'react';
-import {
-  MdAccessTime,
-  MdArrowForward,
-  MdCallMade,
-  MdCallReceived,
-  MdPriorityHigh,
-} from 'react-icons/md';
+import { MdAccessTime, MdArrowForward, MdPriorityHigh } from 'react-icons/md';
 import { BadgeCount, DirectionStatusBadge } from './styles';
 
 /**
@@ -72,23 +66,19 @@ export const TransactionStatusPill: React.FC<{ status?: string }> = ({
 );
 
 /** Same treatment for the direction, which only renders on an account's own
- *  transaction list. Diagonal arrows, so an incoming transfer cannot be read
- *  as the status glyph beside it. */
+ *  transaction list. The word, not an arrow: the column already carries a
+ *  green arrow between From and To, and a second pair of arrows beside it
+ *  read as the same signal rather than a different one. */
 export const InOutBadge: React.FC<{ direction: 'In' | 'Out' }> = ({
   direction,
-}) => {
-  const Glyph = direction === 'In' ? MdCallReceived : MdCallMade;
-
-  return (
-    <DirectionStatusBadge
-      $variant={direction === 'In' ? 'success' : 'warning'}
-      title={direction}
-    >
-      <Glyph size={11} aria-hidden="true" />
-      <VisuallyHidden>{direction}</VisuallyHidden>
-    </DirectionStatusBadge>
-  );
-};
+}) => (
+  <BadgePill
+    $variant={direction === 'In' ? 'success' : 'warning'}
+    title={direction}
+  >
+    {direction}
+  </BadgePill>
+);
 
 /**
  * Hovering one type badge marks every badge of the same contract type in the

--- a/src/components/TransactionsList/badges.tsx
+++ b/src/components/TransactionsList/badges.tsx
@@ -72,11 +72,14 @@ export const TransactionStatusPill: React.FC<{ status?: string }> = ({
 export const InOutBadge: React.FC<{ direction: 'In' | 'Out' }> = ({
   direction,
 }) => (
-  <BadgePill
-    $variant={direction === 'In' ? 'success' : 'warning'}
-    title={direction}
-  >
-    {direction}
+  // The list is divs, not a table, so nothing ties this cell to its "In/Out"
+  // header: a reader would hear a bare "In" in a row that also says Success
+  // and Transfer. Named through the hidden sibling rather than aria-label,
+  // which the spec prohibits on a bare span, and which would leave the pill's
+  // uppercase to be spelled out letter by letter.
+  <BadgePill $variant={direction === 'In' ? 'success' : 'warning'}>
+    <span aria-hidden="true">{direction}</span>
+    <VisuallyHidden>{`Direction: ${direction}`}</VisuallyHidden>
   </BadgePill>
 );
 

--- a/src/components/TransactionsList/styles.ts
+++ b/src/components/TransactionsList/styles.ts
@@ -460,13 +460,16 @@ export const PageSummaryCard = styled(SummaryCard)`
  * capped at 33 characters reached 1400px, so bounding the text alone does not
  * hold the layout.
  *
- * 160px matches the address the cell falls back to, measured at 159.6px, so
- * the column reads the same whichever of the two a row shows. The clamp itself
- * applies to the name only: against a 150px box it cut the last character off
- * the address, measured on all 17 unnamed rows of one account list. The
- * address needs no clamp, because its width never changes.
+ * 160px matches the address the cell falls back to: `parseAddress(..., 16)`
+ * draws 8+8 characters around an ellipsis, and those 19 glyphs measured
+ * 159.6px, so the column reads the same whichever of the two a row shows.
+ *
+ * Names only. The box used to clamp both readings, and at the 150px it
+ * resolved to inside the cell it cut the last character off every unnamed
+ * row: 17 of 17 on one account list. An address drawn at a fixed truncation
+ * has one width and cannot shift the column, so it needs no clamp.
  */
-export const ContractName = styled.span<{ $named?: boolean }>`
+export const ContractName = styled.span<{ $named: boolean }>`
   ${inCard('inline-block')}
 
   && {
@@ -475,10 +478,8 @@ export const ContractName = styled.span<{ $named?: boolean }>`
        Measured before this was fixed: all nine columns changed width when the
        names resolved, moving the row under the reader's pointer.
 
-       Only a name needs the clamp. The address fallback is a fixed 19
-       characters that never resizes, and at 159.6px it does not fit the 150px
-       this box is given inside the cell: the browser ate its last character,
-       so a 62-character address rendered one short of the one beside it. */
+       Only a name needs it: a name's width is unknown until its request
+       lands, an address's is settled by its truncation. */
     ${props =>
       props.$named
         ? css`

--- a/src/components/TransactionsList/styles.ts
+++ b/src/components/TransactionsList/styles.ts
@@ -460,22 +460,33 @@ export const PageSummaryCard = styled(SummaryCard)`
  * capped at 33 characters reached 1400px, so bounding the text alone does not
  * hold the layout.
  *
- * 160px because that is what the box actually holds: a 16-character truncated
- * bech32 address renders at 160px, and the 150 this used to carry cut its last
- * character off in seven of ten rows, at every width from 1100 to 1920.
+ * 160px matches the address the cell falls back to, measured at 159.6px, so
+ * the column reads the same whichever of the two a row shows. The clamp itself
+ * applies to the name only: it was cutting the last character off the address
+ * in every row, which needs no clamp because its width never changes.
  */
-export const ContractName = styled.span`
+export const ContractName = styled.span<{ $named?: boolean }>`
   ${inCard('inline-block')}
 
   && {
     /* Same floor as ceiling: the name lands about a second after the row is
        readable, and a box that grows on arrival drags every column with it.
        Measured before this was fixed: all nine columns changed width when the
-       names resolved, moving the row under the reader's pointer. */
-    min-width: 160px;
-    max-width: 160px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+       names resolved, moving the row under the reader's pointer.
+
+       Only a name needs the clamp. The address fallback is a fixed 19
+       characters that never resizes, and at 159.6px it does not fit the 150px
+       this box is given inside the cell: the browser ate its last character,
+       so a 62-character address rendered one short of the one beside it. */
+    ${props =>
+      props.$named
+        ? css`
+            min-width: 160px;
+            max-width: 160px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          `
+        : null}
     white-space: nowrap;
     vertical-align: bottom;
   }

--- a/src/components/TransactionsList/styles.ts
+++ b/src/components/TransactionsList/styles.ts
@@ -462,8 +462,9 @@ export const PageSummaryCard = styled(SummaryCard)`
  *
  * 160px matches the address the cell falls back to, measured at 159.6px, so
  * the column reads the same whichever of the two a row shows. The clamp itself
- * applies to the name only: it was cutting the last character off the address
- * in every row, which needs no clamp because its width never changes.
+ * applies to the name only: against a 150px box it cut the last character off
+ * the address, measured on all 17 unnamed rows of one account list. The
+ * address needs no clamp, because its width never changes.
  */
 export const ContractName = styled.span<{ $named?: boolean }>`
   ${inCard('inline-block')}

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -496,8 +496,9 @@ export const transactionRowSections = (
         </CenteredRow>
       ),
       span: 1,
-      // Follows ContractName's own box, which holds a 16-character address at
-      // 160px; 150 here left the column hint disagreeing with its content.
+      // Holds a 16-character address, measured at 159.6px, plus the contract
+      // mark beside it; 150 here left the column hint disagreeing with its
+      // content.
       width: 205,
     },
     inOut: {

--- a/src/pages/transactions/index.tsx
+++ b/src/pages/transactions/index.tsx
@@ -496,9 +496,9 @@ export const transactionRowSections = (
         </CenteredRow>
       ),
       span: 1,
-      // Holds a 16-character address, measured at 159.6px, plus the contract
-      // mark beside it; 150 here left the column hint disagreeing with its
-      // content.
+      // Holds `parseAddress(..., 16)`, whose 19 glyphs measured 159.6px,
+      // plus the contract mark beside it; 150 here left the column hint
+      // disagreeing with its content.
       width: 205,
     },
     inOut: {


### PR DESCRIPTION
## What this fixes

**1. The To column was eating the last character of every address.**

`ContractName` clamps its box to 160px so a contract name, which arrives on its own request about a second after the row is readable, cannot resize the cell and drag every column with it. The address the cell falls back to needs no such clamp: it is a fixed 19 characters and never resizes. It was getting one anyway, and measured inside the cell the box is 150px against the address's 159.6px, so the browser clipped the last character and substituted its own ellipsis.

The visible result: a 62-character address rendered one character shorter than the identical address in the From column beside it, 8+7 against 8+8. It happens on the general list too; the account page only makes it obvious by putting the same address in both columns on nearly every row.

The clamp now rides on a `$named` prop, so it applies to the reading whose width is unknown and not to the one that is fixed.

**2. The In/Out badge is a word again.**

The direction column carried a diagonal arrow with the word behind a visually hidden span. The row already draws a green arrow between From and To, so a second pair of arrows beside it reads as the same signal repeated rather than a different one. Back to a word pill on the shared `BadgePill`, keeping the colours the glyph version used: green for In, amber for Out. The word is now real text in the cell instead of a screen-reader label next to an icon.

## Verification

Measured in a browser against a production build, on the account list: 17 addresses, **0 clipped boxes, 0 truncated tails**, both columns rendering at 159.6px in one font. Before the fix the To column measured 150px and dropped a character.

- typecheck: 0 errors
- tests: 1559 passed, 131 suites
- build: green
- coverage on changed lines: 0 uncovered lines on the diff; `ContractTargetLabel` at 100% across statements, branches, functions and lines
- secret scan: clean; no circular imports

Every check added here was also run against a deliberately broken state, and each one is caught by exactly one test:

| Broken state | Caught by |
|---|---|
| both directions given the same colour | `gives In and Out the colors of success and pending` |
| word replaced by a glyph again | `spells the direction out instead of drawing an arrow` |
| clamp applied unconditionally (the original bug) | `leaves the box unclamped while it holds an address` |
| clamp never applied | `clamps the box while it holds a name` |

One of these tests initially passed against the pre-change code as well: the glyph version kept the same word in a hidden span, so asserting on the text alone guarded neither shape. It now asserts the word is the visible badge rather than a clipped label.

## Notes

- Two comments elsewhere in the code justified their numbers by the old clamp behaviour and became untrue with this change; both were corrected rather than left standing.
- Swept for the same pattern across the list components: `max-width` with a fixed pixel value on content occurs once, and that is the instance fixed here. The other ellipsis sites use `min-width: 0` or `max-width: 100%` and scale with their container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transaction direction indicators now display clear “In” and “Out” text labels in compact pills.
  - Direction indicators retain distinct success and warning styling and include accessible descriptive labels.

- **Bug Fixes**
  - Contract names are constrained to 160px with ellipsis when needed, improving readability in transaction lists.
  - Contract-name sizing is now applied separately from address rendering, preserving the existing truncation behavior for address-only targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->